### PR TITLE
refactor(tui): konsistensi bahasa hybrid ID/EN

### DIFF
--- a/app/tui/_chat.py
+++ b/app/tui/_chat.py
@@ -37,7 +37,7 @@ async def render_sse(lines: AsyncIterator[str]) -> None:
             println("class:warn", f"  butuh approval — plan_id={payload.get('plan_id')}")
             println("", payload.get("summary", ""))
         elif event == "action_started":
-            println("class:dim", f"  > running {payload.get('action')}...")
+            println("class:dim", f"  > menjalankan {payload.get('action')}...")
         elif event == "action_result":
             println("", payload.get("output", ""))
         elif event == "text_chunk":
@@ -95,7 +95,7 @@ async def send_chat(text: str) -> None:
             trust_env=False,
         ) as c, c.stream("POST", "/chat/send", json={"text": text}) as resp:
             if resp.status_code == 401:
-                println("class:err", "  session expired. Ketik /login lagi.")
+                println("class:err", "  sesi habis. Ketik /login lagi.")
                 return
             if resp.status_code != 200:
                 body_bytes = await resp.aread()

--- a/app/tui/_commands.py
+++ b/app/tui/_commands.py
@@ -51,7 +51,7 @@ def parse_command(line: str) -> tuple[str, list[str]] | None:
 
 
 async def cmd_help() -> None:
-    println("class:section", "  Commands")
+    println("class:section", "  Perintah")
     println("class:rule",    "  " + "─" * 52)
     rows = [
         ("/help",                 "tampilkan daftar command ini"),
@@ -82,7 +82,7 @@ async def cmd_help() -> None:
 
 
 async def cmd_status() -> None:
-    println("class:section", "  Backend Status")
+    println("class:section", "  Status Backend")
     println("class:rule",    "  " + "─" * 52)
     reachable, info = await probe_health()
     if reachable:
@@ -121,11 +121,11 @@ async def cmd_users(completer: TuiCompleter) -> None:
         println("class:dim", "  belum ada user terdaftar.")
         return
     emails: list[str] = []
-    println("class:section", "  Users")
+    println("class:section", "  Pengguna")
     println("class:rule",    "  " + "─" * 52)
     print_parts([
-        ("class:table.hdr", f"  {'email':<35}{'name':<25}{'telegram':<20}"),
-        ("class:table.hdr", "created"),
+        ("class:table.hdr", f"  {'email':<35}{'nama':<25}{'telegram':<20}"),
+        ("class:table.hdr", "dibuat"),
     ])
     println("class:rule", "  " + "─" * 52)
     for u in users:
@@ -314,7 +314,7 @@ async def cmd_pair_telegram() -> None:
     expires_in = data.get("expires_in_sec", 600)
 
     println("", "")
-    println("class:section", "  Pair Telegram")
+    println("class:section", "  Hubungkan Telegram")
     println("class:rule",    "  " + "─" * 52)
     print_parts([
         ("class:cmd.name", "  Pair code:  "),
@@ -497,10 +497,10 @@ async def _agents_list(token: str) -> None:
         println("class:err", f"  HTTP {r.status_code}: {r.text[:200]}")
         return
     agents = r.json().get("agents", [])
-    println("class:section", "  Agent Config")
+    println("class:section", "  Konfigurasi Agent")
     println("class:rule", "  " + "─" * 60)
     print_parts([
-        ("class:table.hdr", f"  {'agent':<10}{'enabled':<10}{'role':<14}{'workers':<10}"),
+        ("class:table.hdr", f"  {'agent':<10}{'aktif':<10}{'peran':<14}{'worker':<10}"),
         ("class:table.hdr", "model"),
     ])
     println("class:rule", "  " + "─" * 60)
@@ -581,7 +581,7 @@ async def cmd_audit(args: list[str]) -> None:
         println("class:dim", "  belum ada audit event.")
         return
 
-    println("class:section", f"  Audit Log ({len(events)} events)")
+    println("class:section", f"  Log Audit ({len(events)} event)")
     println("class:rule", "  " + "─" * 70)
     for ev in events:
         ts = ev.get("ts", "")[:19].replace("T", " ")

--- a/app/tui/_commands.py
+++ b/app/tui/_commands.py
@@ -54,14 +54,14 @@ async def cmd_help() -> None:
     println("class:section", "  Perintah")
     println("class:rule",    "  " + "─" * 52)
     rows = [
-        ("/help",                 "tampilkan daftar command ini"),
+        ("/help",                 "tampilkan daftar perintah ini"),
         ("/login",                "login Google via QR — wajib pertama kali"),
-        ("/logout",               "logout session TUI saat ini"),
-        ("/me",                   "info user yang sedang login"),
-        ("/pair-telegram",        "link bot Telegram ke akun ini via QR"),
-        ("/status",               "mode bot, jumlah user, versi backend"),
-        ("/users",                "daftar user terdaftar (admin)"),
-        ("/admin-logout <email>", "putus link Telegram user (admin)"),
+        ("/logout",               "logout sesi TUI saat ini"),
+        ("/me",                   "info pengguna yang sedang login"),
+        ("/pair-telegram",        "hubungkan bot Telegram ke akun ini via QR"),
+        ("/status",               "mode bot, jumlah pengguna, versi backend"),
+        ("/users",                "daftar pengguna terdaftar (admin)"),
+        ("/admin-logout <email>", "putus link Telegram pengguna (admin)"),
         ("/logs [n]",             "tail n baris log Docker (default 50)"),
         ("/logs -f",              "follow log live  (Ctrl+C untuk stop)"),
         ("/shell",                "drop ke shell  —  exit untuk kembali"),
@@ -96,8 +96,8 @@ async def cmd_status() -> None:
         if r.status_code == 200:
             data = r.json()
             println("", f"  ·  mode      {data.get('mode', '-')}")
-            println("", f"  ·  users     {data.get('user_count', 0)}")
-            println("", f"  ·  version   {data.get('version', '-')}")
+            println("", f"  ·  pengguna  {data.get('user_count', 0)}")
+            println("", f"  ·  versi     {data.get('version', '-')}")
         else:
             println("class:dim", f"  /admin/status: HTTP {r.status_code} {r.text[:100]}")
     except httpx.HTTPError as exc:
@@ -118,7 +118,7 @@ async def cmd_users(completer: TuiCompleter) -> None:
     payload: dict[str, Any] = r.json()
     users = payload.get("users", [])
     if not users:
-        println("class:dim", "  belum ada user terdaftar.")
+        println("class:dim", "  belum ada pengguna terdaftar.")
         return
     emails: list[str] = []
     println("class:section", "  Pengguna")
@@ -527,11 +527,11 @@ async def _agents_list(token: str) -> None:
         ])
     println("", "")
     if any(a["enabled"] and a.get("installed_on_workers", 0) == 0 for a in agents):
-        println("class:warn", "  ⚠️  Ada agent enabled tapi belum terinstall di mesin worker manapun.")
+        println("class:warn", "  ⚠️  Ada agent aktif tapi belum terinstall di mesin worker manapun.")
         println("class:dim", "    Install CLI di mesin TUI kamu, atau /agents <name> off.")
         println("", "")
     println("class:dim", "  Toggle:  /agents codex on    /agents codex off")
-    println("class:dim", "  Role:    /agents codex role engineer")
+    println("class:dim", "  Peran:   /agents codex role engineer")
     println("class:dim", "  Model:   /agents codex model gpt-4o-mini")
 
 

--- a/app/tui/_runner.py
+++ b/app/tui/_runner.py
@@ -68,13 +68,13 @@ _LOGO: list[tuple[str, str]] = [
     ("class:logo.sub",      "  OCTOPUS  ·  Server Monitoring  ·  Control  ·  AI Chat"),
     ("class:logo.ver",      "  ─────  v0.1.0\n"),
     ("class:logo.hint.key", "  Tab "),
-    ("class:logo.hint",     "complete   "),
+    ("class:logo.hint",     "lengkapi   "),
     ("class:logo.hint.key", "↑↓ "),
-    ("class:logo.hint",     "history   "),
+    ("class:logo.hint",     "riwayat   "),
     ("class:logo.hint.key", "/help "),
-    ("class:logo.hint",     "commands   "),
+    ("class:logo.hint",     "perintah   "),
     ("class:logo.hint.key", "Ctrl-C "),
-    ("class:logo.hint",     "quit"),
+    ("class:logo.hint",     "keluar"),
 ]
 
 
@@ -259,7 +259,7 @@ def run() -> None:
         mouse_support=False,
     )
 
-    println("class:dim", "  Ketik /help untuk daftar command, atau langsung kirim pesan ke bot.")
+    println("class:dim", "  Ketik /help untuk daftar perintah, atau langsung kirim pesan ke bot.")
     println("", "")
 
     async def _init() -> None:
@@ -300,7 +300,7 @@ def run() -> None:
     finally:
         _state.running[0] = False
 
-    print("  Bye.")
+    print("  Sampai jumpa.")
 
 
 async def _dispatch(
@@ -335,6 +335,6 @@ async def _dispatch(
     }
     handler = handlers.get(cmd)
     if handler is None:
-        println("class:dim", f"  command tidak dikenal: /{cmd}")
+        println("class:dim", f"  perintah tidak dikenal: /{cmd}")
     else:
         await handler()

--- a/app/tui/_session.py
+++ b/app/tui/_session.py
@@ -145,20 +145,20 @@ async def poll_pair_code(code: str) -> str | None:
     except httpx.HTTPError:
         return None
     if r.status_code == 410:
-        raise LoginAbortedError("kode pair expired atau tidak dikenal")
+        raise LoginAbortedError("pair code expired or unknown")
     if r.status_code == 200:
         try:
             data = r.json()
         except Exception as exc:
             raise LoginAbortedError(
-                f"backend balas 200 tapi body bukan JSON valid: {exc} "
+                f"backend returned 200 but body is not valid JSON: {exc} "
                 f"(body={r.text[:120]!r})"
             ) from exc
         token = data.get("session_token")
         if data.get("status") == "paired" and token:
             return str(token)
         # 200 tapi bukan paired/token kosong — bug yang tidak boleh terjadi.
-        raise LoginAbortedError(f"backend balas 200 tapi payload aneh: {data!r}")
+        raise LoginAbortedError(f"backend returned 200 but payload is malformed: {data!r}")
     # 202 pending atau status lain → terus loop polling.
     return None
 

--- a/app/tui/_statusbar.py
+++ b/app/tui/_statusbar.py
@@ -22,14 +22,14 @@ def get_status_bar_text() -> FormattedText:
             _state.active_session.email
             or _state.active_session.user_id[:8]
         )
-        user_part = ("class:status.user", f"as: {user_label}")
+        user_part = ("class:status.user", f"login: {user_label}")
     else:
-        user_part = ("class:status.warn", "not logged in — /login")
+        user_part = ("class:status.warn", "belum login — /login")
 
     if online == "yes":
         indicator: list[tuple[str, str]] = [("class:status.ok", " ● online")]
     elif online == "?":
-        indicator = [("class:status.dim", " ◌ connecting…")]
+        indicator = [("class:status.dim", " ◌ menghubungkan…")]
     else:
         indicator = [("class:status.err", " ● offline")]
 
@@ -38,7 +38,7 @@ def get_status_bar_text() -> FormattedText:
         ("class:status.sep", "  │  "),
         ("class:status.dim", f"mode: {mode}"),
         ("class:status.sep", "  │  "),
-        ("class:status.dim", f"users: {users}"),
+        ("class:status.dim", f"pengguna: {users}"),
         ("class:status.sep", "  │  "),
         user_part,
         ("class:status.sep", "  │  "),

--- a/app/tui/_worker.py
+++ b/app/tui/_worker.py
@@ -210,7 +210,7 @@ async def _execute_agent(
         await ws.send(json.dumps({
             "type": "job_error",
             "job_id": job_id,
-            "message": f"agent '{agent}' belum didukung. Available: {', '.join(_AGENTS)}",
+            "message": f"agent '{agent}' belum didukung. Tersedia: {', '.join(_AGENTS)}",
         }))
         return
 


### PR DESCRIPTION
## Summary

- Standardize TUI bahasa: user-facing output Indonesian, internal log/exception messages English
- Hapus campur ID+EN yang tidak konsisten di logo hint, section header, table header, status bar, dan chat renderer
- Pesan `LoginAbortedError` dipindah ke English (konsisten dengan stacktrace)
- Branding string (`OCTOPUS · Server Monitoring · Control · AI Chat`) tetap EN — identitas produk

## Aturan i18n hybrid

| Konteks | Bahasa |
|---|---|
| User-facing (`println`, `print_parts`) | Indonesian |
| `logger.*` calls | English |
| Exception messages | English |
| Command names (`/help`, `/login`) | English |
| Code identifiers | English |
| Branding strings | English |

## Files touched (6)

- `app/tui/_runner.py` — logo hints, exit, unknown-command label
- `app/tui/_commands.py` — section headers, table headers, help rows, status labels, agents hint
- `app/tui/_statusbar.py` — status bar labels
- `app/tui/_chat.py` — \`running\`→\`menjalankan\`, \`session expired\`→\`sesi habis\`
- `app/tui/_session.py` — \`LoginAbortedError\` messages to English
- `app/tui/_worker.py` — \`Available\`→\`Tersedia\`

Diff: 38 insertions, 38 deletions — pure string substitution, zero logic changes.

## Test plan

- [x] \`make check\` lulus (lint + type-check + 313 test)
- [ ] Manual: jalankan TUI lokal (\`python -m app.tui\`), verifikasi:
  - Logo hint tampil dalam bahasa Indonesia
  - \`/help\` rows tampil dalam bahasa Indonesia
  - Status bar \`belum login\`, \`menghubungkan…\`, \`pengguna: N\`, \`login: <email>\`
  - \`/users\`, \`/agents\`, \`/status\`, \`/audit\` section header & table header dalam ID
  - Exit pakai \`Ctrl-C\` muncul \`Sampai jumpa.\`

## Reference

Bagian dari spec PR1–PR5 (TUI + Telegram UX quick wins) — desain & rule i18n hybrid di-track sebagai dokumen tersendiri (akan di-commit di PR berikutnya bersama plan PR5 thinking indicator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)