### PR TITLE
feat(reliability): add per-user rate limiting for Ollama via Redis

### DIFF
--- a/app/adapters/rate_limit.py
+++ b/app/adapters/rate_limit.py
@@ -1,0 +1,42 @@
+"""RedisRateLimiter — per-user cooldown via Redis ``SET NX EX``.
+
+Tujuan: cegah satu user spam request ke pipeline AI yang resource-bound
+(Ollama lokal). Pakai sync client supaya bisa dipanggil dari sync generator
+``HandleMessageUseCase.handle()`` tanpa overhead bridge event loop.
+
+Key format: ``ratelimit:{user_id}`` dengan TTL = cooldown.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class RedisRateLimiter:
+    """Cooldown per user_id. ``is_allowed`` mengembalikan True kalau request boleh lewat."""
+
+    def __init__(self, redis_client: Any, cooldown_seconds: int) -> None:
+        if cooldown_seconds < 0:
+            raise ValueError("cooldown_seconds must be >= 0")
+        self._client = redis_client
+        self._cooldown = cooldown_seconds
+
+    def is_allowed(self, user_id: str) -> bool:
+        # cooldown_seconds <= 0 → fitur efektif off.
+        if self._cooldown <= 0:
+            return True
+        key = _key(user_id)
+        try:
+            result = self._client.set(key, "1", ex=self._cooldown, nx=True)
+        except Exception as exc:
+            # Fail open: Redis down jangan blokir user.
+            logger.warning("Rate limiter Redis SET failed for %s: %s", user_id, exc)
+            return True
+        return bool(result)
+
+
+def _key(user_id: str) -> str:
+    return f"ratelimit:{user_id}"

--- a/app/adapters/redis_client.py
+++ b/app/adapters/redis_client.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import redis as syncredis
 import redis.asyncio as aioredis
 
 from app.config import settings
@@ -22,6 +23,7 @@ from app.config import settings
 logger = logging.getLogger(__name__)
 
 _client: aioredis.Redis | None = None
+_sync_client: syncredis.Redis | None = None
 
 
 def get_client() -> aioredis.Redis:
@@ -38,6 +40,25 @@ def get_client() -> aioredis.Redis:
     return _client
 
 
+def get_sync_client() -> syncredis.Redis:
+    """Return singleton sync Redis client.
+
+    Dipakai dari path sync (mis. ``RedisRateLimiter`` yang dipanggil dari
+    generator sync ``HandleMessageUseCase.handle``) — async client tidak cocok
+    di sana karena butuh event loop.
+    """
+    global _sync_client
+    if _sync_client is None:
+        _sync_client = syncredis.Redis.from_url(
+            settings.redis_url,
+            decode_responses=True,
+            encoding="utf-8",
+            health_check_interval=30,
+        )
+        logger.info("Redis sync client created: %s", _safe_url(settings.redis_url))
+    return _sync_client
+
+
 async def ping() -> bool:
     """Simple connectivity check — return True kalau Redis reachable."""
     try:
@@ -50,10 +71,16 @@ async def ping() -> bool:
 
 async def close() -> None:
     """Cleanup saat shutdown — tutup koneksi pool."""
-    global _client
+    global _client, _sync_client
     if _client is not None:
         await _client.aclose()
         _client = None
+    if _sync_client is not None:
+        try:
+            _sync_client.close()
+        except Exception as exc:
+            logger.warning("Redis sync client close failed: %s", exc)
+        _sync_client = None
 
 
 def _safe_url(url: str) -> str:

--- a/app/composition.py
+++ b/app/composition.py
@@ -23,6 +23,8 @@ from app.adapters.database.session import (
 from app.adapters.handoff_context import RedisHandoffContextProvider
 from app.adapters.knowledge_store_memory import InMemoryKnowledgeStore
 from app.adapters.ollama import OllamaAdapter
+from app.adapters.rate_limit import RedisRateLimiter
+from app.adapters.redis_client import get_sync_client
 from app.config import settings
 from app.domain.use_cases import HandleMessageUseCase
 from app.executor.actions import ActionRegistry
@@ -78,6 +80,14 @@ def _execution_loop() -> ExecutionLoop:
     )
 
 
+@lru_cache(maxsize=1)
+def _rate_limiter() -> RedisRateLimiter:
+    return RedisRateLimiter(
+        redis_client=get_sync_client(),
+        cooldown_seconds=settings.rate_limit_seconds,
+    )
+
+
 # ── RAG factories ────────────────────────────────────────────────────────────
 
 
@@ -124,4 +134,5 @@ def build_use_case() -> HandleMessageUseCase:
         execution_loop=_execution_loop(),
         agent_resolver=SqlAgentRoleResolver(_session_factory()),
         handoff_provider=RedisHandoffContextProvider(),
+        rate_limiter=_rate_limiter(),
     )

--- a/app/config.py
+++ b/app/config.py
@@ -96,6 +96,7 @@ class Settings:
     worker_concurrency: int
     instance_id: str
     telegram_bot_username: str
+    rate_limit_seconds: int
 
     # ── RAG ───────────────────────────────────────────────────────────────────
     rag_enabled: bool
@@ -196,6 +197,7 @@ def load_settings() -> Settings:
             or "backend-default"
         ),
         telegram_bot_username=os.getenv("TELEGRAM_BOT_USERNAME", "").strip(),
+        rate_limit_seconds=max(0, int(os.getenv("RATE_LIMIT_SECONDS", "3"))),
         rag_enabled=_env_bool("RAG_ENABLED", default=True),
         embedder_backend=os.getenv("EMBEDDER_BACKEND", "fastembed").strip().lower(),
         rag_recall_k=max(1, int(os.getenv("RAG_RECALL_K", "5"))),

--- a/app/domain/use_cases.py
+++ b/app/domain/use_cases.py
@@ -28,6 +28,7 @@ from app.ports.agents import AgentRoleResolver, HandoffContextProvider
 from app.ports.ai_provider import AIProvider
 from app.ports.chat_history import ChatHistoryStore
 from app.ports.execution_loop import ExecutionLoopPort
+from app.ports.rate_limit import RateLimiterPort
 
 _CHAT_PROMPT_TEMPLATE = (
     "Kamu Octopus, AI orchestrator yang dipakai operator server lewat Telegram & TUI.\n"
@@ -146,11 +147,21 @@ class HandleMessageUseCase:
     # Injected via composition.py — None disables agent delegation entirely.
     agent_resolver: AgentRoleResolver | None = field(default=None)
     handoff_provider: HandoffContextProvider | None = field(default=None)
+    # Optional per-user cooldown gate. None disables rate limiting.
+    rate_limiter: RateLimiterPort | None = field(default=None)
 
     def handle(self, text: str, ctx: MessageContext) -> Iterator[ChatEvent]:
         """Pure synchronous generator — adapter layer adapts ke async kalau perlu."""
         text = text.strip()
         if not text:
+            return
+
+        # ── 0. Per-user rate limit ────────────────────────────────────────────
+        # Gate sebelum classify supaya request spam tidak menyentuh AI provider.
+        if self.rate_limiter is not None and not self.rate_limiter.is_allowed(ctx.user_id):
+            yield ChatEvent.error(
+                "Sedang memproses pesan kamu sebelumnya, tunggu sebentar..."
+            )
             return
 
         # ── 1. Classify intent ────────────────────────────────────────────────

--- a/app/ports/rate_limit.py
+++ b/app/ports/rate_limit.py
@@ -1,0 +1,13 @@
+"""Port untuk per-user rate limiter.
+
+Domain pakai ini untuk gate request masuk ke pipeline orchestrator
+sebelum kena AI provider (Ollama) yang resource-bound.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class RateLimiterPort(Protocol):
+    def is_allowed(self, user_id: str) -> bool: ...

--- a/tests/adapters/test_rate_limit.py
+++ b/tests/adapters/test_rate_limit.py
@@ -1,0 +1,82 @@
+"""Unit tests RedisRateLimiter — pakai in-memory fake (no real Redis)."""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from app.adapters.rate_limit import RedisRateLimiter
+
+
+class _FakeRedis:
+    """Minimal stand-in for ``redis.Redis`` that supports ``SET NX EX``.
+
+    Cukup untuk perilaku rate limiter: simpan value + expiry (epoch seconds),
+    ``set(..., nx=True)`` return truthy hanya kalau key tidak ada / sudah expired.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, tuple[Any, float | None]] = {}
+
+    def set(self, name: str, value: Any, ex: int | None = None, nx: bool = False) -> bool | None:
+        existing = self._store.get(name)
+        now = time.time()
+        if existing is not None:
+            _, expiry = existing
+            if expiry is not None and expiry <= now:
+                del self._store[name]
+                existing = None
+        if nx and existing is not None:
+            return None
+        expiry = now + ex if ex is not None else None
+        self._store[name] = (value, expiry)
+        return True
+
+    def expire_now(self, name: str) -> None:
+        if name in self._store:
+            val, _ = self._store[name]
+            self._store[name] = (val, time.time() - 1)
+
+
+def test_first_call_in_window_is_allowed() -> None:
+    limiter = RedisRateLimiter(_FakeRedis(), cooldown_seconds=3)
+    assert limiter.is_allowed("user-1") is True
+
+
+def test_second_call_within_window_is_blocked() -> None:
+    fake = _FakeRedis()
+    limiter = RedisRateLimiter(fake, cooldown_seconds=3)
+    assert limiter.is_allowed("user-1") is True
+    assert limiter.is_allowed("user-1") is False
+
+
+def test_call_after_window_is_allowed_again() -> None:
+    fake = _FakeRedis()
+    limiter = RedisRateLimiter(fake, cooldown_seconds=3)
+    assert limiter.is_allowed("user-1") is True
+    fake.expire_now("ratelimit:user-1")
+    assert limiter.is_allowed("user-1") is True
+
+
+def test_different_users_have_independent_windows() -> None:
+    limiter = RedisRateLimiter(_FakeRedis(), cooldown_seconds=3)
+    assert limiter.is_allowed("user-1") is True
+    assert limiter.is_allowed("user-2") is True
+    assert limiter.is_allowed("user-1") is False
+    assert limiter.is_allowed("user-2") is False
+
+
+def test_zero_cooldown_disables_limiter() -> None:
+    fake = _FakeRedis()
+    limiter = RedisRateLimiter(fake, cooldown_seconds=0)
+    assert limiter.is_allowed("user-1") is True
+    assert limiter.is_allowed("user-1") is True
+    assert fake._store == {}
+
+
+def test_redis_failure_fails_open() -> None:
+    class _BoomRedis:
+        def set(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("redis down")
+
+    limiter = RedisRateLimiter(_BoomRedis(), cooldown_seconds=3)
+    assert limiter.is_allowed("user-1") is True

--- a/tests/domain/test_use_cases.py
+++ b/tests/domain/test_use_cases.py
@@ -83,6 +83,45 @@ def test_agent_delegation_yields_delegate_event() -> None:
     assert "delegate_to_agent" in types
 
 
+def test_rate_limited_user_gets_error_event() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("agent_code")
+
+    limiter = MagicMock()
+    limiter.is_allowed.return_value = False
+
+    uc = _make_use_case(intent_parser=intent_parser, rate_limiter=limiter)
+    events = list(uc.handle("apapun", _make_ctx()))
+
+    types = [e.type for e in events]
+    assert types == ["error"]
+    assert "tunggu sebentar" in events[0].payload["message"].lower()
+    intent_parser.parse.assert_not_called()
+    assert "intent_classified" not in types
+
+
+def test_rate_limiter_allowed_lets_classification_proceed() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("agent_code")
+
+    limiter = MagicMock()
+    limiter.is_allowed.return_value = True
+
+    resolver = MagicMock()
+    resolver.agent_for_role.return_value = "codex"
+
+    uc = _make_use_case(
+        intent_parser=intent_parser,
+        rate_limiter=limiter,
+        agent_resolver=resolver,
+    )
+    events = list(uc.handle("refactor kode X", _make_ctx()))
+
+    types = [e.type for e in events]
+    assert "intent_classified" in types
+    limiter.is_allowed.assert_called_once_with("u1")
+
+
 def test_agent_delegation_uses_handoff_provider_when_present() -> None:
     intent_parser = MagicMock()
     intent_parser.parse.return_value = _make_intent("agent_review")


### PR DESCRIPTION
## Summary
Closes #24

Implements **Option A** (per-user cooldown via Redis) — every Telegram/CLI/HTTP request is gated by a `SET NX EX` against `ratelimit:{user_id}`. Default cooldown 3s, configurable via `RATE_LIMIT_SECONDS`.

## Base branch
Stacked on **#38** (`refactor/use-cases-dependency-leak`). Merge #38 first.

## Changes
- `app/ports/rate_limit.py` (new) — `RateLimiterPort` Protocol
- `app/adapters/rate_limit.py` (new) — `RedisRateLimiter` (sync, fail-open on Redis exception)
- `app/adapters/redis_client.py` — added `get_sync_client()` sibling (existing client is async; use case is sync)
- `app/config.py` — `rate_limit_seconds: int = 3`
- `app/domain/use_cases.py` — Optional `rate_limiter: RateLimiterPort | None` field; early gate before classify
- `app/composition.py` — wires `_rate_limiter()` into `build_use_case()`
- Tests: `tests/adapters/test_rate_limit.py` + 2 new use-case tests

## Design notes
- **Fail-open** on Redis outage: prevents Redis incident from blackholing every user.
- **`cooldown_seconds <= 0` disables** limiter — useful for tests and dev.
- **Sync Redis client**: `HandleMessageUseCase.handle()` is a sync generator. Bridging via thread pool for one ~1ms `SET NX EX` is overkill.
- **Option B (global Ollama semaphore)** deferred — separate PR if VPS load proves it's needed.

## Test plan
- [x] 12 new+touched tests pass
- [x] Full suite 436/436 pass
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)