### PR TITLE
feat: add swarm deployment stack for scalable backend

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,0 +1,219 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# docker-stack.yml — Swarm stack untuk octopus (Tahap 1: scalable deployment)
+#
+# Ini versi SWARM dari docker-compose.yml. Dipakai dengan:
+#     docker stack deploy -c docker-stack.yml octopus
+#
+# Beda kunci dari compose (kenapa file ini terpisah):
+#   - `container_name`  → DIHAPUS (swarm kelola nama replica sendiri: octopus_bot.1, .2, …)
+#   - `build`           → DIHAPUS (swarm hanya pakai image yang sudah jadi; build dulu lalu push)
+#   - `depends_on`      → DIHAPUS (tidak ada di swarm; andalkan healthcheck + retry app)
+#   - `mem_limit`       → jadi `deploy.resources.limits`
+#   - `restart`         → jadi `deploy.restart_policy`
+#   - + `deploy.replicas`, `update_config` (rolling), `rollback_config`, `placement`
+#
+# Catatan scaling (lihat docs/SWARM.md):
+#   - bot     = STATELESS dispatcher → boleh banyak replica (ini yang "auto-replicate")
+#   - redis   = state bersama        → SATU replica (pinned), volume di node manager
+#   - ollama  = bottleneck CPU/RAM   → SATU replica (pinned), 4GB
+#   - caddy   = ingress (publish port)→ SATU replica cukup (routing mesh load-balance ke bot)
+#   - telegram-adapter = poller       → WAJIB SATU replica (Telegram getUpdates single-consumer)
+# ─────────────────────────────────────────────────────────────────────────────
+
+networks:
+  octopus_net:
+    driver: overlay
+    attachable: true
+
+volumes:
+  ollama_data:
+    name: aiagent_ollama_data
+  redis_data:
+    name: aiagent_redis_data
+  caddy_data:
+    name: aiagent_caddy_data
+  caddy_config:
+    name: aiagent_caddy_config
+
+services:
+
+  # ── Redis: shared state (sesi, rate-limit, presence, pub/sub antar-instance) ──
+  # SATU replica: ini sumber kebenaran state. Di-pin ke node manager supaya
+  # volume-nya selalu ketemu. Untuk HA sejati nanti: Redis Sentinel / cluster.
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--appendonly", "yes", "--save", "60", "1"]
+    volumes:
+      - redis_data:/data
+    networks:
+      - octopus_net
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
+      restart_policy:
+        condition: any
+        delay: 5s
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 128M
+
+  # ── Ollama: AI model server — BOTTLENECK sebenarnya ──────────────────────────
+  # SATU replica, di-pin. Menambah replica bot TIDAK menambah throughput AI;
+  # untuk itu Ollama harus dipindah ke node/GPU sendiri (lihat docs Tahap 3).
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama_data:/root/.ollama
+    networks:
+      - octopus_net
+    environment:
+      OLLAMA_KEEP_ALIVE: "24h"
+      OLLAMA_NUM_PARALLEL: "1"
+      OLLAMA_NUM_CTX: "4096"
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 60s
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
+      restart_policy:
+        condition: any
+        delay: 10s
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 2G
+
+  # ── Model init: pull model sekali lalu exit ──────────────────────────────────
+  # Di swarm, one-shot pakai `mode: replicated-job` (Docker 25+). Job jalan
+  # sampai selesai (exit 0), tidak di-restart seperti service biasa.
+  ollama-init:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama_data:/root/.ollama
+    networks:
+      - octopus_net
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+      OLLAMA_MODEL: ${OLLAMA_MODEL:-qwen2.5:1.5b}
+    entrypoint: ["ollama", "pull", "${OLLAMA_MODEL:-qwen2.5:1.5b}"]
+    deploy:
+      mode: replicated-job
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+
+  # ── Bot: FastAPI dispatcher — INI yang di-replicate saat user banyak ──────────
+  # Stateless-ish (state di Redis). Kode sudah multi-instance ready (worker_ws B5g
+  # pakai Redis pub/sub utk routing antar-instance). replicas default 2; ubah via:
+  #     docker service scale octopus_bot=N
+  # Rolling update: start replica baru DULU (start-first) sebelum matikan lama →
+  # zero-downtime. Kalau gagal health → auto-rollback ke versi sebelumnya.
+  bot:
+    image: ghcr.io/codinginid/ai-agent:latest
+    env_file: .env
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+      REDIS_URL: redis://redis:6379/0
+    networks:
+      - octopus_net
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:${PORT:-8080}/health || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 20s
+    deploy:
+      replicas: 2
+      update_config:
+        parallelism: 1
+        delay: 10s
+        order: start-first
+        failure_action: rollback
+        monitor: 30s
+      rollback_config:
+        parallelism: 1
+        order: start-first
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 0
+      resources:
+        limits:
+          memory: 768M
+        reservations:
+          memory: 256M
+
+  # ── Telegram adapter: poller — WAJIB SATU replica ────────────────────────────
+  # Telegram getUpdates hanya boleh satu consumer; >1 replica = error 409 Conflict.
+  # CATATAN: di compose pakai `build: ./telegram-adapter`. Swarm tidak bisa build —
+  # harus pre-build & push dulu:
+  #     docker build -t ghcr.io/codinginid/ai-agent-telegram:latest ./telegram-adapter
+  #     docker push  ghcr.io/codinginid/ai-agent-telegram:latest
+  telegram-adapter:
+    image: ghcr.io/codinginid/ai-agent-telegram:latest
+    env_file: .env
+    environment:
+      OCTOPUS_CORE_URL: http://bot:${PORT:-8080}
+    networks:
+      - octopus_net
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
+      resources:
+        limits:
+          memory: 256M
+
+  # ── Caddy: ingress / reverse proxy ───────────────────────────────────────────
+  # Publish port via routing mesh swarm. Caddy proxy ke "bot:8080" → swarm DNS
+  # otomatis load-balance ke semua replica bot. SATU replica caddy sudah cukup.
+  caddy:
+    image: caddy:2-alpine
+    environment:
+      PORT: ${PORT:-8080}
+    ports:
+      - target: ${PORT:-8080}
+        published: ${CADDY_HOST_PORT:-8090}
+        protocol: tcp
+        mode: ingress
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - octopus_net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO /dev/null http://localhost:${PORT:-8080}/health || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 10s
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
+      restart_policy:
+        condition: any
+        delay: 5s
+      resources:
+        limits:
+          memory: 128M

--- a/docs/SWARM.md
+++ b/docs/SWARM.md
@@ -1,0 +1,137 @@
+# Swarm Deployment — Octopus (Tahap 1: scalable)
+
+Panduan menjalankan octopus di **Docker Swarm** supaya backend bisa di-replicate
+saat user banyak. File stack: [`../docker-stack.yml`](../docker-stack.yml).
+
+> **Status:** stack file sudah ditulis & divalidasi (`docker stack config` ✓), dan
+> mekanik scaling swarm sudah diuji di node ini (scale 1→3 converged). Stack
+> **belum di-deploy** — octopus saat ini masih jalan via `docker compose` di port
+> 8090. Bagian "Cutover" di bawah adalah langkah go-live saat Anda siap.
+
+---
+
+## Kenapa Swarm (bukan langsung Kubernetes)
+
+- Swarm **sudah aktif** di VPS ini (1 node, leader) — nol biaya setup.
+- Sintaks = compose + blok `deploy:` → tidak perlu belajar manifest baru.
+- Memberi 80% manfaat (replikasi, rolling update, self-heal) dengan 20% kerumitan.
+- K8s + autoscaling (HPA) baru worth-it saat **multi-node** (Tahap 2/3).
+
+## Peta scaling tiap service
+
+| Service | Replicas | Kenapa |
+|---|---|---|
+| **bot** | **2 (scalable)** | Stateless dispatcher. Kode multi-instance ready (Redis pub/sub B5g). **Ini yang di-scale saat user banyak.** |
+| redis | 1 (pinned) | State bersama (sesi, rate-limit, presence). HA sejati = Sentinel/cluster (nanti). |
+| ollama | 1 (pinned) | **Bottleneck asli** (CPU/RAM, 4GB). Scale = pindah ke node/GPU sendiri (Tahap 3). |
+| caddy | 1 | Ingress; routing mesh swarm auto load-balance ke semua replica bot. |
+| telegram-adapter | **1 (wajib)** | Telegram `getUpdates` single-consumer; >1 = error 409. |
+
+---
+
+## Prasyarat sekali jalan: build & push image
+
+Swarm **tidak bisa `build:`** — hanya jalankan image jadi. Build & push dulu:
+
+```bash
+cd ~/ai-agent
+# bot (sudah ada di ghcr biasanya via CI, tapi kalau mau dari source):
+docker build -t ghcr.io/codinginid/ai-agent:latest .
+docker push ghcr.io/codinginid/ai-agent:latest
+
+# telegram-adapter (di compose pakai build: ./telegram-adapter):
+docker build -t ghcr.io/codinginid/ai-agent-telegram:latest ./telegram-adapter
+docker push ghcr.io/codinginid/ai-agent-telegram:latest
+```
+
+> `.env` & `Caddyfile` dibaca dari direktori saat `docker stack deploy` dijalankan.
+> Pastikan Anda di `~/ai-agent` saat deploy.
+
+---
+
+## Deploy
+
+```bash
+cd ~/ai-agent
+docker stack deploy -c docker-stack.yml octopus
+
+# pantau sampai semua replica Running:
+watch docker stack services octopus
+```
+
+## Scale (jawaban "auto-replicate saat user banyak")
+
+```bash
+# manual scale backend ke 4 replica:
+docker service scale octopus_bot=4
+
+# swarm sebar otomatis + routing mesh load-balance. Verifikasi:
+docker service ps octopus_bot
+```
+
+> **Auto-scale berdasarkan beban** (naik-turun sendiri) BUKAN fitur bawaan Swarm —
+> itu butuh Tahap 2 (k3s + HorizontalPodAutoscaler). Di Swarm, scaling-nya manual
+> (atau via skrip cron yang baca metrik lalu `service scale`).
+
+## Rolling update (deploy versi baru, zero-downtime)
+
+Stack sudah di-set `order: start-first` + `failure_action: rollback`:
+
+```bash
+docker service update --image ghcr.io/codinginid/ai-agent:NEWTAG octopus_bot
+# replica baru start & lolos health DULU, baru yang lama dimatikan.
+# kalau health gagal dalam 30s → otomatis rollback ke versi lama.
+```
+
+## Rollback manual
+
+```bash
+docker service rollback octopus_bot
+```
+
+## Status & log
+
+```bash
+docker stack services octopus              # ringkasan replica per service
+docker service ps   octopus_bot            # task tiap replica + state
+docker service logs -f octopus_bot         # log gabungan semua replica
+```
+
+---
+
+## Cutover dari compose → swarm (go-live, saat siap)
+
+Octopus live sekarang pakai `docker compose` (container `aiagent_*`) di port 8090.
+Stack swarm juga mau publish 8090 → **akan bentrok**. Urutan aman:
+
+```bash
+cd ~/ai-agent
+# 1. matikan stack compose (volume redis/ollama/caddy TETAP aman, named volume):
+docker compose down                 # JANGAN pakai -v (itu hapus volume!)
+
+# 2. deploy swarm (pakai volume yang sama: aiagent_ollama_data, dst):
+docker stack deploy -c docker-stack.yml octopus
+
+# 3. verifikasi dari luar (tunnel cloudflared → 127.0.0.1:8090 tetap sama):
+curl -fsS http://127.0.0.1:8090/health
+```
+
+Rollback cutover (balik ke compose):
+
+```bash
+docker stack rm octopus
+sleep 5
+docker compose up -d
+```
+
+> Volume bersifat **named & eksternal-aman** (`aiagent_*`), jadi data Redis &
+> model Ollama tidak hilang saat pindah compose↔swarm.
+
+---
+
+## Batas di 1 VPS (jujur)
+
+Scaling `bot` hanya membantu sampai CPU/RAM VPS penuh, DAN selama beban AI tidak
+naik (karena Ollama tetap 1). Skalabilitas sejati = **tambah node** ke swarm
+(`docker swarm join`) lalu service otomatis tersebar. Saat itu tiba, pertimbangkan
+Tahap 2 (k3s + HPA) untuk auto-scale berbasis metrik.


### PR DESCRIPTION
## Ringkasan
Tahap 1 deployment scalable: konversi `docker-compose.yml` ke Docker Swarm stack supaya backend (`bot`) bisa di-replicate saat user banyak.

## Yang ditambahkan
- **`docker-stack.yml`** — versi swarm dari compose:
  - `bot`: **2 replica, scalable** (`docker service scale octopus_bot=N`) + rolling update `start-first` (zero-downtime) + `failure_action: rollback`
  - `redis` / `ollama` / `caddy`: **1 replica pinned** ke node manager (state & bottleneck tidak digandakan)
  - `telegram-adapter`: **dikunci 1 replica** (Telegram getUpdates single-consumer; >1 = error 409)
  - `ollama-init`: `mode: replicated-job` (one-shot pull model)
  - `mem_limit`→`deploy.resources`, `restart`→`restart_policy`, buang `build`/`depends_on`/`container_name`
- **`docs/SWARM.md`** — panduan deploy, scale, rolling update, rollback, dan cutover compose→swarm yang aman (named volume `aiagent_*` tidak hilang).

## Validasi
- `docker stack config -c docker-stack.yml` lolos (247 baris resolved)
- Mekanik scaling diuji di node (service throwaway scale 1→3 converged, lalu dihapus)
- **Tidak menyentuh runtime** — octopus live (compose, port 8090) tetap healthy. Stack belum di-deploy; cutover terpisah saat siap.

## Catatan
- Auto-scale berbasis beban (naik-turun otomatis) bukan fitur Swarm — itu Tahap 2 (k3s + HPA).
- Bottleneck sebenarnya Ollama (CPU/RAM); scaling sejati = pisah Ollama ke node/GPU sendiri (Tahap 3).