### PR TITLE
feat(rag): wire recall+index into worker dispatch + composition factories

### DIFF
--- a/app/composition.py
+++ b/app/composition.py
@@ -19,6 +19,7 @@ from app.adapters.database.session import (
     create_database_engine,
     create_session_factory,
 )
+from app.adapters.knowledge_store_memory import InMemoryKnowledgeStore
 from app.adapters.ollama import OllamaAdapter
 from app.config import settings
 from app.domain.use_cases import HandleMessageUseCase
@@ -28,6 +29,8 @@ from app.executor.loop import ExecutionLoop
 from app.intents.parser import IntentParser
 from app.orchestrator.approval import PendingPlanStore
 from app.orchestrator.plans import PlanGenerator
+from app.ports.embedder import Embedder
+from app.ports.knowledge_store import KnowledgeStore
 
 
 @lru_cache(maxsize=1)
@@ -71,6 +74,38 @@ def _execution_loop() -> ExecutionLoop:
         context_collector=_context_collector(),
         working_dir=settings.project_dir,
     )
+
+
+# ── RAG factories ────────────────────────────────────────────────────────────
+
+
+@lru_cache(maxsize=1)
+def _embedder() -> Embedder | None:
+    """Return embedder backend per ``EMBEDDER_BACKEND`` env. None = RAG disabled."""
+    if not settings.rag_enabled:
+        return None
+    backend = settings.embedder_backend
+    if backend == "none":
+        return None
+    if backend == "fastembed":
+        from app.adapters.embedder_fastembed import FastEmbedAdapter
+        return FastEmbedAdapter()
+    if backend == "ollama":
+        from app.adapters.embedder_ollama import OllamaEmbedder
+        return OllamaEmbedder(url=settings.ollama_host, model=settings.ollama_embed_model)
+    raise ValueError(f"Unknown EMBEDDER_BACKEND: {backend!r}")
+
+
+@lru_cache(maxsize=1)
+def _knowledge_store() -> KnowledgeStore:
+    """Production: PgVectorKnowledgeStore. Test/dev SQLite: InMemoryKnowledgeStore.
+
+    Dipilih berdasarkan DATABASE_URL — pgvector cuma jalan di Postgres.
+    """
+    if settings.database_url.startswith("postgresql"):
+        from app.adapters.knowledge_store_pgvector import PgVectorKnowledgeStore
+        return PgVectorKnowledgeStore(_session_factory())
+    return InMemoryKnowledgeStore()
 
 
 def build_use_case() -> HandleMessageUseCase:

--- a/app/config.py
+++ b/app/config.py
@@ -97,6 +97,12 @@ class Settings:
     instance_id: str
     telegram_bot_username: str
 
+    # ── RAG ───────────────────────────────────────────────────────────────────
+    rag_enabled: bool
+    embedder_backend: str       # "fastembed" | "ollama" | "none"
+    rag_recall_k: int
+    ollama_embed_model: str
+
 
 _DEFAULT_MANUAL_COMMANDS: frozenset[str] = frozenset({
     "docker", "git", "ls", "ps", "df", "du", "free",
@@ -190,6 +196,10 @@ def load_settings() -> Settings:
             or "backend-default"
         ),
         telegram_bot_username=os.getenv("TELEGRAM_BOT_USERNAME", "").strip(),
+        rag_enabled=_env_bool("RAG_ENABLED", default=True),
+        embedder_backend=os.getenv("EMBEDDER_BACKEND", "fastembed").strip().lower(),
+        rag_recall_k=max(1, int(os.getenv("RAG_RECALL_K", "5"))),
+        ollama_embed_model=os.getenv("OLLAMA_EMBED_MODEL", "nomic-embed-text").strip(),
     )
 
 

--- a/app/interfaces/worker_ws.py
+++ b/app/interfaces/worker_ws.py
@@ -389,13 +389,23 @@ async def dispatch_agent_job(
 
     async with sem:
         from app.adapters import agent_context, job_store
+        from app.composition import _embedder, _knowledge_store
         from app.config import settings as _settings
+        from app.orchestrator.rag import (
+            enrich_prompt_with_recall,
+            index_task_result,
+        )
 
         job_id = secrets.token_urlsafe(12)
         queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
 
         async with _pending_jobs_lock:
             _pending_jobs[job_id] = queue
+
+        # Resolve project_id untuk scoping scratchpad + RAG. Active-project
+        # per-device belum di-track di WS state — pakai user's default project
+        # sampai task itu landed. Idempotent.
+        project_id = await asyncio.to_thread(_resolve_default_project_id, user_id)
 
         # Persist job state ke Redis — survive restart, observability, multi-instance
         await job_store.create(
@@ -408,11 +418,21 @@ async def dispatch_agent_job(
         )
 
         try:
+            # RAG enrichment — prepend top-K recall hits ke prompt. No-op kalau
+            # embedder None (RAG_ENABLED=false / EMBEDDER_BACKEND=none).
+            enriched_prompt = await enrich_prompt_with_recall(
+                project_id=project_id,
+                prompt=prompt,
+                embedder=_embedder(),
+                store=_knowledge_store(),
+                k=_settings.rag_recall_k,
+            )
+
             payload: dict[str, Any] = {
                 "type": "job",
                 "job_id": job_id,
                 "agent": agent,
-                "prompt": prompt,
+                "prompt": enriched_prompt,
             }
             if extra:
                 payload["extra"] = extra
@@ -452,16 +472,27 @@ async def dispatch_agent_job(
                 elif kind == "job_done":
                     summary = str(event.get("summary", ""))
                     await job_store.update_status(job_id, "done", summary=summary)
+                    full_output = "".join(output_buf).strip()
                     if role:
-                        # TODO(issue #26 task "active project tracking"): ganti
-                        # user_id dengan project_id resolved dari device.
                         await agent_context.store_result(
-                            user_id, role,
+                            project_id, role,
                             agent=agent,
                             prompt=prompt,
-                            output="".join(output_buf).strip(),
+                            output=full_output,
                             summary=summary,
                         )
+                    # Index hasil ke RAG untuk recall di task berikutnya.
+                    # Gagal-silently di dalam helper kalau RAG off / error.
+                    await index_task_result(
+                        project_id=project_id,
+                        prompt=prompt,
+                        output=full_output,
+                        role=role or "default",
+                        agent=agent,
+                        embedder=_embedder(),
+                        store=_knowledge_store(),
+                        extra_meta={"job_id": job_id, "summary": summary},
+                    )
                     return
                 elif kind == "job_error":
                     await job_store.update_status(
@@ -471,3 +502,19 @@ async def dispatch_agent_job(
         finally:
             async with _pending_jobs_lock:
                 _pending_jobs.pop(job_id, None)
+
+
+def _resolve_default_project_id(user_id: str) -> str:
+    """Resolve project_id via default project per user (idempotent).
+
+    Sementara sampai per-device active project tracking landed di WS state.
+    """
+    from app.adapters.database.repositories import ControlPlaneRepository
+    from app.composition import _session_factory
+
+    with _session_factory()() as session:
+        repo = ControlPlaneRepository(session)
+        project = repo.get_or_create_default_project(user_id)
+        project_id = project.id
+        session.commit()
+    return project_id

--- a/app/orchestrator/rag.py
+++ b/app/orchestrator/rag.py
@@ -1,0 +1,101 @@
+"""RAG enrichment helpers — pre-dispatch recall + post-job-done indexing.
+
+Extracted from ``worker_ws`` supaya logic-nya testable tanpa WS plumbing.
+Bekerja terhadap port abstraction (``Embedder``, ``KnowledgeStore``) —
+adapter mana yang dipakai ditentukan di ``composition.py``.
+
+No-op kalau ``embedder is None`` (RAG disabled) — caller boleh memanggil
+tanpa cek, asal pass ``None`` saat RAG off.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from app.ports.embedder import Embedder
+    from app.ports.knowledge_store import KnowledgeStore
+
+logger = logging.getLogger(__name__)
+
+# Cap input text yang di-embed supaya tidak crash embedder pada hasil agent
+# yang super panjang. Cocok dengan ~1k token budget di model lightweight.
+MAX_EMBED_CHARS = 4000
+
+# Cap context block yang di-prepend ke prompt supaya tidak meledakkan token
+# budget agent target.
+MAX_RECALL_CONTEXT_CHARS = 2000
+
+
+async def enrich_prompt_with_recall(
+    *,
+    project_id: str,
+    prompt: str,
+    embedder: Embedder | None,
+    store: KnowledgeStore,
+    k: int = 5,
+) -> str:
+    """Kalau ada chunk relevant di project knowledge, prepend ke prompt.
+
+    Gagal silently — kalau embedder error atau recall error, return prompt
+    apa adanya. RAG adalah enhancement, bukan critical path.
+    """
+    if embedder is None or not prompt.strip():
+        return prompt
+    try:
+        q_emb = await asyncio.to_thread(embedder.embed, prompt[:MAX_EMBED_CHARS])
+        hits = await store.recall(project_id, q_emb, k=k)
+    except Exception as exc:
+        logger.warning("RAG recall failed: %s", exc)
+        return prompt
+    if not hits:
+        return prompt
+
+    lines = ["Konteks relevant dari project memory:"]
+    total = 0
+    for i, hit in enumerate(hits, 1):
+        text = hit.chunk.text
+        if total + len(text) > MAX_RECALL_CONTEXT_CHARS:
+            text = text[: MAX_RECALL_CONTEXT_CHARS - total]
+            lines.append(f"[{i}] (truncated) {text}…")
+            break
+        lines.append(f"[{i}] {text}")
+        total += len(text)
+    return "\n".join(lines) + "\n\n---\n\n" + prompt
+
+
+async def index_task_result(
+    *,
+    project_id: str,
+    prompt: str,
+    output: str,
+    role: str,
+    agent: str,
+    embedder: Embedder | None,
+    store: KnowledgeStore,
+    extra_meta: dict[str, Any] | None = None,
+) -> str | None:
+    """Embed output + index ke project memory untuk recall di task berikutnya.
+
+    Return chunk id kalau berhasil, None kalau RAG off atau gagal.
+    """
+    if embedder is None or not output.strip():
+        return None
+    text = output[:MAX_EMBED_CHARS]
+    try:
+        emb = await asyncio.to_thread(embedder.embed, text)
+    except Exception as exc:
+        logger.warning("RAG embed for index failed: %s", exc)
+        return None
+
+    meta: dict[str, Any] = {"role": role, "agent": agent, "prompt": prompt[:500]}
+    if extra_meta:
+        meta.update(extra_meta)
+
+    try:
+        return await store.index(project_id, output, emb, meta=meta)
+    except Exception as exc:
+        logger.warning("RAG index failed: %s", exc)
+        return None

--- a/tests/orchestrator/test_rag.py
+++ b/tests/orchestrator/test_rag.py
@@ -1,0 +1,201 @@
+"""Unit tests untuk RAG helpers (``enrich_prompt_with_recall``, ``index_task_result``)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from app.adapters.knowledge_store_memory import InMemoryKnowledgeStore
+from app.orchestrator.rag import (
+    MAX_RECALL_CONTEXT_CHARS,
+    enrich_prompt_with_recall,
+    index_task_result,
+)
+
+
+@dataclass
+class FakeEmbedder:
+    """Deterministic embedder for tests. Hash each unique text to a fixed vector."""
+
+    dim: int = 3
+
+    @property
+    def dimension(self) -> int:
+        return self.dim
+
+    def embed(self, text: str) -> list[float]:
+        # Deterministic: same text → same vector, different texts → different vectors.
+        h = hash(text) % 1000
+        return [float(h % 10), float((h // 10) % 10), float((h // 100) % 10)]
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return [self.embed(t) for t in texts]
+
+
+class ExplodingEmbedder:
+    """Embedder yang selalu raise — untuk test gagal-silently."""
+
+    dimension = 3
+
+    def embed(self, text: str) -> list[float]:
+        raise RuntimeError("embedder boom")
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        raise RuntimeError("embedder boom")
+
+
+# ── enrich_prompt_with_recall ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enrich_no_op_when_embedder_is_none() -> None:
+    store = InMemoryKnowledgeStore()
+    out = await enrich_prompt_with_recall(
+        project_id="p", prompt="halo", embedder=None, store=store, k=5,
+    )
+    assert out == "halo"
+
+
+@pytest.mark.asyncio
+async def test_enrich_no_op_when_prompt_empty() -> None:
+    embedder = FakeEmbedder()
+    store = InMemoryKnowledgeStore()
+    out = await enrich_prompt_with_recall(
+        project_id="p", prompt="   ", embedder=embedder, store=store, k=5,
+    )
+    assert out == "   "
+
+
+@pytest.mark.asyncio
+async def test_enrich_returns_prompt_when_no_hits() -> None:
+    embedder = FakeEmbedder()
+    store = InMemoryKnowledgeStore()  # empty
+    out = await enrich_prompt_with_recall(
+        project_id="p", prompt="tanya X", embedder=embedder, store=store, k=5,
+    )
+    assert out == "tanya X"
+
+
+@pytest.mark.asyncio
+async def test_enrich_prepends_recall_block() -> None:
+    embedder = FakeEmbedder()
+    store = InMemoryKnowledgeStore()
+    # Embed prompt manually, index something with the same embedding so recall finds it.
+    same_embed = embedder.embed("query text")
+    await store.index("p", "previous result A", same_embed)
+
+    out = await enrich_prompt_with_recall(
+        project_id="p", prompt="query text", embedder=embedder, store=store, k=5,
+    )
+    assert "Konteks relevant dari project memory:" in out
+    assert "previous result A" in out
+    assert out.endswith("query text")  # original prompt at the end
+
+
+@pytest.mark.asyncio
+async def test_enrich_respects_project_isolation() -> None:
+    embedder = FakeEmbedder()
+    store = InMemoryKnowledgeStore()
+    same_embed = embedder.embed("shared query")
+    await store.index("proj-A", "A-only context", same_embed)
+    await store.index("proj-B", "B-only context", same_embed)
+
+    out_a = await enrich_prompt_with_recall(
+        project_id="proj-A", prompt="shared query", embedder=embedder, store=store, k=5,
+    )
+    out_b = await enrich_prompt_with_recall(
+        project_id="proj-B", prompt="shared query", embedder=embedder, store=store, k=5,
+    )
+    assert "A-only context" in out_a and "B-only context" not in out_a
+    assert "B-only context" in out_b and "A-only context" not in out_b
+
+
+@pytest.mark.asyncio
+async def test_enrich_truncates_when_context_exceeds_cap() -> None:
+    embedder = FakeEmbedder()
+    store = InMemoryKnowledgeStore()
+    big_chunk = "X" * (MAX_RECALL_CONTEXT_CHARS + 500)
+    same_embed = embedder.embed("query")
+    await store.index("p", big_chunk, same_embed)
+
+    out = await enrich_prompt_with_recall(
+        project_id="p", prompt="query", embedder=embedder, store=store, k=5,
+    )
+    # Should contain truncation marker
+    assert "(truncated)" in out
+
+
+@pytest.mark.asyncio
+async def test_enrich_fails_silently_on_embedder_error() -> None:
+    """Embedder explodes → return original prompt, jangan raise."""
+    embedder = ExplodingEmbedder()
+    store = InMemoryKnowledgeStore()
+    out = await enrich_prompt_with_recall(
+        project_id="p", prompt="ok", embedder=embedder, store=store, k=5,
+    )
+    assert out == "ok"
+
+
+# ── index_task_result ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_index_no_op_when_embedder_none() -> None:
+    store = InMemoryKnowledgeStore()
+    result = await index_task_result(
+        project_id="p", prompt="p", output="o",
+        role="engineer", agent="codex",
+        embedder=None, store=store,
+    )
+    assert result is None
+    # store should be empty
+    assert await store.recall("p", [0.0, 0.0, 0.0]) == []
+
+
+@pytest.mark.asyncio
+async def test_index_no_op_when_output_empty() -> None:
+    embedder = FakeEmbedder()
+    store = InMemoryKnowledgeStore()
+    result = await index_task_result(
+        project_id="p", prompt="prompt", output="   ",
+        role="engineer", agent="codex",
+        embedder=embedder, store=store,
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_index_stores_chunk_with_meta() -> None:
+    embedder = FakeEmbedder()
+    store = InMemoryKnowledgeStore()
+    chunk_id = await index_task_result(
+        project_id="p", prompt="refactor X", output="here is the refactor",
+        role="engineer", agent="codex",
+        embedder=embedder, store=store,
+        extra_meta={"job_id": "job-123"},
+    )
+    assert chunk_id is not None
+
+    # Retrieve via recall to verify
+    same_embed = embedder.embed("here is the refactor")
+    hits = await store.recall("p", same_embed, k=1)
+    assert len(hits) == 1
+    assert hits[0].chunk.text == "here is the refactor"
+    meta = hits[0].chunk.meta
+    assert meta["role"] == "engineer"
+    assert meta["agent"] == "codex"
+    assert meta["prompt"] == "refactor X"
+    assert meta["job_id"] == "job-123"
+
+
+@pytest.mark.asyncio
+async def test_index_silently_returns_none_on_embedder_failure() -> None:
+    embedder = ExplodingEmbedder()
+    store = InMemoryKnowledgeStore()
+    result = await index_task_result(
+        project_id="p", prompt="p", output="o",
+        role="engineer", agent="codex",
+        embedder=embedder, store=store,
+    )
+    assert result is None

--- a/tests/test_composition_rag.py
+++ b/tests/test_composition_rag.py
@@ -1,0 +1,94 @@
+"""Tests untuk composition factory RAG — pilih embedder + store sesuai env."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from app.adapters.embedder_fastembed import FastEmbedAdapter
+from app.adapters.embedder_ollama import OllamaEmbedder
+from app.adapters.knowledge_store_memory import InMemoryKnowledgeStore
+
+
+@pytest.fixture(autouse=True)
+def _clear_lru_cache_and_reload(monkeypatch: pytest.MonkeyPatch):
+    """Reset lru_cache di composition + reload settings setiap test."""
+    yield
+    import app.composition as comp
+    import app.config as cfg
+    comp._embedder.cache_clear()
+    comp._knowledge_store.cache_clear()
+    cfg.settings = cfg.load_settings()
+
+
+def _reload_settings(monkeypatch: pytest.MonkeyPatch, **env: str) -> None:
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    import app.composition as comp
+    import app.config as cfg
+    comp._embedder.cache_clear()
+    comp._knowledge_store.cache_clear()
+    importlib.reload(cfg)
+    importlib.reload(comp)
+
+
+# ── _embedder ────────────────────────────────────────────────────────────────
+
+
+def test_embedder_default_is_fastembed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EMBEDDER_BACKEND", raising=False)
+    monkeypatch.delenv("RAG_ENABLED", raising=False)
+    _reload_settings(monkeypatch)
+    from app.composition import _embedder
+    e = _embedder()
+    assert isinstance(e, FastEmbedAdapter)
+
+
+def test_embedder_returns_none_when_rag_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_settings(monkeypatch, RAG_ENABLED="false")
+    from app.composition import _embedder
+    assert _embedder() is None
+
+
+def test_embedder_returns_none_when_backend_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_settings(monkeypatch, EMBEDDER_BACKEND="none")
+    from app.composition import _embedder
+    assert _embedder() is None
+
+
+def test_embedder_ollama_when_backend_ollama(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_settings(monkeypatch, EMBEDDER_BACKEND="ollama")
+    from app.composition import _embedder
+    e = _embedder()
+    assert isinstance(e, OllamaEmbedder)
+
+
+def test_embedder_raises_on_unknown_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_settings(monkeypatch, EMBEDDER_BACKEND="brain-soup")
+    from app.composition import _embedder
+    with pytest.raises(ValueError, match="EMBEDDER_BACKEND"):
+        _embedder()
+
+
+# ── _knowledge_store ─────────────────────────────────────────────────────────
+
+
+def test_knowledge_store_sqlite_default_to_in_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test/dev SQLite tidak support pgvector — fallback ke in-memory."""
+    _reload_settings(monkeypatch, DATABASE_URL="sqlite:///:memory:")
+    from app.composition import _knowledge_store
+    assert isinstance(_knowledge_store(), InMemoryKnowledgeStore)
+
+
+def test_knowledge_store_uses_pgvector_when_postgres_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Production URL → PgVectorKnowledgeStore (tanpa actually konek DB)."""
+    _reload_settings(
+        monkeypatch,
+        DATABASE_URL="postgresql://x:y@h:5432/d",
+    )
+    from app.adapters.knowledge_store_pgvector import PgVectorKnowledgeStore
+    from app.composition import _knowledge_store
+    assert isinstance(_knowledge_store(), PgVectorKnowledgeStore)


### PR DESCRIPTION
Bagian 3/3 RAG. Menutup loop "agent jalan → tulis ke project memory → recall di task berikutnya".

## Apa
**Composition** (``app/composition.py``):
- ``_embedder()`` — pilih FastEmbed (default) atau Ollama berdasar ``EMBEDDER_BACKEND``, return None kalau RAG disabled
- ``_knowledge_store()`` — PgVectorKnowledgeStore untuk Postgres, InMemoryKnowledgeStore untuk SQLite/test

**Config knobs** (``app/config.py``):
- ``RAG_ENABLED`` (default ``true``), ``EMBEDDER_BACKEND`` (default ``fastembed``), ``RAG_RECALL_K`` (default 5), ``OLLAMA_EMBED_MODEL``

**Orchestrator helpers** (``app/orchestrator/rag.py``):
- ``enrich_prompt_with_recall`` — embed prompt → recall top-K → prepend block. Cap 2KB. No-op kalau embedder None.
- ``index_task_result`` — embed output → simpan ke store. Gagal-silently (RAG = enhancement, bukan critical path).

**Wire-up** (``worker_ws.dispatch_agent_job``):
- Resolve ``project_id`` via ``get_or_create_default_project(user_id)`` — sekalian tutup TODO dari PR active-project
- Sebelum kirim ke worker: enrich prompt
- Setelah ``job_done``: index hasil ke RAG (paralel dengan scratchpad write yang sudah ada)

**Tests**: 18 baru — RAG helpers (no-op kondisi, prepend, isolasi project, truncation, gagal-silently, index round-trip dengan meta) + composition factory selection per env var.

## Test plan
- [ ] pytest hijau
- [ ] Manual: jalankan 2 task di project yang sama, verify recall hit kedua kalinya

Refs: issue #26