### PR TITLE
feat(rag): knowledge store port + pgvector + in-memory adapters

### DIFF
--- a/alembic/versions/20260517_0007_knowledge_chunks_pgvector.py
+++ b/alembic/versions/20260517_0007_knowledge_chunks_pgvector.py
@@ -1,0 +1,71 @@
+"""add knowledge_chunks table + pgvector extension
+
+Revision ID: 20260517_0007
+Revises: 20260517_0006
+Create Date: 2026-05-17
+
+RAG infrastructure: enable pgvector + tabel ``knowledge_chunks``. Embedding
+dim 384 cocok dengan model default (FastEmbed all-MiniLM-L6-v2). Index ANN
+pakai HNSW dengan cosine ops karena Embedder produce L2-normalized vector.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from pgvector.sqlalchemy import Vector
+
+revision: str = "20260517_0007"
+down_revision: str | None = "20260517_0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+EMBEDDING_DIM = 384
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    op.create_table(
+        "knowledge_chunks",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.String(length=36),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("embedding", Vector(EMBEDDING_DIM), nullable=False),
+        sa.Column("meta", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    op.create_index(
+        "ix_knowledge_chunks_project_id",
+        "knowledge_chunks",
+        ["project_id"],
+    )
+    op.create_index(
+        "ix_knowledge_chunks_project_created",
+        "knowledge_chunks",
+        ["project_id", "created_at"],
+    )
+    # ANN index — cosine ops karena Embedder produce normalized vector.
+    # HNSW (vs IVFFlat) lebih cocok untuk insert/query ratio yang variabel.
+    op.execute(
+        "CREATE INDEX ix_knowledge_chunks_embedding_hnsw "
+        "ON knowledge_chunks USING hnsw (embedding vector_cosine_ops)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_knowledge_chunks_embedding_hnsw", table_name="knowledge_chunks")
+    op.drop_index("ix_knowledge_chunks_project_created", table_name="knowledge_chunks")
+    op.drop_index("ix_knowledge_chunks_project_id", table_name="knowledge_chunks")
+    op.drop_table("knowledge_chunks")
+    # Sengaja tidak DROP EXTENSION vector — ekstensi bisa shared dengan
+    # tabel/index lain di future.

--- a/app/adapters/database/models.py
+++ b/app/adapters/database/models.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
+from pgvector.sqlalchemy import Vector  # type: ignore[import-untyped]
 from sqlalchemy import (
     JSON,
     BigInteger,
@@ -16,6 +17,8 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.adapters.database.base import Base
+
+KNOWLEDGE_EMBEDDING_DIM = 384  # all-MiniLM-L6-v2 default (FastEmbed)
 
 
 def uuid_str() -> str:
@@ -298,6 +301,30 @@ class ChatMessageModel(Base):
     conversation_id: Mapped[str] = mapped_column(String(80), index=True)
     role: Mapped[str] = mapped_column(String(20))
     content: Mapped[str] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+
+
+class KnowledgeChunkModel(Base):
+    """RAG chunk — fragment teks + embedding, per-project.
+
+    Embedding dim default 384 (``KNOWLEDGE_EMBEDDING_DIM``) — cocok dengan
+    FastEmbed/all-MiniLM-L6-v2 yang dipakai sebagai default Embedder.
+    Re-embed semua kalau ganti model dengan dim berbeda.
+    """
+
+    __tablename__ = "knowledge_chunks"
+    __table_args__ = (
+        Index("ix_knowledge_chunks_project_created", "project_id", "created_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=uuid_str)
+    project_id: Mapped[str] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        index=True,
+    )
+    text: Mapped[str] = mapped_column(Text)
+    embedding: Mapped[list[float]] = mapped_column(Vector(KNOWLEDGE_EMBEDDING_DIM))
+    meta: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
 
 

--- a/app/adapters/knowledge_store_memory.py
+++ b/app/adapters/knowledge_store_memory.py
@@ -1,0 +1,72 @@
+"""In-memory KnowledgeStore — untuk unit test dan dev fallback tanpa Postgres."""
+
+from __future__ import annotations
+
+import math
+import uuid
+from typing import Any
+
+from app.ports.knowledge_store import KnowledgeChunk, RecallResult
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Cosine similarity ∈ [-1, 1]. Return 0.0 untuk vektor nol."""
+    if not a or not b:
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+class InMemoryKnowledgeStore:
+    """KnowledgeStore implementation backed by a simple dict.
+
+    Tidak persistent, tidak ANN-indexed — cocok untuk test dan single-process
+    dev. Production wajib pakai ``PgVectorKnowledgeStore``.
+    """
+
+    def __init__(self) -> None:
+        self._chunks: dict[str, tuple[KnowledgeChunk, list[float]]] = {}
+
+    async def index(
+        self,
+        project_id: str,
+        text: str,
+        embedding: list[float],
+        meta: dict[str, Any] | None = None,
+    ) -> str:
+        chunk_id = str(uuid.uuid4())
+        chunk = KnowledgeChunk(
+            id=chunk_id,
+            project_id=project_id,
+            text=text,
+            meta=dict(meta or {}),
+        )
+        self._chunks[chunk_id] = (chunk, list(embedding))
+        return chunk_id
+
+    async def recall(
+        self,
+        project_id: str,
+        query_embedding: list[float],
+        k: int = 5,
+    ) -> list[RecallResult]:
+        scored = [
+            RecallResult(chunk=chunk, score=_cosine_similarity(query_embedding, emb))
+            for chunk, emb in self._chunks.values()
+            if chunk.project_id == project_id
+        ]
+        scored.sort(key=lambda r: r.score, reverse=True)
+        return scored[:k]
+
+    async def delete_project(self, project_id: str) -> int:
+        before = len(self._chunks)
+        self._chunks = {
+            cid: pair
+            for cid, pair in self._chunks.items()
+            if pair[0].project_id != project_id
+        }
+        return before - len(self._chunks)

--- a/app/adapters/knowledge_store_pgvector.py
+++ b/app/adapters/knowledge_store_pgvector.py
@@ -1,0 +1,117 @@
+"""PgVector-backed KnowledgeStore — production adapter.
+
+Pakai SQLAlchemy ORM untuk insert/delete dan raw SQL untuk ANN query
+(``<=>`` cosine distance operator dari pgvector). Wrap sync DB session di
+``asyncio.to_thread`` supaya konsisten dengan port async signature.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import select
+from sqlalchemy import text as sql_text
+
+from app.adapters.database.models import KnowledgeChunkModel
+from app.ports.knowledge_store import KnowledgeChunk, RecallResult
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session, sessionmaker
+
+
+class PgVectorKnowledgeStore:
+    """Postgres + pgvector adapter. Embeddings di-asumsikan L2-normalized.
+
+    Pakai cosine distance (``<=>``) untuk ANN supaya cocok dengan default
+    FastEmbed / Ollama nomic-embed-text yang produce normalized output.
+    Score = ``1 - distance``, sehingga 1.0 = identik.
+    """
+
+    def __init__(self, factory: sessionmaker[Session]) -> None:
+        self._factory = factory
+
+    async def index(
+        self,
+        project_id: str,
+        text: str,
+        embedding: list[float],
+        meta: dict[str, Any] | None = None,
+    ) -> str:
+        chunk_id = str(uuid.uuid4())
+
+        def _do() -> str:
+            with self._factory() as session:
+                row = KnowledgeChunkModel(
+                    id=chunk_id,
+                    project_id=project_id,
+                    text=text,
+                    embedding=embedding,
+                    meta=dict(meta or {}),
+                )
+                session.add(row)
+                session.commit()
+            return chunk_id
+
+        return await asyncio.to_thread(_do)
+
+    async def recall(
+        self,
+        project_id: str,
+        query_embedding: list[float],
+        k: int = 5,
+    ) -> list[RecallResult]:
+        # Raw SQL untuk leverage pgvector ANN index (HNSW cosine_ops).
+        # ``1 - (embedding <=> :q)`` menghasilkan similarity dalam range [0, 1]
+        # ketika embedding L2-normalized.
+        sql = sql_text(
+            """
+            SELECT id, project_id, text, meta,
+                   1 - (embedding <=> CAST(:q AS vector)) AS score
+            FROM knowledge_chunks
+            WHERE project_id = :project_id
+            ORDER BY embedding <=> CAST(:q AS vector)
+            LIMIT :k
+            """
+        )
+
+        def _do() -> list[RecallResult]:
+            with self._factory() as session:
+                # pgvector expects literal vector format ``[1,2,3]``
+                q_literal = "[" + ",".join(repr(float(x)) for x in query_embedding) + "]"
+                rows = session.execute(
+                    sql,
+                    {"q": q_literal, "project_id": project_id, "k": k},
+                ).all()
+            return [
+                RecallResult(
+                    chunk=KnowledgeChunk(
+                        id=row.id,
+                        project_id=row.project_id,
+                        text=row.text,
+                        meta=dict(row.meta or {}),
+                    ),
+                    score=float(row.score),
+                )
+                for row in rows
+            ]
+
+        return await asyncio.to_thread(_do)
+
+    async def delete_project(self, project_id: str) -> int:
+        def _do() -> int:
+            with self._factory() as session:
+                rows = list(
+                    session.scalars(
+                        select(KnowledgeChunkModel).where(
+                            KnowledgeChunkModel.project_id == project_id
+                        )
+                    )
+                )
+                for r in rows:
+                    session.delete(r)
+                session.commit()
+                return len(rows)
+
+        return await asyncio.to_thread(_do)

--- a/app/ports/knowledge_store.py
+++ b/app/ports/knowledge_store.py
@@ -1,0 +1,65 @@
+"""Port untuk RAG knowledge store — project-scoped semantic memory.
+
+Tugas store:
+- ``index`` — simpan satu chunk text + embedding-nya untuk project.
+- ``recall`` — top-K chunk paling similar dengan query embedding.
+
+Adapter konkret:
+- ``PgVectorKnowledgeStore`` (production) — pakai pgvector cosine distance.
+- ``InMemoryKnowledgeStore`` (test/dev) — pure Python cosine.
+
+Embedding di-passing sudah dalam bentuk ``list[float]``; embedder terpisah
+(``app.ports.embedder``) yang bertanggung-jawab konversi text → vector.
+Pemisahan ini supaya store bisa di-test tanpa model NLP, dan embedder
+bisa di-swap (Ollama / fastembed / managed API).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class KnowledgeChunk:
+    """Satu fragmen teks dalam project knowledge store."""
+
+    id: str
+    project_id: str
+    text: str
+    meta: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RecallResult:
+    """Hasil recall — chunk plus similarity score (1.0 = identik, 0.0 = orthogonal)."""
+
+    chunk: KnowledgeChunk
+    score: float
+
+
+class KnowledgeStore(Protocol):
+    """Project-scoped vector store. Implementor handle persistence + ANN."""
+
+    async def index(
+        self,
+        project_id: str,
+        text: str,
+        embedding: list[float],
+        meta: dict[str, Any] | None = None,
+    ) -> str:
+        """Simpan chunk. Return ID chunk yang baru disimpan."""
+        ...
+
+    async def recall(
+        self,
+        project_id: str,
+        query_embedding: list[float],
+        k: int = 5,
+    ) -> list[RecallResult]:
+        """Top-K chunk dengan similarity tertinggi untuk project tersebut."""
+        ...
+
+    async def delete_project(self, project_id: str) -> int:
+        """Hapus semua chunk milik project. Return jumlah row terhapus."""
+        ...

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ httpx==0.28.1
 idna==3.13
 markdown-it-py==4.0.0
 mdurl==0.1.2
+pgvector>=0.3,<1.0
 psutil==7.2.2
 psycopg[binary]>=3.2,<4.0
 Pygments==2.20.0

--- a/tests/adapters/test_knowledge_store_memory.py
+++ b/tests/adapters/test_knowledge_store_memory.py
@@ -1,0 +1,167 @@
+"""Unit tests untuk InMemoryKnowledgeStore.
+
+Validasi behavior port KnowledgeStore lewat in-memory adapter — paling lengkap
+karena tidak butuh Postgres + pgvector running. PgVectorKnowledgeStore di-test
+terpisah di integration test (pakai real Neon test instance, kalau env tersedia).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.adapters.knowledge_store_memory import (
+    InMemoryKnowledgeStore,
+    _cosine_similarity,
+)
+
+# ── _cosine_similarity helper ─────────────────────────────────────────────────
+
+
+def test_cosine_similarity_identical_vectors_returns_one() -> None:
+    assert math.isclose(_cosine_similarity([1, 2, 3], [1, 2, 3]), 1.0)
+
+
+def test_cosine_similarity_orthogonal_vectors_returns_zero() -> None:
+    assert math.isclose(_cosine_similarity([1, 0], [0, 1]), 0.0)
+
+
+def test_cosine_similarity_opposite_vectors_returns_minus_one() -> None:
+    assert math.isclose(_cosine_similarity([1, 0], [-1, 0]), -1.0)
+
+
+def test_cosine_similarity_zero_vector_returns_zero() -> None:
+    assert _cosine_similarity([0, 0, 0], [1, 2, 3]) == 0.0
+
+
+def test_cosine_similarity_empty_returns_zero() -> None:
+    assert _cosine_similarity([], [1, 2]) == 0.0
+
+
+# ── index + fetch round-trip ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_index_returns_id_string() -> None:
+    store = InMemoryKnowledgeStore()
+    chunk_id = await store.index("proj-1", "hello world", [0.1, 0.2, 0.3])
+    assert isinstance(chunk_id, str)
+    assert len(chunk_id) > 0
+
+
+@pytest.mark.asyncio
+async def test_recall_returns_indexed_chunk() -> None:
+    store = InMemoryKnowledgeStore()
+    await store.index("proj-1", "the answer is 42", [1.0, 0.0, 0.0])
+    results = await store.recall("proj-1", [1.0, 0.0, 0.0], k=5)
+    assert len(results) == 1
+    assert results[0].chunk.text == "the answer is 42"
+    assert math.isclose(results[0].score, 1.0)
+
+
+@pytest.mark.asyncio
+async def test_recall_meta_preserved() -> None:
+    store = InMemoryKnowledgeStore()
+    await store.index(
+        "proj-1", "x", [1.0, 0.0],
+        meta={"role": "engineer", "task_id": "abc"},
+    )
+    results = await store.recall("proj-1", [1.0, 0.0], k=1)
+    assert results[0].chunk.meta == {"role": "engineer", "task_id": "abc"}
+
+
+# ── Project isolation ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recall_does_not_cross_projects() -> None:
+    """Acceptance: dua project punya scratchpad terpisah — RAG juga harus."""
+    store = InMemoryKnowledgeStore()
+    await store.index("proj-A", "A content", [1.0, 0.0, 0.0])
+    await store.index("proj-B", "B content", [1.0, 0.0, 0.0])
+
+    a = await store.recall("proj-A", [1.0, 0.0, 0.0])
+    b = await store.recall("proj-B", [1.0, 0.0, 0.0])
+
+    assert len(a) == 1 and a[0].chunk.text == "A content"
+    assert len(b) == 1 and b[0].chunk.text == "B content"
+
+
+@pytest.mark.asyncio
+async def test_recall_empty_project_returns_empty_list() -> None:
+    store = InMemoryKnowledgeStore()
+    await store.index("proj-A", "x", [1.0])
+    results = await store.recall("proj-empty", [1.0], k=5)
+    assert results == []
+
+
+# ── Top-K ordering ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recall_orders_by_similarity_descending() -> None:
+    store = InMemoryKnowledgeStore()
+    await store.index("p", "less similar",  [1.0, 1.0, 0.0])  # cos ~0.71 to [1,0,0]
+    await store.index("p", "most similar",  [1.0, 0.0, 0.0])  # cos 1.0
+    await store.index("p", "orthogonal",    [0.0, 1.0, 0.0])  # cos 0.0
+
+    results = await store.recall("p", [1.0, 0.0, 0.0], k=3)
+    assert [r.chunk.text for r in results] == [
+        "most similar", "less similar", "orthogonal"
+    ]
+    assert results[0].score > results[1].score > results[2].score
+
+
+@pytest.mark.asyncio
+async def test_recall_limits_to_k() -> None:
+    store = InMemoryKnowledgeStore()
+    for i in range(10):
+        await store.index("p", f"chunk-{i}", [float(i), 0.0])
+    results = await store.recall("p", [5.0, 0.0], k=3)
+    assert len(results) == 3
+
+
+@pytest.mark.asyncio
+async def test_recall_returns_all_if_k_larger_than_corpus() -> None:
+    store = InMemoryKnowledgeStore()
+    await store.index("p", "only", [1.0])
+    results = await store.recall("p", [1.0], k=100)
+    assert len(results) == 1
+
+
+# ── delete_project ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_project_removes_all_chunks_in_that_project() -> None:
+    store = InMemoryKnowledgeStore()
+    await store.index("doomed", "x", [1.0])
+    await store.index("doomed", "y", [0.5])
+    await store.index("survives", "z", [1.0])
+
+    n = await store.delete_project("doomed")
+    assert n == 2
+    assert await store.recall("doomed", [1.0]) == []
+    remaining = await store.recall("survives", [1.0])
+    assert len(remaining) == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_project_returns_zero_when_nothing_to_delete() -> None:
+    store = InMemoryKnowledgeStore()
+    await store.index("p", "x", [1.0])
+    assert await store.delete_project("ghost") == 0
+
+
+# ── Port conformance ─────────────────────────────────────────────────────────
+
+
+def test_in_memory_store_satisfies_knowledge_store_protocol() -> None:
+    """Structural typing check — InMemory adapter punya signature yang dibutuhkan port."""
+    from app.ports.knowledge_store import KnowledgeStore
+    store: KnowledgeStore = InMemoryKnowledgeStore()
+    # Pass kalau type-check tidak protes; runtime cuma assert attribute presence.
+    assert hasattr(store, "index")
+    assert hasattr(store, "recall")
+    assert hasattr(store, "delete_project")


### PR DESCRIPTION
Bagian 1/3 RAG infra. Ports + storage. Embedder dan orchestrator wire-up di PR berikutnya.

## Apa
- ``app/ports/knowledge_store.py`` — Protocol ``KnowledgeStore`` (index/recall/delete_project) + dataclass ``KnowledgeChunk``/``RecallResult``
- ``KnowledgeChunkModel`` (project_id FK, text, embedding Vector(384), meta JSONB)
- Migration ``20260517_0007``: CREATE EXTENSION vector + tabel + HNSW cosine ANN index
- ``PgVectorKnowledgeStore`` (production) — raw SQL pakai ``<=>`` cosine
- ``InMemoryKnowledgeStore`` (test/dev) — pure Python cosine
- 16 unit test (Protocol conformance, isolation antar project, top-K, k>corpus, edge cases)

## Test plan
- [ ] pytest tests/adapters/test_knowledge_store_memory.py hijau di CI
- [ ] Migration apply ke staging Postgres tanpa error
- [ ] pgvector extension enabled di Neon production

Refs: issue #26