### PR TITLE
feat(rag): Embedder port + FastEmbed + Ollama adapters

### DIFF
--- a/app/adapters/embedder_fastembed.py
+++ b/app/adapters/embedder_fastembed.py
@@ -1,0 +1,50 @@
+"""FastEmbed adapter — local CPU embedder.
+
+Default model ``sentence-transformers/all-MiniLM-L6-v2`` (384-dim, ~90 MB).
+Model download otomatis ke ``~/.cache/fastembed`` saat instance pertama
+dibuat (lazy via ``_get_model``).
+
+FastEmbed sudah L2-normalize output by default, jadi cocok langsung dengan
+``KnowledgeStore`` cosine-similarity flow tanpa post-processing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+DEFAULT_DIMENSION = 384
+
+
+class FastEmbedAdapter:
+    """Lazy-init: model di-load saat ``embed``/``embed_batch`` dipanggil
+    pertama kali. Hindari import-time download saat test discovery.
+    """
+
+    def __init__(self, model_name: str = DEFAULT_MODEL, dim: int = DEFAULT_DIMENSION) -> None:
+        self._model_name = model_name
+        self._dim = dim
+        self._model: Any | None = None
+
+    @property
+    def dimension(self) -> int:
+        return self._dim
+
+    def _get_model(self) -> Any:
+        if self._model is None:
+            # Import lazy supaya fastembed (yang berat) tidak loaded saat import-time.
+            from fastembed import TextEmbedding
+            self._model = TextEmbedding(model_name=self._model_name)
+        return self._model
+
+    def embed(self, text: str) -> list[float]:
+        model = self._get_model()
+        # FastEmbed yields generator — ambil first element.
+        vector = next(iter(model.embed([text])))
+        return [float(x) for x in vector]
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        model = self._get_model()
+        return [[float(x) for x in vec] for vec in model.embed(texts)]

--- a/app/adapters/embedder_ollama.py
+++ b/app/adapters/embedder_ollama.py
@@ -1,0 +1,63 @@
+"""Ollama-backed Embedder adapter.
+
+Pakai HTTP API ``/api/embeddings`` di Ollama. Default model
+``nomic-embed-text`` (768-dim, ~140 MB Q4). Pilih ini kalau backend sudah
+jalan Ollama untuk LLM chat — gratis ekstra, share infra.
+
+Ollama tidak L2-normalize output by default, jadi adapter normalize
+manual supaya cosine similarity bekerja konsisten dengan FastEmbed adapter.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import requests  # type: ignore[import-untyped]
+
+from app.domain.exceptions import AIProviderError
+
+DEFAULT_MODEL = "nomic-embed-text"
+DEFAULT_DIMENSION = 768
+
+
+def _l2_normalize(vec: list[float]) -> list[float]:
+    norm = math.sqrt(sum(x * x for x in vec))
+    if norm == 0:
+        return vec
+    return [x / norm for x in vec]
+
+
+@dataclass
+class OllamaEmbedder:
+    url: str
+    model: str = DEFAULT_MODEL
+    dim: int = DEFAULT_DIMENSION
+    timeout: int = 60
+
+    @property
+    def dimension(self) -> int:
+        return self.dim
+
+    def embed(self, text: str) -> list[float]:
+        try:
+            resp = requests.post(
+                f"{self.url.rstrip('/')}/api/embeddings",
+                json={"model": self.model, "prompt": text},
+                timeout=self.timeout,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        except requests.RequestException as exc:
+            raise AIProviderError(f"Ollama embed failed: {exc}") from exc
+
+        raw = payload.get("embedding")
+        if not isinstance(raw, list) or not raw:
+            raise AIProviderError(f"Ollama embed returned no vector: {payload}")
+        return _l2_normalize([float(x) for x in raw])
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        # Ollama HTTP belum support batch /api/embeddings — jalan per-item.
+        # Tidak ideal untuk index banyak chunk; pertimbangkan FastEmbed untuk
+        # bulk indexing.
+        return [self.embed(t) for t in texts]

--- a/app/ports/embedder.py
+++ b/app/ports/embedder.py
@@ -1,0 +1,35 @@
+"""Port untuk text → embedding vector.
+
+Dua mode:
+- ``embed(text)`` — single text, untuk query recall.
+- ``embed_batch(texts)`` — list of texts, untuk bulk indexing.
+
+Implementor:
+- ``FastEmbedAdapter`` — local CPU, default ``all-MiniLM-L6-v2`` (384-dim).
+  Cocok untuk VPS minimal (~90 MB model, ~15 ms per call CPU).
+- ``OllamaEmbedder`` — pakai Ollama HTTP, default ``nomic-embed-text``
+  (768-dim). Pilih ini kalau backend sudah jalan Ollama.
+
+Embedding wajib L2-normalized supaya cosine similarity bekerja benar di
+``KnowledgeStore`` adapter pgvector. FastEmbed normalize by default; Ollama
+biasanya tidak — adapter harus normalisasi.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class Embedder(Protocol):
+    @property
+    def dimension(self) -> int:
+        """Embedding dim — harus cocok dengan ``KnowledgeChunkModel.embedding``."""
+        ...
+
+    def embed(self, text: str) -> list[float]:
+        """Embed satu text — return L2-normalized vector."""
+        ...
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Embed list of texts. Lebih efisien dibanding loop ``embed`` per item."""
+        ...

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ qrcode>=8.0,<9.0
 certifi==2026.4.22
 charset-normalizer==3.4.7
 fastapi==0.115.12
+fastembed>=0.4,<1.0
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1

--- a/tests/adapters/test_embedders.py
+++ b/tests/adapters/test_embedders.py
@@ -1,0 +1,162 @@
+"""Unit tests untuk Embedder adapters — fastembed dan Ollama keduanya
+dimock supaya test tidak butuh download model atau network call."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from app.adapters.embedder_fastembed import FastEmbedAdapter
+from app.adapters.embedder_ollama import OllamaEmbedder, _l2_normalize
+from app.domain.exceptions import AIProviderError
+
+# ── _l2_normalize helper ──────────────────────────────────────────────────────
+
+
+def test_l2_normalize_unit_vector_unchanged() -> None:
+    """Vector dengan norm=1 harus return identik (modulo floating)."""
+    import math
+    v = [0.6, 0.8]  # norm = 1
+    out = _l2_normalize(v)
+    assert math.isclose(out[0], 0.6)
+    assert math.isclose(out[1], 0.8)
+
+
+def test_l2_normalize_scales_to_unit_norm() -> None:
+    import math
+    v = [3.0, 4.0]  # norm = 5
+    out = _l2_normalize(v)
+    norm = math.sqrt(sum(x * x for x in out))
+    assert math.isclose(norm, 1.0)
+
+
+def test_l2_normalize_zero_vector_returns_zero() -> None:
+    assert _l2_normalize([0.0, 0.0, 0.0]) == [0.0, 0.0, 0.0]
+
+
+# ── FastEmbedAdapter (dengan mock) ────────────────────────────────────────────
+
+
+def _fake_textembedding_class(vectors: list[list[float]]) -> Any:
+    """Build a mock that mimics ``fastembed.TextEmbedding`` instance."""
+    instance = MagicMock()
+    # FastEmbed.embed() yields generator of numpy-array-likes.
+    instance.embed.side_effect = lambda texts: iter(vectors[: len(texts)])
+    return MagicMock(return_value=instance)
+
+
+def test_fastembed_dimension_returns_configured() -> None:
+    e = FastEmbedAdapter(dim=384)
+    assert e.dimension == 384
+
+
+def test_fastembed_embed_returns_list_of_floats() -> None:
+    fake_cls = _fake_textembedding_class([[1.0, 2.0, 3.0]])
+    with patch("fastembed.TextEmbedding", fake_cls):
+        e = FastEmbedAdapter()
+        result = e.embed("hello")
+    assert result == [1.0, 2.0, 3.0]
+    assert all(isinstance(x, float) for x in result)
+
+
+def test_fastembed_batch_embed_returns_list_of_vectors() -> None:
+    fake_cls = _fake_textembedding_class([[1.0, 0.0], [0.0, 1.0], [0.5, 0.5]])
+    with patch("fastembed.TextEmbedding", fake_cls):
+        e = FastEmbedAdapter()
+        result = e.embed_batch(["a", "b", "c"])
+    assert result == [[1.0, 0.0], [0.0, 1.0], [0.5, 0.5]]
+
+
+def test_fastembed_empty_batch_returns_empty_list() -> None:
+    """Tidak perlu load model untuk batch kosong."""
+    e = FastEmbedAdapter()  # tidak akan instantiate TextEmbedding
+    assert e.embed_batch([]) == []
+
+
+def test_fastembed_lazy_init_only_loads_model_once() -> None:
+    fake_cls = _fake_textembedding_class([[1.0], [2.0], [3.0]])
+    with patch("fastembed.TextEmbedding", fake_cls):
+        e = FastEmbedAdapter()
+        e.embed("a")
+        e.embed("b")
+        e.embed("c")
+        assert fake_cls.call_count == 1  # model di-construct sekali
+
+
+# ── OllamaEmbedder (dengan mock requests) ─────────────────────────────────────
+
+
+def _post_resp(payload: dict[str, Any], status: int = 200) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = payload
+    if status >= 400:
+        r.raise_for_status.side_effect = requests.HTTPError(response=r)
+    return r
+
+
+def test_ollama_embedder_dimension_returns_configured() -> None:
+    e = OllamaEmbedder(url="http://x", dim=768)
+    assert e.dimension == 768
+
+
+def test_ollama_embed_returns_normalized_vector() -> None:
+    """Ollama biasa return non-normalized; adapter harus normalize."""
+    import math
+    with patch("requests.post", return_value=_post_resp({"embedding": [3.0, 4.0]})):
+        e = OllamaEmbedder(url="http://localhost:11434")
+        out = e.embed("hello")
+    norm = math.sqrt(sum(x * x for x in out))
+    assert math.isclose(norm, 1.0)
+
+
+def test_ollama_embed_raises_on_http_error() -> None:
+    with patch("requests.post", return_value=_post_resp({"error": "fail"}, status=500)):
+        e = OllamaEmbedder(url="http://localhost:11434")
+        with pytest.raises(AIProviderError):
+            e.embed("hello")
+
+
+def test_ollama_embed_raises_on_request_exception() -> None:
+    with patch("requests.post", side_effect=requests.ConnectionError("down")):
+        e = OllamaEmbedder(url="http://localhost:11434")
+        with pytest.raises(AIProviderError) as exc:
+            e.embed("hello")
+    assert "Ollama embed failed" in str(exc.value)
+
+
+def test_ollama_embed_raises_when_response_missing_embedding() -> None:
+    with patch("requests.post", return_value=_post_resp({"foo": "bar"})):
+        e = OllamaEmbedder(url="http://localhost:11434")
+        with pytest.raises(AIProviderError) as exc:
+            e.embed("hello")
+    assert "no vector" in str(exc.value)
+
+
+def test_ollama_embed_batch_calls_embed_per_item() -> None:
+    with patch("requests.post", return_value=_post_resp({"embedding": [1.0, 0.0]})):
+        e = OllamaEmbedder(url="http://x")
+        results = e.embed_batch(["a", "b", "c"])
+    assert len(results) == 3
+
+
+# ── Port conformance ──────────────────────────────────────────────────────────
+
+
+def test_fastembed_satisfies_embedder_protocol() -> None:
+    from app.ports.embedder import Embedder
+    e: Embedder = FastEmbedAdapter()
+    assert hasattr(e, "dimension")
+    assert hasattr(e, "embed")
+    assert hasattr(e, "embed_batch")
+
+
+def test_ollama_satisfies_embedder_protocol() -> None:
+    from app.ports.embedder import Embedder
+    e: Embedder = OllamaEmbedder(url="http://x")
+    assert hasattr(e, "dimension")
+    assert hasattr(e, "embed")
+    assert hasattr(e, "embed_batch")


### PR DESCRIPTION
Bagian 2/3 RAG infra. Port ``Embedder`` + dua adapter. Wire-up di PR berikutnya.

## Apa
- Port ``app/ports/embedder.py`` — Protocol dengan ``dimension`` + ``embed(text)`` + ``embed_batch(texts)``
- ``FastEmbedAdapter`` (default) — all-MiniLM-L6-v2 384-dim ~90 MB, lazy init
- ``OllamaEmbedder`` (opt-in) — nomic-embed-text 768-dim via HTTP API, post-normalize L2
- 16 unit test (mocked underlying libs)
- ``fastembed>=0.4`` ditambah ke requirements.txt

## Test plan
- [ ] pytest tests/adapters/test_embedders.py hijau
- [ ] FastEmbed model download saat backend pertama kali start (test di staging)

Refs: issue #26