### PR TITLE
feat(skill): user-facing CRUD — HTTP API + TUI /skill commands

### DIFF
--- a/app/interfaces/gateway.py
+++ b/app/interfaces/gateway.py
@@ -8,6 +8,7 @@ from app.config import settings
 from app.interfaces.admin import router as admin_router
 from app.interfaces.auth import router as auth_router
 from app.interfaces.chat import router as chat_router
+from app.interfaces.skills import router as skills_router
 from app.interfaces.worker_ws import router as worker_ws_router
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,7 @@ app = FastAPI(title="Octopus Core", version="0.1.0", lifespan=lifespan)
 app.include_router(auth_router)
 app.include_router(admin_router)
 app.include_router(chat_router)
+app.include_router(skills_router)
 app.include_router(worker_ws_router)
 
 

--- a/app/interfaces/skills.py
+++ b/app/interfaces/skills.py
@@ -1,0 +1,245 @@
+"""HTTP endpoints untuk Skill CRUD + run streaming.
+
+Auth: Bearer session token (dari TUI login flow). Semua endpoint user-scoped
+via project ownership — user tidak bisa list/baca/edit skill milik user lain.
+
+Endpoints:
+- ``GET    /skills?project_id=...``       — list skills dalam project
+- ``POST   /skills``                       — create skill (body: project_id + definition)
+- ``GET    /skills/{skill_id}``            — get satu skill
+- ``PUT    /skills/{skill_id}``            — update (re-validate definition)
+- ``DELETE /skills/{skill_id}``            — delete
+- ``POST   /skills/{skill_id}/run``        — execute via ``SkillExecutor``,
+  stream event SSE (skill_started, step_*, skill_completed/failed).
+
+Mapping error:
+- ``SkillValidationError`` → 400 Bad Request
+- ``DatabaseConflictError`` → 409 Conflict
+- Skill not found / not owned → 404 Not Found
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Body, Header, HTTPException, status
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from app.adapters.agent_configs import UserAgentConfigRepository
+from app.adapters.database.repositories import (
+    ControlPlaneRepository,
+    DatabaseConflictError,
+)
+from app.adapters.sessions import UserSessionRepository
+from app.composition import _session_factory
+from app.domain.skills import SkillValidationError, parse_skill, skill_to_dict
+from app.orchestrator.skill_executor import SkillEvent, SkillExecutor
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/skills", tags=["skills"])
+
+
+# ── Auth helper ──────────────────────────────────────────────────────────────
+
+
+def _resolve_user_id(authorization: str | None) -> str:
+    """Resolve user_id dari Bearer session token. Raise 401 kalau invalid."""
+    if authorization is None or not authorization.lower().startswith("bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Bearer token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    token = authorization.split(" ", 1)[1].strip()
+    repo = UserSessionRepository(_session_factory())
+    info = repo.resolve(token)
+    if info is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid or expired session",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return info.user_id
+
+
+# ── Request/response shapes ──────────────────────────────────────────────────
+
+
+class SkillCreateRequest(BaseModel):
+    project_id: str
+    definition: dict[str, Any]
+
+
+class SkillUpdateRequest(BaseModel):
+    definition: dict[str, Any]
+
+
+class SkillRunRequest(BaseModel):
+    prompt: str
+
+
+def _skill_to_response(row: Any) -> dict[str, Any]:
+    return {
+        "id": row.id,
+        "project_id": row.project_id,
+        "name": row.name,
+        "description": row.description,
+        "definition": row.definition,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+    }
+
+
+# ── CRUD endpoints ───────────────────────────────────────────────────────────
+
+
+@router.get("")
+async def list_skills(
+    project_id: str,
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    """List skills milik project. Empty list kalau project bukan milik user."""
+    user_id = _resolve_user_id(authorization)
+    with _session_factory()() as session:
+        repo = ControlPlaneRepository(session)
+        rows = repo.list_project_skills(project_id, user_id)
+        return {"skills": [_skill_to_response(r) for r in rows]}
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_skill(
+    req: Annotated[SkillCreateRequest, Body(...)],
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    user_id = _resolve_user_id(authorization)
+    with _session_factory()() as session:
+        repo = ControlPlaneRepository(session)
+        try:
+            row = repo.create_skill(req.project_id, user_id, req.definition)
+        except SkillValidationError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        except DatabaseConflictError as exc:
+            raise HTTPException(409, str(exc)) from exc
+        session.commit()
+        return _skill_to_response(row)
+
+
+@router.get("/{skill_id}")
+async def get_skill(
+    skill_id: str,
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    user_id = _resolve_user_id(authorization)
+    with _session_factory()() as session:
+        repo = ControlPlaneRepository(session)
+        row = repo.get_skill(skill_id, user_id)
+        if row is None:
+            raise HTTPException(404, f"Skill {skill_id} tidak ditemukan")
+        return _skill_to_response(row)
+
+
+@router.put("/{skill_id}")
+async def update_skill(
+    skill_id: str,
+    req: Annotated[SkillUpdateRequest, Body(...)],
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    user_id = _resolve_user_id(authorization)
+    with _session_factory()() as session:
+        repo = ControlPlaneRepository(session)
+        try:
+            row = repo.update_skill(skill_id, user_id, req.definition)
+        except SkillValidationError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        except DatabaseConflictError as exc:
+            # Bisa "skill not found" atau "rename collision" — bedakan via msg.
+            msg = str(exc)
+            code = 404 if "tidak ditemukan" in msg else 409
+            raise HTTPException(code, msg) from exc
+        session.commit()
+        return _skill_to_response(row)
+
+
+@router.delete("/{skill_id}")
+async def delete_skill(
+    skill_id: str,
+    authorization: str | None = Header(default=None),
+) -> dict[str, bool]:
+    user_id = _resolve_user_id(authorization)
+    with _session_factory()() as session:
+        repo = ControlPlaneRepository(session)
+        if not repo.delete_skill(skill_id, user_id):
+            raise HTTPException(404, f"Skill {skill_id} tidak ditemukan")
+        session.commit()
+    return {"deleted": True}
+
+
+# ── Validate endpoint (dry-run schema check) ─────────────────────────────────
+
+
+@router.post("/validate")
+async def validate_skill(
+    req: Annotated[SkillUpdateRequest, Body(...)],
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    """Dry-run parse — useful untuk UI 'cek dulu sebelum save'."""
+    _resolve_user_id(authorization)  # auth required, no DB write
+    try:
+        skill = parse_skill(req.definition)
+    except SkillValidationError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    return {"valid": True, "normalized": skill_to_dict(skill)}
+
+
+# ── Run endpoint (SSE stream) ────────────────────────────────────────────────
+
+
+def _format_sse(event: SkillEvent) -> str:
+    return f"event: {event.type}\ndata: {json.dumps(event.payload)}\n\n"
+
+
+@router.post("/{skill_id}/run")
+async def run_skill(
+    skill_id: str,
+    req: Annotated[SkillRunRequest, Body(...)],
+    authorization: str | None = Header(default=None),
+) -> StreamingResponse:
+    """Execute skill, stream events via SSE.
+
+    Dispatcher = ``dispatch_agent_job`` di worker_ws.
+    Agent resolver = ``UserAgentConfigRepository.agent_for_role``.
+    """
+    user_id = _resolve_user_id(authorization)
+
+    with _session_factory()() as session:
+        repo = ControlPlaneRepository(session)
+        row = repo.get_skill(skill_id, user_id)
+        if row is None:
+            raise HTTPException(404, f"Skill {skill_id} tidak ditemukan")
+        skill = repo.load_skill_domain(row)
+
+    # Production wiring: dispatcher & resolver tidak di-inject ke router supaya
+    # endpoint tetap simple. Untuk test, kita patch endpoint ini lewat factory
+    # override (lihat ``tests/interfaces/test_skills_endpoints.py``).
+    from app.interfaces.worker_ws import dispatch_agent_job
+    user_agent_repo = UserAgentConfigRepository(_session_factory())
+    executor = SkillExecutor(
+        dispatcher=dispatch_agent_job,
+        agent_resolver=user_agent_repo.agent_for_role,
+    )
+
+    from collections.abc import AsyncIterator as _AsyncIterator
+
+    async def stream() -> _AsyncIterator[str]:
+        async for ev in executor.execute(skill, user_id=user_id, base_prompt=req.prompt):
+            yield _format_sse(ev)
+        yield "event: done\ndata: {}\n\n"
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/app/tui/_commands.py
+++ b/app/tui/_commands.py
@@ -598,3 +598,203 @@ async def cmd_audit(args: list[str]) -> None:
             ("class:dim",         preview[:80]),
         ])
     println("", "")
+
+
+# ── /skill — workflow Skill DSL ──────────────────────────────────────────────
+
+
+async def cmd_skill(args: list[str]) -> None:
+    """List, show, delete, run, atau load skills.
+
+    Usage:
+      /skill                          — list semua skill di project active
+      /skill <project_id>             — list di project tertentu
+      /skill show <skill_id>          — tampilkan JSON definition
+      /skill rm <skill_id>            — hapus skill
+      /skill run <skill_id> <prompt>  — eksekusi (streaming events)
+      /skill load <project_id> <path> — load definition dari JSON file → create
+    """
+    session = _state.active_session
+    if session is None:
+        println("class:warn", "  login dulu via /login")
+        return
+
+    sub = args[0].lower() if args else "list"
+
+    if sub in ("list", "ls") or not args:
+        project_id = args[1] if len(args) > 1 and sub != "list" else (
+            args[0] if args and sub == "list" and len(args) > 1 else None
+        )
+        # Simplifikasi: kalau arg pertama bukan keyword, treat as project_id.
+        if args and args[0] not in {"list", "ls", "show", "rm", "run", "load"}:
+            project_id = args[0]
+        if project_id is None:
+            println("class:warn", "  butuh project_id. Usage: /skill <project_id>")
+            return
+        await _skill_list(session.token, project_id)
+        return
+
+    if sub == "show" and len(args) >= 2:
+        await _skill_show(session.token, args[1])
+        return
+    if sub == "rm" and len(args) >= 2:
+        await _skill_delete(session.token, args[1])
+        return
+    if sub == "run" and len(args) >= 3:
+        await _skill_run(session.token, args[1], " ".join(args[2:]))
+        return
+    if sub == "load" and len(args) >= 3:
+        await _skill_load(session.token, args[1], args[2])
+        return
+
+    println("class:warn", "  usage: /skill [list|show|rm|run|load] ...")
+
+
+async def _skill_list(token: str, project_id: str) -> None:
+    try:
+        async with httpx.AsyncClient(timeout=10.0, trust_env=False) as c:
+            r = await c.get(
+                f"{settings.app_url}/skills",
+                params={"project_id": project_id},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        println("class:err", f"  request gagal: {fmt_http_error(exc)}")
+        return
+    if r.status_code != 200:
+        println("class:err", f"  HTTP {r.status_code}: {r.text[:200]}")
+        return
+    skills = r.json().get("skills", [])
+    if not skills:
+        println("class:dim", f"  (no skills di project {project_id})")
+        return
+    println("class:section", f"  Skills di project {project_id}")
+    println("class:rule", "  " + "─" * 60)
+    for s in skills:
+        print_parts([
+            ("class:cmd.name", f"  {s['name']:<24}"),
+            ("class:dim",      f"{s['id'][:8]}…  "),
+            ("",               s.get("description", "")[:50] or "—"),
+        ])
+    println("", "")
+
+
+async def _skill_show(token: str, skill_id: str) -> None:
+    import json as _json
+    try:
+        async with httpx.AsyncClient(timeout=10.0, trust_env=False) as c:
+            r = await c.get(
+                f"{settings.app_url}/skills/{skill_id}",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        println("class:err", f"  request gagal: {fmt_http_error(exc)}")
+        return
+    if r.status_code != 200:
+        println("class:err", f"  HTTP {r.status_code}: {r.text[:200]}")
+        return
+    data = r.json()
+    println("class:section", f"  Skill: {data['name']}")
+    println("class:rule", "  " + "─" * 60)
+    pretty = _json.dumps(data["definition"], indent=2, ensure_ascii=False)
+    for line in pretty.splitlines():
+        println("class:dim", "  " + line)
+    println("", "")
+
+
+async def _skill_delete(token: str, skill_id: str) -> None:
+    try:
+        async with httpx.AsyncClient(timeout=10.0, trust_env=False) as c:
+            r = await c.delete(
+                f"{settings.app_url}/skills/{skill_id}",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        println("class:err", f"  request gagal: {fmt_http_error(exc)}")
+        return
+    if r.status_code == 200:
+        println("class:ok", f"  ✓ skill {skill_id} dihapus")
+    else:
+        println("class:err", f"  HTTP {r.status_code}: {r.text[:200]}")
+
+
+async def _skill_load(token: str, project_id: str, path: str) -> None:
+    import json as _json
+    try:
+        with open(os.path.expanduser(path), encoding="utf-8") as f:
+            definition = _json.load(f)
+    except OSError as exc:
+        println("class:err", f"  baca file gagal: {exc}")
+        return
+    except _json.JSONDecodeError as exc:
+        println("class:err", f"  JSON invalid: {exc}")
+        return
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0, trust_env=False) as c:
+            r = await c.post(
+                f"{settings.app_url}/skills",
+                json={"project_id": project_id, "definition": definition},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    except httpx.HTTPError as exc:
+        println("class:err", f"  request gagal: {fmt_http_error(exc)}")
+        return
+    if r.status_code == 201:
+        data = r.json()
+        println("class:ok", f"  ✓ skill '{data['name']}' dibuat (id: {data['id'][:8]}…)")
+    else:
+        println("class:err", f"  HTTP {r.status_code}: {r.text[:200]}")
+
+
+async def _skill_run(token: str, skill_id: str, prompt: str) -> None:
+    import json as _json
+    println("class:section", f"  Running skill {skill_id}…")
+    try:
+        async with httpx.AsyncClient(timeout=None, trust_env=False) as c, c.stream(
+            "POST",
+            f"{settings.app_url}/skills/{skill_id}/run",
+            json={"prompt": prompt},
+            headers={"Authorization": f"Bearer {token}"},
+        ) as r:
+            if r.status_code != 200:
+                body = await r.aread()
+                println("class:err", f"  HTTP {r.status_code}: {body.decode()[:200]}")
+                return
+            event_name = ""
+            async for line in r.aiter_lines():
+                if line.startswith("event: "):
+                    event_name = line[len("event: "):]
+                elif line.startswith("data: "):
+                    payload = line[len("data: "):]
+                    _render_skill_event(event_name, payload, _json)
+    except httpx.HTTPError as exc:
+        println("class:err", f"  request gagal: {fmt_http_error(exc)}")
+
+
+def _render_skill_event(event_name: str, payload_str: str, json_mod: Any) -> None:
+    try:
+        payload = json_mod.loads(payload_str) if payload_str else {}
+    except Exception:
+        payload = {}
+    if event_name == "skill_started":
+        n = payload.get("step_count", "?")
+        println("class:section", f"  ▶ skill '{payload.get('skill_name')}' ({n} steps)")
+    elif event_name == "step_started":
+        println(
+            "class:cmd.name",
+            f"  → step '{payload.get('step_name')}' (role={payload.get('role')}, agent={payload.get('agent')})",
+        )
+    elif event_name == "step_chunk":
+        text = payload.get("text", "")
+        if text:
+            println("class:dim", "    " + text.rstrip())
+    elif event_name == "step_done":
+        summary = payload.get("summary", "")
+        println("class:ok", f"  ✓ step done{(' — ' + summary) if summary else ''}")
+    elif event_name == "step_failed":
+        println("class:err", f"  ✗ step failed: {payload.get('reason', '')}")
+    elif event_name == "skill_completed":
+        println("class:ok", "  ✓✓ skill completed")
+    elif event_name == "skill_failed":
+        println("class:err", f"  ✗✗ skill failed: {payload.get('reason', '')}")

--- a/app/tui/_runner.py
+++ b/app/tui/_runner.py
@@ -33,6 +33,7 @@ from app.tui._commands import (
     cmd_me,
     cmd_pair_telegram,
     cmd_shell,
+    cmd_skill,
     cmd_status,
     cmd_users,
     parse_command,
@@ -332,6 +333,8 @@ async def _dispatch(
         "logs":           lambda: cmd_logs(args),
         "shell":          cmd_shell,
         "zsh":            cmd_shell,
+        "skill":          lambda: cmd_skill(args),
+        "skills":         lambda: cmd_skill(args),
     }
     handler = handlers.get(cmd)
     if handler is None:

--- a/tests/interfaces/test_skills_endpoints.py
+++ b/tests/interfaces/test_skills_endpoints.py
@@ -1,0 +1,134 @@
+"""Unit tests untuk helper di ``app.interfaces.skills``.
+
+Project belum punya FastAPI TestClient infra global, jadi test fokus ke
+helper layer yang kompleks: auth resolver + serializer + SSE formatter.
+Endpoint logic CRUD (yang cuma forward ke repository) sudah ditest di
+``tests/adapters/test_skill_repository.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.interfaces.skills import (
+    _format_sse,
+    _resolve_user_id,
+    _skill_to_response,
+)
+from app.orchestrator.skill_executor import SkillEvent
+
+# ── _resolve_user_id ─────────────────────────────────────────────────────────
+
+
+def test_resolve_user_id_raises_401_without_bearer() -> None:
+    with pytest.raises(HTTPException) as exc:
+        _resolve_user_id(None)
+    assert exc.value.status_code == 401
+    assert "Missing Bearer token" in str(exc.value.detail)
+
+
+def test_resolve_user_id_raises_401_on_malformed_header() -> None:
+    with pytest.raises(HTTPException) as exc:
+        _resolve_user_id("Basic abc123")
+    assert exc.value.status_code == 401
+
+
+def test_resolve_user_id_raises_401_on_unknown_session_token() -> None:
+    fake_repo = MagicMock()
+    fake_repo.resolve.return_value = None
+    with (
+        patch("app.interfaces.skills.UserSessionRepository", return_value=fake_repo),
+        patch("app.interfaces.skills._session_factory", return_value=MagicMock()),
+        pytest.raises(HTTPException) as exc,
+    ):
+        _resolve_user_id("Bearer not-a-real-token")
+    assert exc.value.status_code == 401
+    assert "invalid or expired" in str(exc.value.detail)
+
+
+def test_resolve_user_id_returns_user_id_on_valid_session() -> None:
+    fake_info = MagicMock(user_id="user-42")
+    fake_repo = MagicMock()
+    fake_repo.resolve.return_value = fake_info
+    with (
+        patch("app.interfaces.skills.UserSessionRepository", return_value=fake_repo),
+        patch("app.interfaces.skills._session_factory", return_value=MagicMock()),
+    ):
+        assert _resolve_user_id("Bearer good-token") == "user-42"
+    fake_repo.resolve.assert_called_once_with("good-token")
+
+
+# ── _skill_to_response ───────────────────────────────────────────────────────
+
+
+def test_skill_to_response_serializes_timestamps() -> None:
+    row = MagicMock()
+    row.id = "skill-1"
+    row.project_id = "proj-1"
+    row.name = "test"
+    row.description = "desc"
+    row.definition = {"name": "test", "steps": []}
+    row.created_at = datetime(2026, 5, 18, 12, 0, 0, tzinfo=UTC)
+    row.updated_at = datetime(2026, 5, 18, 13, 30, 0, tzinfo=UTC)
+
+    out = _skill_to_response(row)
+    assert out["id"] == "skill-1"
+    assert out["project_id"] == "proj-1"
+    assert out["name"] == "test"
+    assert out["description"] == "desc"
+    assert out["definition"] == {"name": "test", "steps": []}
+    assert out["created_at"] == "2026-05-18T12:00:00+00:00"
+    assert out["updated_at"] == "2026-05-18T13:30:00+00:00"
+
+
+def test_skill_to_response_handles_none_timestamps() -> None:
+    row = MagicMock()
+    row.id = "s"
+    row.project_id = "p"
+    row.name = "n"
+    row.description = ""
+    row.definition = {}
+    row.created_at = None
+    row.updated_at = None
+    out = _skill_to_response(row)
+    assert out["created_at"] is None
+    assert out["updated_at"] is None
+
+
+# ── _format_sse ──────────────────────────────────────────────────────────────
+
+
+def test_format_sse_emits_event_and_data_lines() -> None:
+    ev = SkillEvent("step_started", {"step_name": "design", "agent": "glm"})
+    out = _format_sse(ev)
+    lines = out.strip().split("\n")
+    assert lines[0] == "event: step_started"
+    assert lines[1].startswith("data: ")
+    payload = json.loads(lines[1][len("data: "):])
+    assert payload == {"step_name": "design", "agent": "glm"}
+    # Two trailing newlines for SSE event separator
+    assert out.endswith("\n\n")
+
+
+def test_format_sse_empty_payload_still_valid() -> None:
+    ev = SkillEvent("skill_started")
+    out = _format_sse(ev)
+    assert "event: skill_started" in out
+    assert "data: {}" in out
+
+
+def test_format_sse_payload_is_valid_json() -> None:
+    """SSE consumers (TUI _skill_run, browser EventSource) butuh data:
+    valid JSON yang bisa di-parse."""
+    ev = SkillEvent("step_chunk", {"step_name": "x", "text": "line with \"quotes\" and\nnewline"})
+    out = _format_sse(ev)
+    data_line = next(
+        line for line in out.split("\n") if line.startswith("data: ")
+    )
+    parsed = json.loads(data_line[len("data: "):])
+    assert parsed["text"] == 'line with "quotes" and\nnewline'


### PR DESCRIPTION
Bagian 3/3 Skill subsystem. Wrap schema/storage (PR #33) + executor (PR #34) dengan interface user.

## Apa
**HTTP API** (``app/interfaces/skills.py``, prefix ``/skills``, Bearer session token):
- ``GET /skills?project_id=...`` — list per project
- ``POST /skills`` — create (validate via ``parse_skill`` dulu)
- ``GET /skills/{id}`` — fetch
- ``PUT /skills/{id}`` — update (re-validate, reject rename collision)
- ``DELETE /skills/{id}`` — hapus
- ``POST /skills/validate`` — dry-run schema check
- ``POST /skills/{id}/run`` — execute via ``SkillExecutor``, stream SSE

Error mapping: SkillValidationError→400, DatabaseConflictError→409, not found→404, no/bad Bearer→401.
Router mounted di ``gateway.py``.

**TUI commands** (``/skill`` di TUI):
- ``/skill <project_id>`` — list
- ``/skill show <skill_id>`` — pretty-print JSON
- ``/skill rm <skill_id>`` — delete
- ``/skill load <project_id> <path>`` — read JSON file → POST create
- ``/skill run <skill_id> <prompt...>`` — stream events ke output (colored)

**Tests**: 9 unit test untuk auth resolver, serializer, SSE formatter. Endpoint CRUD logic (thin wrappers) sudah dicover di repository tests.

## Test plan
- [ ] pytest hijau
- [ ] Manual: load skill JSON via ``/skill load``, run via ``/skill run`` di TUI

Refs: issue #26