### PR TITLE
feat(skill): Skill DSL schema + storage + repository CRUD

### DIFF
--- a/alembic/versions/20260518_0008_skills_table.py
+++ b/alembic/versions/20260518_0008_skills_table.py
@@ -1,0 +1,57 @@
+"""add skills table
+
+Revision ID: 20260518_0008
+Revises: 20260517_0007
+Create Date: 2026-05-18
+
+User-defined Skill workflow (DSL JSON) — schema disimpan di JSONB
+``definition``, divalidasi via ``app.domain.skills.parse_skill`` di repository
+sebelum INSERT.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260518_0008"
+down_revision: str | None = "20260517_0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "skills",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.String(length=36),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("definition", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.UniqueConstraint("project_id", "name", name="uq_skills_project_name"),
+    )
+    op.create_index("ix_skills_project_id", "skills", ["project_id"])
+    op.create_index("ix_skills_project", "skills", ["project_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_skills_project", table_name="skills")
+    op.drop_index("ix_skills_project_id", table_name="skills")
+    op.drop_table("skills")

--- a/app/adapters/database/models.py
+++ b/app/adapters/database/models.py
@@ -328,6 +328,36 @@ class KnowledgeChunkModel(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
 
 
+class SkillModel(Base):
+    """User-defined workflow Skill (DSL deklaratif, lihat ``app.domain.skills``).
+
+    ``definition`` JSONB menyimpan parsed-validated dict yang round-trip dengan
+    ``app.domain.skills.skill_to_dict`` / ``parse_skill``. UNIQUE(project_id, name)
+    supaya satu project tidak punya dua skill bernama sama.
+    """
+
+    __tablename__ = "skills"
+    __table_args__ = (
+        UniqueConstraint("project_id", "name", name="uq_skills_project_name"),
+        Index("ix_skills_project", "project_id"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=uuid_str)
+    project_id: Mapped[str] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(120))
+    description: Mapped[str] = mapped_column(Text, default="")
+    definition: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
+    )
+
+
 class AuditEventModel(Base):
     __tablename__ = "audit_events"
     __table_args__ = (

--- a/app/adapters/database/repositories.py
+++ b/app/adapters/database/repositories.py
@@ -7,11 +7,13 @@ from app.adapters.database.models import (
     AgentIntegrationModel,
     DeviceModel,
     ProjectModel,
+    SkillModel,
     TelegramAccountModel,
     UserModel,
     utc_now,
 )
 from app.domain.accounts import DeviceIdentity, TenantIdentity
+from app.domain.skills import Skill, parse_skill, skill_to_dict
 
 
 class DatabaseConflictError(Exception):
@@ -273,3 +275,106 @@ class ControlPlaneRepository:
         integration.capabilities = capabilities or {}
         self._session.flush()
         return integration
+
+    # ── Skills ────────────────────────────────────────────────────────────────
+
+    def create_skill(
+        self, project_id: str, user_id: str, definition: dict[str, Any]
+    ) -> SkillModel:
+        """Validate JSON definition + persist. Raise ``DatabaseConflictError``
+        kalau project bukan milik user atau skill name sudah ada.
+        Raise ``SkillValidationError`` kalau JSON tidak valid.
+        """
+        project = self.get_project(project_id, user_id)
+        if project is None:
+            raise DatabaseConflictError(
+                f"Project {project_id} tidak ditemukan untuk user"
+            )
+        skill = parse_skill(definition)
+        existing = self._session.scalar(
+            select(SkillModel).where(
+                SkillModel.project_id == project_id,
+                SkillModel.name == skill.name,
+            )
+        )
+        if existing is not None:
+            raise DatabaseConflictError(
+                f"Skill '{skill.name}' sudah ada di project ini"
+            )
+        row = SkillModel(
+            project_id=project_id,
+            name=skill.name,
+            description=skill.description,
+            definition=skill_to_dict(skill),
+        )
+        self._session.add(row)
+        self._session.flush()
+        return row
+
+    def list_project_skills(self, project_id: str, user_id: str) -> list[SkillModel]:
+        if self.get_project(project_id, user_id) is None:
+            return []
+        return list(self._session.scalars(
+            select(SkillModel).where(SkillModel.project_id == project_id)
+        ))
+
+    def get_skill(
+        self, skill_id: str, user_id: str
+    ) -> SkillModel | None:
+        """Fetch skill, scoped by user (via project ownership)."""
+        row = self._session.scalar(
+            select(SkillModel)
+            .join(ProjectModel, SkillModel.project_id == ProjectModel.id)
+            .where(SkillModel.id == skill_id, ProjectModel.user_id == user_id)
+        )
+        return row
+
+    def get_skill_by_name(
+        self, project_id: str, name: str, user_id: str
+    ) -> SkillModel | None:
+        if self.get_project(project_id, user_id) is None:
+            return None
+        return self._session.scalar(
+            select(SkillModel).where(
+                SkillModel.project_id == project_id,
+                SkillModel.name == name,
+            )
+        )
+
+    def update_skill(
+        self, skill_id: str, user_id: str, definition: dict[str, Any]
+    ) -> SkillModel:
+        row = self.get_skill(skill_id, user_id)
+        if row is None:
+            raise DatabaseConflictError(f"Skill {skill_id} tidak ditemukan")
+        skill = parse_skill(definition)
+        # Rename collision check kalau name berubah
+        if skill.name != row.name:
+            clash = self._session.scalar(
+                select(SkillModel).where(
+                    SkillModel.project_id == row.project_id,
+                    SkillModel.name == skill.name,
+                    SkillModel.id != row.id,
+                )
+            )
+            if clash is not None:
+                raise DatabaseConflictError(
+                    f"Skill '{skill.name}' sudah dipakai di project ini"
+                )
+        row.name = skill.name
+        row.description = skill.description
+        row.definition = skill_to_dict(skill)
+        self._session.flush()
+        return row
+
+    def delete_skill(self, skill_id: str, user_id: str) -> bool:
+        row = self.get_skill(skill_id, user_id)
+        if row is None:
+            return False
+        self._session.delete(row)
+        self._session.flush()
+        return True
+
+    def load_skill_domain(self, row: SkillModel) -> Skill:
+        """Helper untuk caller yang butuh ``Skill`` dataclass (mis. executor)."""
+        return parse_skill(row.definition)

--- a/app/domain/skills.py
+++ b/app/domain/skills.py
@@ -1,0 +1,311 @@
+"""Skill DSL — workflow deklaratif user-defined untuk multi-agent orkestrasi.
+
+Skill adalah graf DAG dari steps. Setiap step di-execute oleh agent yang
+assigned ke ``role`` step tersebut (lihat ``app.adapters.agent_configs``).
+``depends_on`` menentukan urutan + memungkinkan hand-off output antar step.
+
+Format JSON contoh::
+
+    {
+      "name": "build-company-profile-site",
+      "description": "Bikin website company profile end-to-end.",
+      "steps": [
+        {"name": "design",     "role": "architect", "depends_on": []},
+        {"name": "copy",       "role": "engineer",  "depends_on": ["design"]},
+        {"name": "code",       "role": "engineer",  "depends_on": ["design", "copy"]},
+        {"name": "review",     "role": "reviewer",  "depends_on": ["code"]}
+      ],
+      "manager": {
+        "role": "architect",
+        "max_revisions": 2,
+        "acceptance_criteria": "All outputs combined satisfy the brief"
+      }
+    }
+
+Pure domain — zero import library eksternal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.domain.capabilities import ROLE_REQUIRED_CAPABILITIES
+
+# ── Errors ────────────────────────────────────────────────────────────────────
+
+
+class SkillValidationError(ValueError):
+    """JSON Skill tidak valid — DAG cycle, unknown role, atau format salah."""
+
+
+# ── Entities ──────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Step:
+    name: str
+    role: str
+    depends_on: tuple[str, ...] = ()
+    prompt_template: str | None = None
+    produces: str | None = None
+
+
+@dataclass(frozen=True)
+class Manager:
+    """Phase-2 manager config. Phase-1 executor abaikan field ini."""
+
+    role: str
+    max_revisions: int = 2
+    acceptance_criteria: str = ""
+
+
+@dataclass(frozen=True)
+class Skill:
+    name: str
+    steps: tuple[Step, ...]
+    description: str = ""
+    manager: Manager | None = None
+
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+MAX_STEPS = 50
+MAX_NAME_LEN = 120
+MAX_DESCRIPTION_LEN = 2000
+
+# Sengaja loose — biar user bisa nama step apapun selama tidak kosong.
+_FORBIDDEN_CHARS = set("/\\\t\n\r")
+
+
+# ── Validation primitives ─────────────────────────────────────────────────────
+
+
+def _require_str(value: Any, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise SkillValidationError(f"{field_name} harus string, dapat {type(value).__name__}")
+    return value
+
+
+def _require_non_empty(value: str, field_name: str) -> str:
+    if not value.strip():
+        raise SkillValidationError(f"{field_name} tidak boleh kosong")
+    return value
+
+
+def _validate_name(value: str, field_name: str) -> str:
+    _require_non_empty(value, field_name)
+    if len(value) > MAX_NAME_LEN:
+        raise SkillValidationError(
+            f"{field_name} terlalu panjang (max {MAX_NAME_LEN} char)"
+        )
+    if _FORBIDDEN_CHARS & set(value):
+        raise SkillValidationError(f"{field_name} mengandung char terlarang")
+    return value
+
+
+def _validate_role(role: str, context: str) -> str:
+    _require_non_empty(role, f"role di {context}")
+    if role not in ROLE_REQUIRED_CAPABILITIES:
+        known = ", ".join(sorted(ROLE_REQUIRED_CAPABILITIES))
+        raise SkillValidationError(
+            f"Role '{role}' di {context} tidak dikenal. Pilih: {known}"
+        )
+    return role
+
+
+def _detect_cycle(steps: list[Step]) -> None:
+    """Topological sort dengan Kahn algorithm — kalau gagal, ada cycle."""
+    indeg: dict[str, int] = {s.name: 0 for s in steps}
+    graph: dict[str, list[str]] = {s.name: [] for s in steps}
+    for s in steps:
+        for dep in s.depends_on:
+            graph[dep].append(s.name)
+            indeg[s.name] += 1
+    queue = [n for n, d in indeg.items() if d == 0]
+    visited = 0
+    while queue:
+        n = queue.pop()
+        visited += 1
+        for child in graph[n]:
+            indeg[child] -= 1
+            if indeg[child] == 0:
+                queue.append(child)
+    if visited != len(steps):
+        raise SkillValidationError(
+            "Cycle terdeteksi di steps.depends_on — workflow tidak boleh recursive"
+        )
+
+
+# ── Parser ────────────────────────────────────────────────────────────────────
+
+
+def parse_step(data: Any, index: int) -> Step:
+    if not isinstance(data, dict):
+        raise SkillValidationError(f"steps[{index}] harus object, dapat {type(data).__name__}")
+
+    raw_name = data.get("name") or data.get("role")  # role boleh dipakai sebagai default name
+    name = _validate_name(_require_str(raw_name, f"steps[{index}].name"), f"steps[{index}].name")
+    role = _validate_role(_require_str(data.get("role"), f"steps[{index}].role"), f"steps[{index}]")
+
+    raw_deps = data.get("depends_on", [])
+    if not isinstance(raw_deps, list):
+        raise SkillValidationError(f"steps[{index}].depends_on harus list")
+    deps: list[str] = []
+    for d in raw_deps:
+        deps.append(_validate_name(_require_str(d, f"steps[{index}].depends_on item"), "depends_on"))
+
+    prompt_tpl = data.get("prompt_template")
+    if prompt_tpl is not None and not isinstance(prompt_tpl, str):
+        raise SkillValidationError(f"steps[{index}].prompt_template harus string atau null")
+
+    produces = data.get("produces")
+    if produces is not None:
+        produces = _validate_name(_require_str(produces, "produces"), "produces")
+
+    return Step(
+        name=name,
+        role=role,
+        depends_on=tuple(deps),
+        prompt_template=prompt_tpl,
+        produces=produces,
+    )
+
+
+def parse_manager(data: Any) -> Manager:
+    if not isinstance(data, dict):
+        raise SkillValidationError(f"manager harus object, dapat {type(data).__name__}")
+    role = _validate_role(_require_str(data.get("role"), "manager.role"), "manager")
+    max_rev = data.get("max_revisions", 2)
+    if not isinstance(max_rev, int) or max_rev < 0:
+        raise SkillValidationError("manager.max_revisions harus integer ≥ 0")
+    crit = data.get("acceptance_criteria", "")
+    if not isinstance(crit, str):
+        raise SkillValidationError("manager.acceptance_criteria harus string")
+    return Manager(role=role, max_revisions=max_rev, acceptance_criteria=crit)
+
+
+def parse_skill(data: Any) -> Skill:
+    """Validate + load Skill dari dict (mis. hasil json.loads).
+
+    Raise ``SkillValidationError`` dengan pesan deskriptif kalau format salah.
+    """
+    if not isinstance(data, dict):
+        raise SkillValidationError(f"skill harus object, dapat {type(data).__name__}")
+
+    name = _validate_name(_require_str(data.get("name"), "name"), "name")
+
+    description = data.get("description", "")
+    if not isinstance(description, str):
+        raise SkillValidationError("description harus string")
+    if len(description) > MAX_DESCRIPTION_LEN:
+        raise SkillValidationError(
+            f"description terlalu panjang (max {MAX_DESCRIPTION_LEN} char)"
+        )
+
+    raw_steps = data.get("steps")
+    if not isinstance(raw_steps, list) or not raw_steps:
+        raise SkillValidationError("steps harus list non-kosong")
+    if len(raw_steps) > MAX_STEPS:
+        raise SkillValidationError(f"jumlah steps melebihi cap ({MAX_STEPS})")
+
+    steps = [parse_step(s, i) for i, s in enumerate(raw_steps)]
+
+    # Step name unik
+    seen: set[str] = set()
+    for s in steps:
+        if s.name in seen:
+            raise SkillValidationError(f"step name '{s.name}' duplikat")
+        seen.add(s.name)
+
+    # depends_on harus reference step yang ada
+    for s in steps:
+        for dep in s.depends_on:
+            if dep not in seen:
+                raise SkillValidationError(
+                    f"step '{s.name}' depends_on '{dep}' yang tidak terdaftar"
+                )
+            if dep == s.name:
+                raise SkillValidationError(f"step '{s.name}' depends_on dirinya sendiri")
+
+    _detect_cycle(steps)
+
+    raw_manager = data.get("manager")
+    manager = parse_manager(raw_manager) if raw_manager is not None else None
+
+    return Skill(
+        name=name,
+        description=description,
+        steps=tuple(steps),
+        manager=manager,
+    )
+
+
+# ── Serialization (round-trip with parse_skill) ───────────────────────────────
+
+
+def skill_to_dict(skill: Skill) -> dict[str, Any]:
+    """Inverse dari ``parse_skill`` — supaya bisa store-then-load round-trip."""
+    out: dict[str, Any] = {
+        "name": skill.name,
+        "description": skill.description,
+        "steps": [
+            {
+                "name": s.name,
+                "role": s.role,
+                "depends_on": list(s.depends_on),
+                **({"prompt_template": s.prompt_template} if s.prompt_template else {}),
+                **({"produces": s.produces} if s.produces else {}),
+            }
+            for s in skill.steps
+        ],
+    }
+    if skill.manager is not None:
+        out["manager"] = {
+            "role": skill.manager.role,
+            "max_revisions": skill.manager.max_revisions,
+            "acceptance_criteria": skill.manager.acceptance_criteria,
+        }
+    return out
+
+
+# ── DAG ordering (executor butuh ini di PR berikutnya) ────────────────────────
+
+
+def topological_order(skill: Skill) -> list[Step]:
+    """Return urutan step yang valid untuk eksekusi sequential.
+
+    Stable: kalau dua step bisa dijalankan paralel, urutan-nya mengikuti
+    urutan deklarasi user — bukan diacak. Bermanfaat untuk reproducibility.
+    """
+    by_name = {s.name: s for s in skill.steps}
+    indeg = {s.name: len(s.depends_on) for s in skill.steps}
+    ready: list[str] = [s.name for s in skill.steps if indeg[s.name] == 0]
+    out: list[Step] = []
+
+    graph: dict[str, list[str]] = {s.name: [] for s in skill.steps}
+    for s in skill.steps:
+        for dep in s.depends_on:
+            graph[dep].append(s.name)
+
+    declared_order = [s.name for s in skill.steps]
+    while ready:
+        # Pop earliest-declared ready step (stability).
+        ready.sort(key=lambda n: declared_order.index(n))
+        n = ready.pop(0)
+        out.append(by_name[n])
+        for child in graph[n]:
+            indeg[child] -= 1
+            if indeg[child] == 0:
+                ready.append(child)
+
+    if len(out) != len(skill.steps):
+        # Defensive — seharusnya tidak terjadi karena parse_skill sudah cek cycle.
+        raise SkillValidationError("Internal: topological sort tidak lengkap (cycle?)")
+    return out
+
+
+# ── Field for "extra context" — defaults ──────────────────────────────────────
+
+_DEFAULT_TEMPLATE_VARS = {"prompt", "handoff", "recall"}  # placeholder for executor PR
+_ = field  # keep import alive for downstream dataclass extensions

--- a/tests/adapters/test_skill_repository.py
+++ b/tests/adapters/test_skill_repository.py
@@ -1,0 +1,203 @@
+"""Repository tests untuk Skill CRUD pada ``ControlPlaneRepository``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.adapters.database.models import Base, UserModel
+from app.adapters.database.repositories import (
+    ControlPlaneRepository,
+    DatabaseConflictError,
+)
+from app.domain.skills import SkillValidationError
+
+
+def _valid_skill(name: str = "skill-a") -> dict[str, Any]:
+    return {
+        "name": name,
+        "steps": [
+            {"name": "design", "role": "architect"},
+            {"name": "build", "role": "engineer", "depends_on": ["design"]},
+        ],
+    }
+
+
+@pytest.fixture()
+def session():
+    engine = create_engine("sqlite:///:memory:", echo=False)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    with factory() as s:
+        yield s
+
+
+@pytest.fixture()
+def repo_user_project(session):
+    user = UserModel(display_name="Alice", email="alice@x.com")
+    session.add(user)
+    session.flush()
+    repo = ControlPlaneRepository(session)
+    project = repo.create_project(user.id, "myproj", ".")
+    return repo, user.id, project.id
+
+
+# ── create_skill ─────────────────────────────────────────────────────────────
+
+
+def test_create_skill_stores_definition(repo_user_project) -> None:
+    repo, user_id, project_id = repo_user_project
+    row = repo.create_skill(project_id, user_id, _valid_skill("alpha"))
+    assert row.id is not None
+    assert row.name == "alpha"
+    assert row.project_id == project_id
+    assert isinstance(row.definition, dict)
+    assert row.definition["name"] == "alpha"
+    assert len(row.definition["steps"]) == 2
+
+
+def test_create_skill_rejects_invalid_definition(repo_user_project) -> None:
+    repo, user_id, project_id = repo_user_project
+    bad = {"name": "broken", "steps": [{"name": "x", "role": "wizard"}]}
+    with pytest.raises(SkillValidationError):
+        repo.create_skill(project_id, user_id, bad)
+
+
+def test_create_skill_rejects_duplicate_name_in_same_project(repo_user_project) -> None:
+    repo, user_id, project_id = repo_user_project
+    repo.create_skill(project_id, user_id, _valid_skill("dup"))
+    with pytest.raises(DatabaseConflictError, match="sudah ada"):
+        repo.create_skill(project_id, user_id, _valid_skill("dup"))
+
+
+def test_create_skill_rejects_for_other_user_project(repo_user_project, session) -> None:
+    repo, _user_id, project_id = repo_user_project
+    other = UserModel(display_name="Bob", email="bob@x.com")
+    session.add(other)
+    session.flush()
+    with pytest.raises(DatabaseConflictError):
+        repo.create_skill(project_id, other.id, _valid_skill("x"))
+
+
+# ── list / get ───────────────────────────────────────────────────────────────
+
+
+def test_list_skills_returns_created(repo_user_project) -> None:
+    repo, user_id, project_id = repo_user_project
+    repo.create_skill(project_id, user_id, _valid_skill("a"))
+    repo.create_skill(project_id, user_id, _valid_skill("b"))
+    names = sorted(s.name for s in repo.list_project_skills(project_id, user_id))
+    assert names == ["a", "b"]
+
+
+def test_list_skills_empty_for_unknown_project(repo_user_project) -> None:
+    repo, user_id, _ = repo_user_project
+    assert repo.list_project_skills("ghost", user_id) == []
+
+
+def test_list_skills_isolates_users(repo_user_project, session) -> None:
+    repo, user_id, project_id = repo_user_project
+    repo.create_skill(project_id, user_id, _valid_skill("a"))
+    other = UserModel(display_name="Bob", email="bob@x.com")
+    session.add(other)
+    session.flush()
+    assert repo.list_project_skills(project_id, other.id) == []
+
+
+def test_get_skill_by_id_for_owner(repo_user_project) -> None:
+    repo, user_id, project_id = repo_user_project
+    created = repo.create_skill(project_id, user_id, _valid_skill("a"))
+    got = repo.get_skill(created.id, user_id)
+    assert got is not None and got.name == "a"
+
+
+def test_get_skill_by_id_returns_none_for_other_user(repo_user_project, session) -> None:
+    repo, user_id, project_id = repo_user_project
+    created = repo.create_skill(project_id, user_id, _valid_skill("a"))
+    other = UserModel(display_name="Bob", email="bob@x.com")
+    session.add(other)
+    session.flush()
+    assert repo.get_skill(created.id, other.id) is None
+
+
+def test_get_skill_by_name(repo_user_project) -> None:
+    repo, user_id, project_id = repo_user_project
+    repo.create_skill(project_id, user_id, _valid_skill("named"))
+    got = repo.get_skill_by_name(project_id, "named", user_id)
+    assert got is not None and got.name == "named"
+
+
+# ── update_skill ─────────────────────────────────────────────────────────────
+
+
+def test_update_skill_replaces_definition(repo_user_project) -> None:
+    repo, user_id, project_id = repo_user_project
+    row = repo.create_skill(project_id, user_id, _valid_skill("orig"))
+    new_def = _valid_skill("orig")
+    new_def["description"] = "updated"
+    updated = repo.update_skill(row.id, user_id, new_def)
+    assert updated.description == "updated"
+
+
+def test_update_skill_rename_collision_rejected(repo_user_project) -> None:
+    repo, user_id, project_id = repo_user_project
+    repo.create_skill(project_id, user_id, _valid_skill("a"))
+    b = repo.create_skill(project_id, user_id, _valid_skill("b"))
+    # rename b -> a should fail (a exists)
+    new_def = _valid_skill("a")
+    with pytest.raises(DatabaseConflictError, match="sudah dipakai"):
+        repo.update_skill(b.id, user_id, new_def)
+
+
+def test_update_skill_unknown_id_raises(repo_user_project) -> None:
+    repo, user_id, _ = repo_user_project
+    with pytest.raises(DatabaseConflictError):
+        repo.update_skill("ghost", user_id, _valid_skill("x"))
+
+
+def test_update_skill_validates_new_definition(repo_user_project) -> None:
+    repo, user_id, project_id = repo_user_project
+    row = repo.create_skill(project_id, user_id, _valid_skill("a"))
+    bad = {"name": "a", "steps": [{"name": "x", "role": "wizard"}]}
+    with pytest.raises(SkillValidationError):
+        repo.update_skill(row.id, user_id, bad)
+
+
+# ── delete_skill ─────────────────────────────────────────────────────────────
+
+
+def test_delete_skill_returns_true_when_deleted(repo_user_project) -> None:
+    repo, user_id, project_id = repo_user_project
+    row = repo.create_skill(project_id, user_id, _valid_skill("doomed"))
+    assert repo.delete_skill(row.id, user_id) is True
+    assert repo.get_skill(row.id, user_id) is None
+
+
+def test_delete_skill_returns_false_when_not_found(repo_user_project) -> None:
+    repo, user_id, _ = repo_user_project
+    assert repo.delete_skill("ghost", user_id) is False
+
+
+def test_delete_skill_blocked_for_other_user(repo_user_project, session) -> None:
+    repo, user_id, project_id = repo_user_project
+    row = repo.create_skill(project_id, user_id, _valid_skill("x"))
+    other = UserModel(display_name="Bob", email="bob@x.com")
+    session.add(other)
+    session.flush()
+    assert repo.delete_skill(row.id, other.id) is False
+    # Original still exists for owner
+    assert repo.get_skill(row.id, user_id) is not None
+
+
+# ── load_skill_domain (round-trip ke dataclass) ──────────────────────────────
+
+
+def test_load_skill_domain_returns_validated_dataclass(repo_user_project) -> None:
+    repo, user_id, project_id = repo_user_project
+    row = repo.create_skill(project_id, user_id, _valid_skill("workflow"))
+    skill = repo.load_skill_domain(row)
+    assert skill.name == "workflow"
+    assert [s.name for s in skill.steps] == ["design", "build"]

--- a/tests/test_skills_schema.py
+++ b/tests/test_skills_schema.py
@@ -1,0 +1,269 @@
+"""Unit tests untuk Skill DSL schema (``app.domain.skills``).
+
+Pure domain — zero mocks, zero DB.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.domain.skills import (
+    MAX_DESCRIPTION_LEN,
+    MAX_STEPS,
+    Manager,
+    Skill,
+    SkillValidationError,
+    Step,
+    parse_skill,
+    skill_to_dict,
+    topological_order,
+)
+
+# ── Minimum valid skill ───────────────────────────────────────────────────────
+
+
+def _minimal_skill_dict() -> dict[str, object]:
+    return {
+        "name": "trivial",
+        "steps": [{"name": "only", "role": "engineer"}],
+    }
+
+
+def test_parse_minimal_skill_succeeds() -> None:
+    skill = parse_skill(_minimal_skill_dict())
+    assert skill.name == "trivial"
+    assert len(skill.steps) == 1
+    assert skill.steps[0].name == "only"
+    assert skill.steps[0].role == "engineer"
+    assert skill.manager is None
+
+
+def test_parse_full_skill_with_manager_and_dependencies() -> None:
+    data = {
+        "name": "build-site",
+        "description": "End-to-end website build",
+        "steps": [
+            {"name": "design", "role": "architect", "depends_on": []},
+            {"name": "code", "role": "engineer", "depends_on": ["design"]},
+            {"name": "review", "role": "reviewer", "depends_on": ["code"]},
+        ],
+        "manager": {
+            "role": "architect",
+            "max_revisions": 3,
+            "acceptance_criteria": "Production-ready",
+        },
+    }
+    skill = parse_skill(data)
+    assert skill.name == "build-site"
+    assert skill.description == "End-to-end website build"
+    assert [s.name for s in skill.steps] == ["design", "code", "review"]
+    assert skill.steps[1].depends_on == ("design",)
+    assert skill.manager is not None
+    assert skill.manager.max_revisions == 3
+
+
+def test_parse_uses_role_as_default_step_name() -> None:
+    """Step boleh tidak punya 'name' eksplisit kalau pakai role sebagai identifier."""
+    data = {
+        "name": "x",
+        "steps": [{"role": "engineer"}],
+    }
+    skill = parse_skill(data)
+    assert skill.steps[0].name == "engineer"
+
+
+# ── Validation errors ─────────────────────────────────────────────────────────
+
+
+def test_reject_non_dict_input() -> None:
+    with pytest.raises(SkillValidationError):
+        parse_skill("not a dict")  # type: ignore[arg-type]
+
+
+def test_reject_missing_name() -> None:
+    with pytest.raises(SkillValidationError, match="name"):
+        parse_skill({"steps": [{"name": "x", "role": "engineer"}]})
+
+
+def test_reject_empty_steps() -> None:
+    with pytest.raises(SkillValidationError, match="steps"):
+        parse_skill({"name": "x", "steps": []})
+
+
+def test_reject_steps_above_cap() -> None:
+    steps = [{"name": f"s{i}", "role": "engineer"} for i in range(MAX_STEPS + 1)]
+    with pytest.raises(SkillValidationError, match=r"melebihi cap"):
+        parse_skill({"name": "x", "steps": steps})
+
+
+def test_reject_unknown_role() -> None:
+    with pytest.raises(SkillValidationError, match="wizard"):
+        parse_skill({
+            "name": "x",
+            "steps": [{"name": "a", "role": "wizard"}],
+        })
+
+
+def test_reject_duplicate_step_names() -> None:
+    with pytest.raises(SkillValidationError, match="duplikat"):
+        parse_skill({
+            "name": "x",
+            "steps": [
+                {"name": "a", "role": "engineer"},
+                {"name": "a", "role": "reviewer"},
+            ],
+        })
+
+
+def test_reject_depends_on_referencing_nonexistent_step() -> None:
+    with pytest.raises(SkillValidationError, match="ghost"):
+        parse_skill({
+            "name": "x",
+            "steps": [
+                {"name": "a", "role": "engineer", "depends_on": ["ghost"]},
+            ],
+        })
+
+
+def test_reject_self_dependency() -> None:
+    with pytest.raises(SkillValidationError, match="dirinya sendiri"):
+        parse_skill({
+            "name": "x",
+            "steps": [
+                {"name": "a", "role": "engineer", "depends_on": ["a"]},
+            ],
+        })
+
+
+def test_reject_cycle_in_dependencies() -> None:
+    with pytest.raises(SkillValidationError, match=r"[Cc]ycle"):
+        parse_skill({
+            "name": "x",
+            "steps": [
+                {"name": "a", "role": "engineer", "depends_on": ["b"]},
+                {"name": "b", "role": "engineer", "depends_on": ["c"]},
+                {"name": "c", "role": "engineer", "depends_on": ["a"]},
+            ],
+        })
+
+
+def test_reject_description_too_long() -> None:
+    with pytest.raises(SkillValidationError, match="description"):
+        parse_skill({
+            "name": "x",
+            "description": "X" * (MAX_DESCRIPTION_LEN + 1),
+            "steps": [{"name": "a", "role": "engineer"}],
+        })
+
+
+def test_reject_unknown_role_in_manager() -> None:
+    with pytest.raises(SkillValidationError, match="ceo"):
+        parse_skill({
+            "name": "x",
+            "steps": [{"name": "a", "role": "engineer"}],
+            "manager": {"role": "ceo"},
+        })
+
+
+def test_reject_negative_max_revisions_in_manager() -> None:
+    with pytest.raises(SkillValidationError, match="max_revisions"):
+        parse_skill({
+            "name": "x",
+            "steps": [{"name": "a", "role": "engineer"}],
+            "manager": {"role": "architect", "max_revisions": -1},
+        })
+
+
+# ── skill_to_dict round-trip ─────────────────────────────────────────────────
+
+
+def test_round_trip_minimal() -> None:
+    data = _minimal_skill_dict()
+    skill = parse_skill(data)
+    back = skill_to_dict(skill)
+    again = parse_skill(back)
+    assert again == skill
+
+
+def test_round_trip_full_with_manager() -> None:
+    data = {
+        "name": "x",
+        "description": "desc",
+        "steps": [
+            {"name": "a", "role": "engineer", "depends_on": []},
+            {"name": "b", "role": "reviewer", "depends_on": ["a"], "produces": "review"},
+        ],
+        "manager": {
+            "role": "architect",
+            "max_revisions": 5,
+            "acceptance_criteria": "good enough",
+        },
+    }
+    skill = parse_skill(data)
+    again = parse_skill(skill_to_dict(skill))
+    assert again == skill
+
+
+# ── topological_order ────────────────────────────────────────────────────────
+
+
+def test_topo_order_simple_chain() -> None:
+    skill = parse_skill({
+        "name": "x",
+        "steps": [
+            {"name": "c", "role": "reviewer", "depends_on": ["b"]},
+            {"name": "b", "role": "engineer", "depends_on": ["a"]},
+            {"name": "a", "role": "engineer", "depends_on": []},
+        ],
+    })
+    order = topological_order(skill)
+    assert [s.name for s in order] == ["a", "b", "c"]
+
+
+def test_topo_order_is_stable_for_independent_steps() -> None:
+    """Step yang bisa paralel mengikuti urutan deklarasi user."""
+    skill = parse_skill({
+        "name": "x",
+        "steps": [
+            {"name": "first",  "role": "engineer", "depends_on": []},
+            {"name": "second", "role": "engineer", "depends_on": []},
+            {"name": "third",  "role": "reviewer", "depends_on": ["first", "second"]},
+        ],
+    })
+    order = topological_order(skill)
+    assert [s.name for s in order] == ["first", "second", "third"]
+
+
+def test_topo_order_complex_dag() -> None:
+    skill = parse_skill({
+        "name": "x",
+        "steps": [
+            {"name": "design",  "role": "architect", "depends_on": []},
+            {"name": "copy",    "role": "engineer",  "depends_on": ["design"]},
+            {"name": "code",    "role": "engineer",  "depends_on": ["design", "copy"]},
+            {"name": "review",  "role": "reviewer",  "depends_on": ["code"]},
+        ],
+    })
+    order = topological_order(skill)
+    names = [s.name for s in order]
+    # Constraints: design < copy < code < review; design < code
+    assert names.index("design") < names.index("copy")
+    assert names.index("copy") < names.index("code")
+    assert names.index("code") < names.index("review")
+
+
+# ── Dataclass behavior ───────────────────────────────────────────────────────
+
+
+def test_skill_dataclass_is_frozen() -> None:
+    from dataclasses import FrozenInstanceError
+    skill = Skill(name="x", steps=(Step(name="a", role="engineer"),))
+    with pytest.raises(FrozenInstanceError):
+        skill.name = "y"  # type: ignore[misc]
+
+
+def test_manager_dataclass_is_frozen() -> None:
+    from dataclasses import FrozenInstanceError
+    m = Manager(role="architect")
+    with pytest.raises(FrozenInstanceError):
+        m.max_revisions = 99  # type: ignore[misc]


### PR DESCRIPTION
Bagian 1/3 Skill subsystem. Schema + storage + repo. Executor & user-facing CRUD di PR berikutnya.

## Apa
- ``app/domain/skills.py`` pure domain — ``Step``/``Manager``/``Skill`` frozen dataclass + ``parse_skill`` validator (DAG cycle, depends_on dangling, unknown role, duplicate name, oversize) + ``skill_to_dict`` round-trip + ``topological_order``
- ``SkillModel(id, project_id FK CASCADE, name, description, definition JSONB, timestamps)`` UNIQUE(project_id, name)
- Migration ``20260518_0008`` — ``down_revision`` di-pin ke ``20260517_0006`` (main HEAD saat PR dibuat). **Akan saya rebase ke ``20260517_0007`` setelah ``feat/rag-knowledge-store`` (PR #31) merged**.
- Repository CRUD di ``ControlPlaneRepository``: ``create_skill``/``list``/``get``/``update``/``delete``/``load_skill_domain`` — semua user-scoped via project ownership
- 40 tests (22 schema validation + 18 repo CRUD)

## Test plan
- [ ] pytest hijau
- [ ] Migration apply ke staging tanpa break dependency chain

Refs: issue #26