### PR TITLE
refactor(domain): fix dependency leak in use_cases.py via ports

### DIFF
--- a/app/adapters/agent_role_resolver.py
+++ b/app/adapters/agent_role_resolver.py
@@ -1,0 +1,19 @@
+"""SqlAgentRoleResolver — resolve (user_id, role) → agent CLI name via DB."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from app.adapters.agent_configs import UserAgentConfigRepository
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import sessionmaker
+
+
+@dataclass
+class SqlAgentRoleResolver:
+    _factory: sessionmaker[Any]
+
+    def agent_for_role(self, user_id: str, role: str) -> str | None:
+        return UserAgentConfigRepository(self._factory).agent_for_role(user_id, role)

--- a/app/adapters/handoff_context.py
+++ b/app/adapters/handoff_context.py
@@ -1,0 +1,41 @@
+"""RedisHandoffContextProvider — prepend prior role's last output to a prompt."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+from typing import Any
+
+from app.adapters.agent_context import build_handoff_prefix, fetch_role
+
+# Roles that inherit context from a prior role. Reviewer and architect typically
+# consume the engineer's most recent output as additional context.
+_HANDOFF_FROM: dict[str, str] = {
+    "reviewer":  "engineer",
+    "architect": "engineer",
+}
+
+
+class RedisHandoffContextProvider:
+    def prepend_context(self, project_id: str, role: str, prompt: str) -> str:
+        prev_role = _HANDOFF_FROM.get(role)
+        if not prev_role:
+            return prompt
+
+        def _run() -> dict[str, Any] | None:
+            # Fresh event loop in a dedicated thread — safe regardless of outer loop state.
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(fetch_role(project_id, prev_role))
+            finally:
+                loop.close()
+
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                prev = pool.submit(_run).result(timeout=5)
+        except Exception:
+            return prompt
+
+        if not prev:
+            return prompt
+        return build_handoff_prefix(prev, role) + prompt

--- a/app/composition.py
+++ b/app/composition.py
@@ -14,11 +14,13 @@ if TYPE_CHECKING:
     from sqlalchemy import Engine
     from sqlalchemy.orm import sessionmaker
 
+from app.adapters.agent_role_resolver import SqlAgentRoleResolver
 from app.adapters.chat_history import SqlAlchemyChatHistory
 from app.adapters.database.session import (
     create_database_engine,
     create_session_factory,
 )
+from app.adapters.handoff_context import RedisHandoffContextProvider
 from app.adapters.knowledge_store_memory import InMemoryKnowledgeStore
 from app.adapters.ollama import OllamaAdapter
 from app.config import settings
@@ -120,4 +122,6 @@ def build_use_case() -> HandleMessageUseCase:
         history=SqlAlchemyChatHistory(_session_factory()),
         history_limit=settings.chat_history_limit,
         execution_loop=_execution_loop(),
+        agent_resolver=SqlAgentRoleResolver(_session_factory()),
+        handoff_provider=RedisHandoffContextProvider(),
     )

--- a/app/domain/use_cases.py
+++ b/app/domain/use_cases.py
@@ -24,6 +24,7 @@ from app.intents.parser import IntentParser
 from app.intents.schemas import EXECUTABLE_ACTIONS, Intent
 from app.orchestrator.approval import PendingPlanStore
 from app.orchestrator.plans import PlanGenerator
+from app.ports.agents import AgentRoleResolver, HandoffContextProvider
 from app.ports.ai_provider import AIProvider
 from app.ports.chat_history import ChatHistoryStore
 from app.ports.execution_loop import ExecutionLoopPort
@@ -142,6 +143,9 @@ class HandleMessageUseCase:
     history_limit: int = 6
     # Optional: when provided, complex requests are routed through the agentic loop.
     execution_loop: ExecutionLoopPort | None = field(default=None)
+    # Injected via composition.py — None disables agent delegation entirely.
+    agent_resolver: AgentRoleResolver | None = field(default=None)
+    handoff_provider: HandoffContextProvider | None = field(default=None)
 
     def handle(self, text: str, ctx: MessageContext) -> Iterator[ChatEvent]:
         """Pure synchronous generator — adapter layer adapts ke async kalau perlu."""
@@ -167,8 +171,13 @@ class HandleMessageUseCase:
         # yang ngerelay ke worker user via WS dispatcher. Use case cuma kasih
         # mapping intent → agent CLI + prompt yang udah dibersihin.
         if intent.is_agent():
-            agent_name = _agent_for_intent(intent.intent, ctx.user_id)
             role = _role_for_intent(intent.intent)
+            if self.agent_resolver is None:
+                yield ChatEvent.error(
+                    f"Agent resolver tidak tersedia untuk role '{role}'."
+                )
+                return
+            agent_name = self.agent_resolver.agent_for_role(ctx.user_id, role)
             if agent_name is None:
                 yield ChatEvent.error(
                     f"Belum ada agent yang assigned untuk role '{role}'. "
@@ -176,9 +185,10 @@ class HandleMessageUseCase:
                 )
                 return
             cleaned = _strip_command_prefix(text)
-            # Hand-off antar role: kalau ini reviewer/architect, ambil output
-            # role sebelumnya (engineer hasil terakhir) sebagai context tambahan.
-            cleaned = _maybe_prepend_handoff(ctx.project_id, role, cleaned)
+            if self.handoff_provider is not None:
+                cleaned = self.handoff_provider.prepend_context(
+                    ctx.project_id, role, cleaned
+                )
             yield ChatEvent.delegate_to_agent(
                 agent=agent_name,
                 prompt=cleaned,
@@ -346,25 +356,6 @@ def _role_for_intent(intent_name: str) -> str:
     return _INTENT_TO_ROLE.get(intent_name, "engineer")
 
 
-def _agent_for_intent(intent_name: str, user_id: str) -> str | None:
-    """Resolve intent → CLI agent name dari config DB per-user.
-
-    Cari agent yang ``enabled=True`` dan ``role`` cocok. Return None kalau user
-    belum config agent untuk role tersebut.
-    """
-    from app.adapters.agent_configs import UserAgentConfigRepository
-    from app.adapters.database.session import (
-        create_database_engine,
-        create_session_factory,
-    )
-    from app.config import settings as _settings
-
-    role = _role_for_intent(intent_name)
-    factory = create_session_factory(create_database_engine(_settings.database_url))
-    repo = UserAgentConfigRepository(factory)
-    return repo.agent_for_role(user_id, role)
-
-
 def _strip_command_prefix(text: str) -> str:
     """Buang prefix ``/code``, ``/review``, ``/architect``, ``/refactor`` kalau ada."""
     text = text.strip()
@@ -377,39 +368,3 @@ def _strip_command_prefix(text: str) -> str:
     return text
 
 
-# Mapping role yang inherit context dari role sebelumnya. Reviewer biasanya
-# review output engineer; architect bisa pakai output engineer juga.
-_HANDOFF_FROM: dict[str, str] = {
-    "reviewer":  "engineer",
-    "architect": "engineer",
-}
-
-
-def _maybe_prepend_handoff(project_id: str, current_role: str, prompt: str) -> str:
-    """Kalau current_role punya hand-off mapping, prepend hasil role sebelumnya."""
-    prev_role = _HANDOFF_FROM.get(current_role)
-    if not prev_role:
-        return prompt
-
-    import asyncio
-    import concurrent.futures
-
-    from app.adapters.agent_context import build_handoff_prefix, fetch_role
-
-    def _run() -> dict[str, Any] | None:
-        # New event loop in dedicated thread — safe regardless of outer loop state.
-        loop = asyncio.new_event_loop()
-        try:
-            return loop.run_until_complete(fetch_role(project_id, prev_role))
-        finally:
-            loop.close()
-
-    try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            prev = pool.submit(_run).result(timeout=5)
-    except Exception:
-        return prompt
-
-    if not prev:
-        return prompt
-    return build_handoff_prefix(prev, current_role) + prompt

--- a/app/ports/agents.py
+++ b/app/ports/agents.py
@@ -6,3 +6,15 @@ from app.domain.agents import AgentCapability
 
 class AgentDiscoveryPort(Protocol):
     def discover(self) -> Sequence[AgentCapability]: ...
+
+
+class AgentRoleResolver(Protocol):
+    """Resolve (user_id, role) → agent CLI name from persistent config."""
+
+    def agent_for_role(self, user_id: str, role: str) -> str | None: ...
+
+
+class HandoffContextProvider(Protocol):
+    """Prepend the prior role's last output to the current prompt, if any."""
+
+    def prepend_context(self, project_id: str, role: str, prompt: str) -> str: ...

--- a/tests/domain/test_use_cases.py
+++ b/tests/domain/test_use_cases.py
@@ -1,0 +1,106 @@
+"""Unit tests HandleMessageUseCase — domain layer, zero adapter imports."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from app.domain.messaging import MessageContext
+from app.domain.use_cases import HandleMessageUseCase
+from app.intents.schemas import Intent
+
+
+def _make_ctx(user_id: str = "u1", project_id: str = "p1") -> MessageContext:
+    return MessageContext(
+        user_id=user_id,
+        conversation_id="chat-1",
+        project_id=project_id,
+        project_root=Path("/workspace"),
+        project_name="test-project",
+    )
+
+
+def _make_intent(intent: str = "agent_code", confidence: float = 0.95) -> Intent:
+    return Intent(
+        intent=intent,
+        project_id="p1",
+        confidence=confidence,
+        requires_approval=False,
+        parameters={},
+        reason="test",
+    )
+
+
+def _make_use_case(**overrides: Any) -> HandleMessageUseCase:
+    defaults: dict[str, Any] = {
+        "ai": MagicMock(),
+        "intent_parser": MagicMock(),
+        "plan_generator": MagicMock(),
+        "action_registry": MagicMock(),
+        "pending_plans": MagicMock(),
+        "history": MagicMock(),
+    }
+    defaults.update(overrides)
+    return HandleMessageUseCase(**defaults)
+
+
+def test_agent_delegation_yields_error_when_no_resolver() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("agent_code")
+
+    uc = _make_use_case(intent_parser=intent_parser, agent_resolver=None)
+    events = list(uc.handle("refactor kode X", _make_ctx()))
+
+    types = [e.type for e in events]
+    assert "error" in types
+
+
+def test_agent_delegation_yields_error_when_no_agent_configured() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("agent_code")
+
+    resolver = MagicMock()
+    resolver.agent_for_role.return_value = None
+
+    uc = _make_use_case(intent_parser=intent_parser, agent_resolver=resolver)
+    events = list(uc.handle("refactor kode X", _make_ctx()))
+
+    types = [e.type for e in events]
+    assert "error" in types
+
+
+def test_agent_delegation_yields_delegate_event() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("agent_code")
+
+    resolver = MagicMock()
+    resolver.agent_for_role.return_value = "codex"
+
+    uc = _make_use_case(intent_parser=intent_parser, agent_resolver=resolver)
+    events = list(uc.handle("refactor kode X", _make_ctx()))
+
+    types = [e.type for e in events]
+    assert "delegate_to_agent" in types
+
+
+def test_agent_delegation_uses_handoff_provider_when_present() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("agent_review")
+
+    resolver = MagicMock()
+    resolver.agent_for_role.return_value = "claude"
+
+    handoff = MagicMock()
+    handoff.prepend_context.return_value = "[HANDOFF]\nreview kode X"
+
+    uc = _make_use_case(
+        intent_parser=intent_parser,
+        agent_resolver=resolver,
+        handoff_provider=handoff,
+    )
+    events = list(uc.handle("review kode X", _make_ctx()))
+
+    handoff.prepend_context.assert_called_once()
+    delegate_events = [e for e in events if e.type == "delegate_to_agent"]
+    assert delegate_events
+    assert "[HANDOFF]" in delegate_events[0].payload["prompt"]


### PR DESCRIPTION
## Summary
Closes #15

`HandleMessageUseCase` di `app/domain/use_cases.py` melanggar Hexagonal rule — `_agent_for_intent()` dan `_maybe_prepend_handoff()` import langsung dari `app.adapters.*` + `app.config`. Composition root yang seharusnya inject, bukan domain.

## Changes
- **`app/ports/agents.py`** — tambah `AgentRoleResolver` + `HandoffContextProvider` Protocol.
- **`app/domain/use_cases.py`** — `HandleMessageUseCase` terima keduanya via constructor (Optional, default `None`). Helper `_agent_for_intent` & `_maybe_prepend_handoff` dihapus.
- **`app/adapters/agent_role_resolver.py`** (new) — `SqlAgentRoleResolver` implements `AgentRoleResolver` via `UserAgentConfigRepository`.
- **`app/adapters/handoff_context.py`** (new) — `RedisHandoffContextProvider` implements `HandoffContextProvider`, pakai `fetch_role` + `build_handoff_prefix` dari `agent_context`.
- **`app/composition.py`** — inject dua adapter baru di `build_use_case()`.
- **`tests/domain/test_use_cases.py`** (new) — 4 unit test agent delegation path tanpa adapter import.

## Verification
- `grep -rn "from app.adapters\|from app.config" app/domain/` → empty ✓
- `make check` (ruff + mypy + pytest 428 tests) → all green ✓

## Test plan
- [x] `pytest tests/domain/test_use_cases.py -v` → 4/4 passed
- [x] `ruff check app/ tests/` → clean
- [x] `mypy app/` → 108 files, no issues
- [x] Full `pytest tests/` → 428 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)