### PR TITLE
feat(observability): add JSON Lines audit logger + trace_id

### DIFF
--- a/app/adapters/audit.py
+++ b/app/adapters/audit.py
@@ -1,30 +1,34 @@
-"""Audit log via Redis Streams.
+"""Audit logging — dua sink saling melengkapi.
 
-Setiap event penting (chat send, agent dispatch, agent done) di-XADD ke
-``audit:stream``. Read-side: XREVRANGE atau XLEN untuk replay/observability.
+1. Redis Streams (``log_event`` / ``recent``) — best-effort cap di ~5000 event,
+   dipakai handler/web buat fast-replay observability.
+2. JSON Lines file (``JsonlAuditLogger``) — append-only, durable di disk,
+   secrets-redacted. Domain ``HandleMessageUseCase`` panggil lewat port
+   ``app.ports.audit.AuditLogger`` supaya tetep DI-friendly.
 
-Format event (fields-pairs di Stream):
-- ts            : ISO timestamp UTC
-- event         : event_type (chat_send | agent_dispatch | agent_done | agent_error)
-- user_id       : UUID user (atau "?")
-- intent        : intent name (kalau ada)
-- agent         : agent name (kalau ada)
-- prompt_preview: 80 char pertama dari prompt
-- status        : ok | error | started
-- detail        : optional extra info
+Format JSONL: satu event per baris, schema::
+
+    {"ts": "2026-05-25T03:21:09.123456+00:00", "event": "request_received",
+     "trace_id": "uuid-...", "user_id": "u1", ...}
+
+Rotation: filesystem-level — kalau ukuran file > ``max_bytes`` saat write,
+file di-rename ke ``audit.jsonl.1`` (overwrite previous). Sederhana, no daemon.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import threading
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from app.adapters.redis_client import get_client, k_audit_stream
 
 logger = logging.getLogger(__name__)
 
-# Cap stream supaya tidak grow infinite — keep ~last 5000 events.
 _MAX_LEN = 5000
 
 
@@ -87,3 +91,90 @@ async def recent(n: int = 50, user_id: str | None = None) -> list[dict[str, Any]
         if len(out) >= n:
             break
     return out
+
+
+# ── JSON Lines audit logger ─────────────────────────────────────────────────
+
+# Substring (case-insensitive) yang nandain key sensitif. Apapun yang nyentuh
+# key ini di-redact jadi "***" sebelum di-serialize.
+_SECRET_SUBSTRINGS: tuple[str, ...] = (
+    "token",
+    "password",
+    "secret",
+    "api_key",
+    "apikey",
+)
+
+_REDACTED = "***"
+
+
+def _redact(value: Any) -> Any:
+    """Recursively redact secrets di dict/list. Scalar value lewat apa adanya."""
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for k, v in value.items():
+            lowered = str(k).lower()
+            if any(s in lowered for s in _SECRET_SUBSTRINGS):
+                out[str(k)] = _REDACTED
+            else:
+                out[str(k)] = _redact(v)
+        return out
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    return value
+
+
+class JsonlAuditLogger:
+    """Append JSON Lines ke file dengan size-based rotation.
+
+    Bukan thread-safe across processes — multi-worker setup harus pakai
+    sink terpusat (Redis stream / syslog). Single-process safe via Lock.
+    """
+
+    def __init__(self, path: Path, max_bytes: int = 10 * 1024 * 1024) -> None:
+        self._path = path
+        self._max_bytes = max_bytes
+        self._lock = threading.Lock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def log(self, event: str, trace_id: str, **fields: Any) -> None:
+        """Write satu event. Failure di-swallow + warn supaya gak ganggu caller."""
+        record: dict[str, Any] = {
+            "ts": datetime.now(UTC).isoformat(),
+            "event": event,
+            "trace_id": trace_id,
+        }
+        record.update(_redact(fields))
+        # ``default=str`` covers Path/UUID/datetime; broad except is intentional —
+        # an audit failure must never propagate into request handling.
+        try:
+            line = json.dumps(record, ensure_ascii=False, default=str)
+        except Exception as exc:
+            logger.warning("audit jsonl serialize failed: %s", exc)
+            return
+
+        with self._lock:
+            try:
+                self._rotate_if_needed(len(line) + 1)
+                with self._path.open("a", encoding="utf-8") as fh:
+                    fh.write(line)
+                    fh.write("\n")
+            except OSError as exc:
+                logger.warning("audit jsonl write failed: %s", exc)
+
+    def _rotate_if_needed(self, incoming_bytes: int) -> None:
+        try:
+            current = self._path.stat().st_size
+        except FileNotFoundError:
+            return
+        if current + incoming_bytes <= self._max_bytes:
+            return
+        rotated = self._path.with_suffix(self._path.suffix + ".1")
+        try:
+            os.replace(self._path, rotated)
+        except OSError as exc:
+            logger.warning("audit jsonl rotate failed: %s", exc)

--- a/app/composition.py
+++ b/app/composition.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import sessionmaker
 
 from app.adapters.agent_role_resolver import SqlAgentRoleResolver
+from app.adapters.audit import JsonlAuditLogger
 from app.adapters.chat_history import SqlAlchemyChatHistory
 from app.adapters.database.session import (
     create_database_engine,
@@ -23,7 +24,7 @@ from app.adapters.database.session import (
 from app.adapters.handoff_context import RedisHandoffContextProvider
 from app.adapters.knowledge_store_memory import InMemoryKnowledgeStore
 from app.adapters.ollama import OllamaAdapter
-from app.config import settings
+from app.config import BASE_DIR, settings
 from app.domain.use_cases import HandleMessageUseCase
 from app.executor.actions import ActionRegistry
 from app.executor.context import ContextCollector
@@ -67,6 +68,11 @@ def _build_pending_plans() -> PendingPlanStore:
 @lru_cache(maxsize=1)
 def _context_collector() -> ContextCollector:
     return ContextCollector(working_dir=settings.project_dir)
+
+
+@lru_cache(maxsize=1)
+def _audit_logger() -> JsonlAuditLogger:
+    return JsonlAuditLogger(path=BASE_DIR / "logs" / "audit.jsonl")
 
 
 @lru_cache(maxsize=1)
@@ -124,4 +130,5 @@ def build_use_case() -> HandleMessageUseCase:
         execution_loop=_execution_loop(),
         agent_resolver=SqlAgentRoleResolver(_session_factory()),
         handoff_provider=RedisHandoffContextProvider(),
+        audit=_audit_logger(),
     )

--- a/app/domain/messaging.py
+++ b/app/domain/messaging.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 
 class ChatEventType(StrEnum):
@@ -42,6 +43,9 @@ class MessageContext:
     project_name: str
     telegram_user_id: int | None = None  # untuk audit, optional
     extra: dict[str, Any] = field(default_factory=dict)
+    # UUID per request, dipropagasi ke setiap audit event supaya flow end-to-end
+    # bisa di-grep dari logs/audit.jsonl.
+    trace_id: str = field(default_factory=lambda: str(uuid4()))
 
 
 @dataclass(frozen=True)

--- a/app/domain/use_cases.py
+++ b/app/domain/use_cases.py
@@ -26,6 +26,7 @@ from app.orchestrator.approval import PendingPlanStore
 from app.orchestrator.plans import PlanGenerator
 from app.ports.agents import AgentRoleResolver, HandoffContextProvider
 from app.ports.ai_provider import AIProvider
+from app.ports.audit import AuditLogger
 from app.ports.chat_history import ChatHistoryStore
 from app.ports.execution_loop import ExecutionLoopPort
 
@@ -146,19 +147,41 @@ class HandleMessageUseCase:
     # Injected via composition.py — None disables agent delegation entirely.
     agent_resolver: AgentRoleResolver | None = field(default=None)
     handoff_provider: HandoffContextProvider | None = field(default=None)
+    # Optional — when wired, every request emits structured audit events.
+    audit: AuditLogger | None = field(default=None)
 
     def handle(self, text: str, ctx: MessageContext) -> Iterator[ChatEvent]:
-        """Pure synchronous generator — adapter layer adapts ke async kalau perlu."""
+        """Public entry — wraps ``_handle_inner`` to emit request/response audit pairs."""
         text = text.strip()
         if not text:
             return
 
+        self._audit("request_received", ctx, text_preview=text[:200])
+
+        outcome = "ok"
+        try:
+            for event in self._handle_inner(text, ctx):
+                if event.type == ChatEventType.ERROR:
+                    outcome = "error"
+                yield event
+        finally:
+            self._audit("response_sent", ctx, outcome=outcome)
+
+    def _handle_inner(self, text: str, ctx: MessageContext) -> Iterator[ChatEvent]:
         # ── 1. Classify intent ────────────────────────────────────────────────
         try:
             intent = self.intent_parser.parse(text, ctx.project_id)
         except IntentParseError as exc:
+            self._audit("error", ctx, stage="intent_parse", detail=str(exc))
             yield ChatEvent.error(f"Gagal classify intent: {exc}")
             return
+
+        self._audit(
+            "intent_parsed",
+            ctx,
+            intent=intent.intent,
+            confidence=intent.confidence,
+        )
 
         yield ChatEvent.intent_classified(
             intent=intent.intent,
@@ -211,6 +234,19 @@ class HandleMessageUseCase:
         yield from self._handle_action(text, intent, ctx)
 
     # ── private ───────────────────────────────────────────────────────────────
+
+    def _audit(self, event: str, ctx: MessageContext, **fields: Any) -> None:
+        """Forward ke ``AuditLogger`` kalau ada. Best-effort — error di-swallow di adapter."""
+        if self.audit is None:
+            return
+        self.audit.log(
+            event,
+            ctx.trace_id,
+            user_id=ctx.user_id,
+            conversation_id=ctx.conversation_id,
+            project_id=ctx.project_id,
+            **fields,
+        )
 
     def _handle_loop(self, text: str, ctx: MessageContext) -> Iterator[ChatEvent]:
         """Route complex request through ExecutionLoop. Bridge LoopEvents → ChatEvents."""

--- a/app/ports/audit.py
+++ b/app/ports/audit.py
@@ -1,0 +1,15 @@
+"""Port untuk structured audit logging.
+
+Domain layer (``HandleMessageUseCase``) panggil ``log`` untuk mencatat event
+penting selama menangani request. Implementasi konkret (JSON Lines file,
+stdout, atau remote sink) ada di ``app/adapters/audit.py`` dan di-inject
+lewat composition root.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class AuditLogger(Protocol):
+    def log(self, event: str, trace_id: str, **fields: Any) -> None: ...

--- a/tests/adapters/test_audit.py
+++ b/tests/adapters/test_audit.py
@@ -1,0 +1,97 @@
+"""Unit tests untuk ``JsonlAuditLogger`` — JSON Lines + rotation + redaction."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.adapters.audit import JsonlAuditLogger
+
+
+def _read_lines(path: Path) -> list[dict[str, object]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_log_writes_jsonl_with_required_fields(tmp_path: Path) -> None:
+    log = JsonlAuditLogger(path=tmp_path / "audit.jsonl")
+
+    log.log("request_received", "trace-1", user_id="u1", text_preview="halo")
+
+    entries = _read_lines(log.path)
+    assert len(entries) == 1
+    record = entries[0]
+    assert record["event"] == "request_received"
+    assert record["trace_id"] == "trace-1"
+    assert record["user_id"] == "u1"
+    assert record["text_preview"] == "halo"
+    assert "ts" in record
+
+
+def test_log_creates_parent_directory(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "deeper" / "audit.jsonl"
+
+    log = JsonlAuditLogger(path=target)
+    log.log("ping", "t")
+
+    assert target.exists()
+    assert len(_read_lines(target)) == 1
+
+
+def test_log_redacts_known_secret_keys(tmp_path: Path) -> None:
+    log = JsonlAuditLogger(path=tmp_path / "audit.jsonl")
+
+    log.log(
+        "request_received",
+        "trace-1",
+        telegram_bot_token="123:ABCDEF",
+        api_key="sk-live-xyz",
+        password="hunter2",
+        nested={"refresh_token": "secret", "username": "alice"},
+        safe_field="visible",
+    )
+
+    record = _read_lines(log.path)[0]
+    assert record["telegram_bot_token"] == "***"
+    assert record["api_key"] == "***"
+    assert record["password"] == "***"
+    assert record["nested"]["refresh_token"] == "***"
+    assert record["nested"]["username"] == "alice"
+    assert record["safe_field"] == "visible"
+
+
+def test_log_rotates_when_file_exceeds_cap(tmp_path: Path) -> None:
+    log = JsonlAuditLogger(path=tmp_path / "audit.jsonl", max_bytes=200)
+
+    for i in range(20):
+        log.log("noise", f"trace-{i}", payload="x" * 50)
+
+    rotated = tmp_path / "audit.jsonl.1"
+    assert rotated.exists(), "rotation must move old content to .1"
+    assert log.path.exists(), "new active log must exist after rotation"
+    assert log.path.stat().st_size <= 200 + 200  # current file roughly under cap
+
+
+def test_log_swallows_serialization_errors(tmp_path: Path) -> None:
+    log = JsonlAuditLogger(path=tmp_path / "audit.jsonl")
+
+    class NotSerializable:
+        def __repr__(self) -> str:
+            raise RuntimeError("boom")
+
+    # Should not raise — default=str fallback handles most, but if it still
+    # fails the adapter must log a warning and return cleanly.
+    log.log("event", "trace-1", payload=NotSerializable())
+
+
+@pytest.mark.parametrize(
+    "secret_key",
+    ["TELEGRAM_BOT_TOKEN", "OPENAI_API_KEY", "db_password", "session_secret"],
+)
+def test_log_redacts_case_insensitive(tmp_path: Path, secret_key: str) -> None:
+    log = JsonlAuditLogger(path=tmp_path / "audit.jsonl")
+
+    log.log("env_dump", "t", **{secret_key: "leak-me"})
+
+    record = _read_lines(log.path)[0]
+    assert record[secret_key] == "***"

--- a/tests/domain/test_use_cases.py
+++ b/tests/domain/test_use_cases.py
@@ -83,6 +83,109 @@ def test_agent_delegation_yields_delegate_event() -> None:
     assert "delegate_to_agent" in types
 
 
+def test_audit_emits_request_intent_and_response_events() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("agent_code")
+
+    resolver = MagicMock()
+    resolver.agent_for_role.return_value = "codex"
+
+    audit = MagicMock()
+    uc = _make_use_case(
+        intent_parser=intent_parser,
+        agent_resolver=resolver,
+        audit=audit,
+    )
+
+    list(uc.handle("refactor kode X", _make_ctx()))
+
+    event_names = [call.args[0] for call in audit.log.call_args_list]
+    assert "request_received" in event_names
+    assert "intent_parsed" in event_names
+    assert "response_sent" in event_names
+    # response_sent harus event terakhir supaya trace tertutup rapi.
+    assert event_names[-1] == "response_sent"
+
+
+def test_audit_propagates_trace_id_from_context() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("agent_code")
+
+    resolver = MagicMock()
+    resolver.agent_for_role.return_value = "codex"
+
+    audit = MagicMock()
+    ctx = MessageContext(
+        user_id="u1",
+        conversation_id="chat-1",
+        project_id="p1",
+        project_root=Path("/workspace"),
+        project_name="test-project",
+        trace_id="fixed-trace-uuid",
+    )
+
+    uc = _make_use_case(
+        intent_parser=intent_parser,
+        agent_resolver=resolver,
+        audit=audit,
+    )
+    list(uc.handle("refactor", ctx))
+
+    for call in audit.log.call_args_list:
+        assert call.args[1] == "fixed-trace-uuid"
+
+
+def test_audit_emits_error_event_on_intent_parse_failure() -> None:
+    from app.domain.exceptions import IntentParseError
+
+    intent_parser = MagicMock()
+    intent_parser.parse.side_effect = IntentParseError("bad json")
+
+    audit = MagicMock()
+    uc = _make_use_case(intent_parser=intent_parser, audit=audit)
+
+    list(uc.handle("apa kabar", _make_ctx()))
+
+    event_names = [call.args[0] for call in audit.log.call_args_list]
+    assert "error" in event_names
+    assert event_names[-1] == "response_sent"
+    # response_sent should mark error outcome
+    last_call = audit.log.call_args_list[-1]
+    assert last_call.kwargs.get("outcome") == "error"
+
+
+def test_audit_is_optional_use_case_runs_without_logger() -> None:
+    intent_parser = MagicMock()
+    intent_parser.parse.return_value = _make_intent("agent_code")
+
+    resolver = MagicMock()
+    resolver.agent_for_role.return_value = "codex"
+
+    uc = _make_use_case(intent_parser=intent_parser, agent_resolver=resolver, audit=None)
+    events = list(uc.handle("refactor", _make_ctx()))
+
+    assert events  # use case still produces events with no logger
+
+
+def test_message_context_generates_unique_trace_id_by_default() -> None:
+    ctx_a = MessageContext(
+        user_id="u",
+        conversation_id="c",
+        project_id="p",
+        project_root=Path("/x"),
+        project_name="x",
+    )
+    ctx_b = MessageContext(
+        user_id="u",
+        conversation_id="c",
+        project_id="p",
+        project_root=Path("/x"),
+        project_name="x",
+    )
+    assert ctx_a.trace_id != ctx_b.trace_id
+    assert len(ctx_a.trace_id) >= 32  # uuid4 length
+
+
 def test_agent_delegation_uses_handoff_provider_when_present() -> None:
     intent_parser = MagicMock()
     intent_parser.parse.return_value = _make_intent("agent_review")


### PR DESCRIPTION
## Summary
Partial fix for #8 — delivers the infrastructure (JSONL logger + trace_id + core events). User-facing `/logs`, `/last`, `/status` commands deferred to follow-up.

## Base branch
Stacked on **#38** (`refactor/use-cases-dependency-leak`). Merge #38 first.

## In scope (delivered)
- `app/ports/audit.py` (new) — `AuditLogger` Protocol (domain-pure)
- `app/adapters/audit.py` — added `JsonlAuditLogger` class:
  - Writes to `logs/audit.jsonl`
  - Size-based rotation at **10 MB** (`.jsonl` → `.jsonl.1`)
  - **Recursive secret redaction** (case-insensitive substring match on `token`/`password`/`secret`/`api_key`)
- `app/domain/messaging.py` — `MessageContext.trace_id: str` (UUID default)
- `app/domain/use_cases.py` — injected `audit: AuditLogger | None`; `_handle_inner()` wrapped in try/finally so `response_sent` always fires
- `app/composition.py` — wires `_audit_logger()` at `<repo>/logs/audit.jsonl`
- Events emitted: `request_received`, `intent_parsed`, `error`, `response_sent`
- 9 audit adapter tests + 5 domain audit/trace tests

## Deferred (separate PRs)
1. `/logs`, `/last`, `/status` Telegram + TUI commands
2. `plan_generated`, `approval_requested`/`decision`, `execution_started`/`finished` — these live in `app/orchestrator/` and `app/handlers/`; require touching modules outside use case

Existing Redis Streams functions in `app/adapters/audit.py` left intact.

## Test plan
- [x] Full suite 442 passed
- [x] ruff + mypy clean (109 source files)
- [x] No secrets leaked in any of the test audit lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)