### PR TITLE
test: add unit tests for HandleMessageUseCase and IntentParser

### DIFF
--- a/tests/domain/test_use_cases.py
+++ b/tests/domain/test_use_cases.py
@@ -5,9 +5,14 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-from app.domain.messaging import MessageContext
+from app.domain.exceptions import (
+    ActionExecutionError,
+    AIProviderError,
+    IntentParseError,
+)
+from app.domain.messaging import ChatEventType, MessageContext
 from app.domain.use_cases import HandleMessageUseCase
-from app.intents.schemas import Intent
+from app.intents.schemas import ExecutionPlan, Intent, PlanStep
 
 
 def _make_ctx(user_id: str = "u1", project_id: str = "p1") -> MessageContext:
@@ -104,3 +109,382 @@ def test_agent_delegation_uses_handoff_provider_when_present() -> None:
     delegate_events = [e for e in events if e.type == "delegate_to_agent"]
     assert delegate_events
     assert "[HANDOFF]" in delegate_events[0].payload["prompt"]
+
+
+# ── Entry-point guard rails ───────────────────────────────────────────────────
+
+
+def test_empty_text_yields_no_events() -> None:
+    uc = _make_use_case()
+    events = list(uc.handle("   ", _make_ctx()))
+    assert events == []
+
+
+def test_intent_parse_error_yields_error_event() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.side_effect = IntentParseError("boom")
+
+    uc = _make_use_case(intent_parser=intent_parser)
+    events = list(uc.handle("apa kabar", _make_ctx()))
+
+    assert len(events) == 1
+    assert events[0].type == ChatEventType.ERROR
+    assert "boom" in events[0].payload["message"]
+
+
+# ── Chat path ────────────────────────────────────────────────────────────────
+
+
+def test_chat_intent_streams_chunks_and_final() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("chat", confidence=1.0)
+
+    ai = MagicMock()
+    ai.chat_stream.return_value = iter(["hai ", "halo ", "user"])
+
+    history = MagicMock()
+    history.recent.return_value = []
+
+    uc = _make_use_case(intent_parser=intent_parser, ai=ai, history=history)
+    events = list(uc.handle("halo", _make_ctx()))
+
+    types = [e.type for e in events]
+    assert ChatEventType.INTENT_CLASSIFIED in types
+    chunk_events = [e for e in events if e.type == ChatEventType.TEXT_CHUNK]
+    final_events = [e for e in events if e.type == ChatEventType.FINAL]
+    assert [e.payload["text"] for e in chunk_events] == ["hai ", "halo ", "user"]
+    assert final_events
+    assert final_events[0].payload["text"] == "hai halo user"
+    # user + assistant masing-masing satu kali → 2 append
+    assert history.append.call_count == 2
+
+
+def test_chat_intent_skips_empty_chunks() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("chat", confidence=1.0)
+
+    ai = MagicMock()
+    ai.chat_stream.return_value = iter(["", "data", ""])
+
+    history = MagicMock()
+    history.recent.return_value = []
+
+    uc = _make_use_case(intent_parser=intent_parser, ai=ai, history=history)
+    events = list(uc.handle("hi", _make_ctx()))
+
+    chunk_events = [e for e in events if e.type == ChatEventType.TEXT_CHUNK]
+    assert [e.payload["text"] for e in chunk_events] == ["data"]
+
+
+def test_chat_intent_ai_provider_error_yields_error_event() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("chat", confidence=1.0)
+
+    ai = MagicMock()
+    ai.chat_stream.side_effect = AIProviderError("network down")
+
+    history = MagicMock()
+    history.recent.return_value = []
+
+    uc = _make_use_case(intent_parser=intent_parser, ai=ai, history=history)
+    events = list(uc.handle("halo", _make_ctx()))
+
+    error_events = [e for e in events if e.type == ChatEventType.ERROR]
+    assert error_events
+    assert "network down" in error_events[0].payload["message"]
+
+
+def test_unknown_intent_routes_to_chat_when_no_execution_loop() -> None:
+    """Unknown intent + no execution_loop → still goes through chat path."""
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("unknown", confidence=0.0)
+
+    ai = MagicMock()
+    ai.chat_stream.return_value = iter(["maaf"])
+
+    history = MagicMock()
+    history.recent.return_value = []
+
+    uc = _make_use_case(intent_parser=intent_parser, ai=ai, history=history)
+    events = list(uc.handle("buka kulkas", _make_ctx()))
+
+    final_events = [e for e in events if e.type == ChatEventType.FINAL]
+    assert final_events
+    assert final_events[0].payload["text"] == "maaf"
+
+
+# ── Action path (simple, no approval) ─────────────────────────────────────────
+
+
+def _make_plan(intent: Intent, requires_approval: bool = False) -> ExecutionPlan:
+    return ExecutionPlan(
+        plan_id="plan-1",
+        summary="test plan",
+        steps=[PlanStep.from_intent(intent)],
+        requires_approval=requires_approval,
+        project_id=intent.project_id,
+        intent=intent.intent,
+    )
+
+
+def test_action_intent_without_approval_yields_started_result_final() -> None:
+    intent = _make_intent("memory", confidence=0.95)
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = intent
+
+    plan_generator = MagicMock()
+    plan_generator.generate.return_value = _make_plan(intent, requires_approval=False)
+
+    action_registry = MagicMock()
+    action_registry.execute.return_value = "MemTotal: 16Gi, used: 8Gi"
+
+    ai = MagicMock()
+    ai.chat.return_value = "RAM 50% terpakai"
+
+    uc = _make_use_case(
+        intent_parser=intent_parser,
+        plan_generator=plan_generator,
+        action_registry=action_registry,
+        ai=ai,
+    )
+    events = list(uc.handle("cek ram", _make_ctx()))
+
+    types = [e.type for e in events]
+    assert ChatEventType.ACTION_STARTED in types
+    assert ChatEventType.ACTION_RESULT in types
+    final = [e for e in events if e.type == ChatEventType.FINAL]
+    assert final
+    assert "memory" in final[0].payload["text"]
+    assert "RAM 50% terpakai" in final[0].payload["text"]
+
+
+def test_action_intent_whoami_skips_ai_summary() -> None:
+    intent = _make_intent("whoami", confidence=0.95)
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = intent
+
+    plan_generator = MagicMock()
+    plan_generator.generate.return_value = _make_plan(intent)
+
+    action_registry = MagicMock()
+    action_registry.execute.return_value = "user@host /workspace"
+
+    ai = MagicMock()
+
+    uc = _make_use_case(
+        intent_parser=intent_parser,
+        plan_generator=plan_generator,
+        action_registry=action_registry,
+        ai=ai,
+    )
+    events = list(uc.handle("whoami", _make_ctx()))
+
+    ai.chat.assert_not_called()
+    final = [e for e in events if e.type == ChatEventType.FINAL]
+    assert final[0].payload["text"] == "user@host /workspace"
+
+
+def test_action_intent_ai_summary_failure_falls_back_to_raw_output() -> None:
+    intent = _make_intent("memory", confidence=0.95)
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = intent
+
+    plan_generator = MagicMock()
+    plan_generator.generate.return_value = _make_plan(intent)
+
+    action_registry = MagicMock()
+    action_registry.execute.return_value = "RAW MEM 8G/16G"
+
+    ai = MagicMock()
+    ai.chat.side_effect = AIProviderError("ollama down")
+
+    uc = _make_use_case(
+        intent_parser=intent_parser,
+        plan_generator=plan_generator,
+        action_registry=action_registry,
+        ai=ai,
+    )
+    events = list(uc.handle("cek ram", _make_ctx()))
+
+    final = [e for e in events if e.type == ChatEventType.FINAL]
+    assert final
+    assert "RAW MEM 8G/16G" in final[0].payload["text"]
+
+
+def test_action_intent_execution_error_yields_error_event() -> None:
+    intent = _make_intent("disk", confidence=0.95)
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = intent
+
+    plan_generator = MagicMock()
+    plan_generator.generate.return_value = _make_plan(intent)
+
+    action_registry = MagicMock()
+    action_registry.execute.side_effect = ActionExecutionError("df failed")
+
+    uc = _make_use_case(
+        intent_parser=intent_parser,
+        plan_generator=plan_generator,
+        action_registry=action_registry,
+    )
+    events = list(uc.handle("cek disk", _make_ctx()))
+
+    error_events = [e for e in events if e.type == ChatEventType.ERROR]
+    assert error_events
+    assert "df failed" in error_events[0].payload["message"]
+    # No FINAL once execution fails.
+    assert not [e for e in events if e.type == ChatEventType.FINAL]
+
+
+# ── Action path (approval required) ───────────────────────────────────────────
+
+
+def test_action_requiring_approval_yields_approval_event_and_saves_plan() -> None:
+    intent = _make_intent("docker_restart", confidence=0.9)
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = intent
+
+    plan = _make_plan(intent, requires_approval=True)
+    plan_generator = MagicMock()
+    plan_generator.generate.return_value = plan
+
+    pending = MagicMock()
+    action_registry = MagicMock()
+
+    uc = _make_use_case(
+        intent_parser=intent_parser,
+        plan_generator=plan_generator,
+        pending_plans=pending,
+        action_registry=action_registry,
+    )
+    events = list(uc.handle("docker restart web", _make_ctx()))
+
+    approval_events = [e for e in events if e.type == ChatEventType.APPROVAL_REQUIRED]
+    assert approval_events
+    assert approval_events[0].payload["plan_id"] == "plan-1"
+    pending.save.assert_called_once()
+    # Action must NOT execute once approval is needed.
+    action_registry.execute.assert_not_called()
+
+
+# ── Action path (intent recognized but no handler) ────────────────────────────
+
+
+def test_action_intent_unknown_handler_yields_final_with_belum_ada_handler() -> None:
+    # 'deploy' is action-y but NOT in EXECUTABLE_ACTIONS — must hit fallback.
+    intent = _make_intent("deploy", confidence=0.9)
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = intent
+
+    plan_generator = MagicMock()
+    plan_generator.generate.return_value = _make_plan(intent, requires_approval=False)
+
+    uc = _make_use_case(intent_parser=intent_parser, plan_generator=plan_generator)
+    events = list(uc.handle("deploy", _make_ctx()))
+
+    final = [e for e in events if e.type == ChatEventType.FINAL]
+    assert final
+    assert "belum ada handler" in final[0].payload["text"]
+
+
+# ── Complex request → ExecutionLoop ───────────────────────────────────────────
+
+
+def _loop_event(ev_type: str, **data: Any) -> Any:
+    ev = MagicMock()
+    ev.type = ev_type
+    ev.data = data
+    return ev
+
+
+def test_complex_request_routes_to_execution_loop_when_present() -> None:
+    # 'deploy' is action-ish, not in _EXPLICIT_SIMPLE_INTENTS; combined with a
+    # complex trigger word ("kenapa") it routes through ExecutionLoop.
+    intent = _make_intent("deploy", confidence=0.8)
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = intent
+
+    history = MagicMock()
+    history.recent.return_value = []
+
+    loop = MagicMock()
+    loop.run.return_value = iter([
+        _loop_event("observing", message="scanning"),
+        _loop_event("thinking", message="thinking..."),
+        _loop_event("action_started", action="terminal", command="ls"),
+        _loop_event("action_result", action="terminal", output="file1"),
+        _loop_event("final", text="done"),
+    ])
+
+    uc = _make_use_case(
+        intent_parser=intent_parser,
+        history=history,
+        execution_loop=loop,
+    )
+    events = list(uc.handle("kenapa server lambat", _make_ctx()))
+
+    types = [e.type for e in events]
+    assert ChatEventType.OBSERVING in types
+    assert ChatEventType.THINKING in types
+    assert ChatEventType.ACTION_STARTED in types
+    assert ChatEventType.ACTION_RESULT in types
+    final = [e for e in events if e.type == ChatEventType.FINAL]
+    assert final and final[0].payload["text"] == "done"
+    # Assistant history must be persisted when loop produces a final.
+    assert any(
+        call.args[1] == "assistant" and call.args[2] == "done"
+        for call in history.append.call_args_list
+    )
+
+
+def test_complex_request_loop_ai_error_yields_error_event() -> None:
+    intent = _make_intent("deploy", confidence=0.8)
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = intent
+
+    history = MagicMock()
+    history.recent.return_value = []
+
+    loop = MagicMock()
+    loop.run.side_effect = AIProviderError("LLM offline")
+
+    uc = _make_use_case(
+        intent_parser=intent_parser,
+        history=history,
+        execution_loop=loop,
+    )
+    events = list(uc.handle("kenapa container restart", _make_ctx()))
+
+    errors = [e for e in events if e.type == ChatEventType.ERROR]
+    assert errors
+    assert "LLM offline" in errors[0].payload["message"]
+
+
+def test_simple_intent_with_execution_loop_present_still_takes_action_path() -> None:
+    """memory is in _EXPLICIT_SIMPLE_INTENTS — should never hit the loop."""
+    intent = _make_intent("memory", confidence=0.95)
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = intent
+
+    plan_generator = MagicMock()
+    plan_generator.generate.return_value = _make_plan(intent)
+
+    action_registry = MagicMock()
+    action_registry.execute.return_value = "MEM OK"
+
+    ai = MagicMock()
+    ai.chat.return_value = "ringkasan"
+
+    loop = MagicMock()
+
+    uc = _make_use_case(
+        intent_parser=intent_parser,
+        plan_generator=plan_generator,
+        action_registry=action_registry,
+        ai=ai,
+        execution_loop=loop,
+    )
+    events = list(uc.handle("cek ram", _make_ctx()))
+
+    loop.run.assert_not_called()
+    assert any(e.type == ChatEventType.ACTION_RESULT for e in events)


### PR DESCRIPTION
## Summary
Closes #14

Adds 13 new tests for `HandleMessageUseCase` covering chat / action / approval / complex-loop paths. `IntentParser` is already well-covered (29 existing tests).

## Base branch
This PR is **stacked on top of #38** (`refactor/use-cases-dependency-leak`). Merge #38 first; this targets that branch.

## Coverage
| Module | Before | After |
|---|---|---|
| `app.domain.use_cases` | 38% | **91%** |
| `app.intents.parser` | 97% | 97% |
| Combined | — | **93%** |

## New test cases
- Empty text → no events
- Intent parse error → error event
- Chat path: stream chunks + final, skip empty chunks, AI provider error
- Unknown intent → chat fallback when no execution loop
- Action path: started/result/final, whoami skips AI summary, AI fallback, execution error
- Approval required → approval event + plan saved
- Unknown handler → "belum ada handler" final
- Complex request → routes through execution loop, loop AI error → error event
- Simple intent ignores execution loop

## Deferred (negligible cost vs signal)
Remaining 9% in `use_cases.py` = trivial bridge mappings inside `_loop_event_to_chat_event` (already exercised indirectly by complex-loop happy-path test). Remaining 3% in `parser.py` = one docker_compose dispatch + JSON decode fallback already covered by similar adjacent tests.

## Test plan
- [x] 443 passed (full suite), 0 failed
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)