### PR TITLE
feat: add role-to-model router for worker delegation

### DIFF
--- a/app/adapters/worker_dispatch.py
+++ b/app/adapters/worker_dispatch.py
@@ -5,9 +5,9 @@ chat handler, so the executing thread has no running event loop. That makes it
 safe to spin up a private loop via ``asyncio.run`` to drive the async dispatch
 to completion and aggregate its streamed events into a single ``DispatchResult``.
 
-Role → agent mapping is intentionally minimal here (PR-1 scope). The richer
-role→model router lands in a later PR (see docs/ORCHESTRATOR.md); this adapter
-only needs to turn a role into a concrete agent name the worker understands.
+Routing (role → agent + model) is delegated to ``orchestrator/router.pick``,
+which is pure and capability-aware. This adapter owns the I/O: reading config
+maps and querying the worker capability registry (Redis ``k_caps``).
 """
 
 from __future__ import annotations
@@ -15,47 +15,72 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from app.config import settings
+from app.orchestrator.router import pick
 from app.ports.worker_dispatch import DispatchResult
 
 logger = logging.getLogger(__name__)
 
-# Minimal role → agent mapping. Replaced by orchestrator/router.py in PR-2.
-# infra stays on a local agent by policy (server ops must not leave the box);
-# until a local coding agent exists, it falls back to echo (no-op safe default).
-_ROLE_TO_AGENT: dict[str, str] = {
-    "engineer": "claude",
-    "reviewer": "glm",
-    "research": "codex",
-    "infra": "echo",
-}
-_DEFAULT_AGENT = "claude"
+
+def _role_agent_map() -> dict[str, str]:
+    return {
+        "engineer": settings.delegate_role_engineer,
+        "reviewer": settings.delegate_role_reviewer,
+        "research": settings.delegate_role_research,
+        "infra": settings.delegate_role_infra,
+    }
+
+
+def _agent_model_map() -> dict[str, str]:
+    """Per-agent model override sourced from existing *_model settings.
+
+    Empty string means "let the agent CLI use its own default model".
+    """
+    return {
+        "claude": settings.claude_model,
+        "codex": settings.codex_model,
+        "glm": settings.glm_model,
+    }
 
 
 class WorkerDispatchAdapter:
     """Concrete WorkerDispatchPort backed by ``worker_ws.dispatch_agent_job``."""
 
     def dispatch(self, user_id: str, role: str, prompt: str) -> DispatchResult:
-        agent = _ROLE_TO_AGENT.get(role, _DEFAULT_AGENT)
         try:
-            return asyncio.run(self._dispatch_async(user_id, agent, role, prompt))
+            return asyncio.run(self._dispatch_async(user_id, role, prompt))
         except RuntimeError as exc:
             # e.g. "asyncio.run() cannot be called from a running event loop"
             logger.warning("worker dispatch could not run: %s", exc)
             return DispatchResult(output="", ok=False, error=f"dispatch runtime error: {exc}")
 
     async def _dispatch_async(
-        self, user_id: str, agent: str, role: str, prompt: str,
+        self, user_id: str, role: str, prompt: str,
     ) -> DispatchResult:
         from app.interfaces.worker_ws import (
             NoWorkerAvailableError,
             dispatch_agent_job,
         )
 
+        available = await self._available_caps(user_id)
+        decision = pick(
+            role,
+            role_agent_map=_role_agent_map(),
+            agent_model_map=_agent_model_map(),
+            available_caps=available,
+        )
+        logger.info(
+            "route role=%s → agent=%s model=%s (%s)",
+            role, decision.agent, decision.model or "(default)", decision.reason,
+        )
+
         chunks: list[str] = []
         summary = ""
         try:
             async for ev in dispatch_agent_job(
-                user_id, agent, prompt, extra={"role": role},
+                user_id, decision.agent, prompt,
+                extra={"role": decision.role},
+                model=decision.model,
             ):
                 kind = ev.get("type", "")
                 if kind == "job_chunk":
@@ -84,3 +109,25 @@ class WorkerDispatchAdapter:
             ok=False,
             error="worker stream ended without completion",
         )
+
+    async def _available_caps(self, user_id: str) -> frozenset[str] | None:
+        """Agents that at least one online worker advertises (via k_caps).
+
+        Returns ``None`` on Redis failure to signal "capabilities unknown" so the
+        router skips filtering rather than wrongly excluding every agent.
+        """
+        from app.adapters.redis_client import get_client, k_caps
+
+        client = get_client()
+        found: set[str] = set()
+        for agent_id in ("codex", "claude", "glm"):
+            try:
+                count = await client.scard(k_caps(user_id, agent_id))  # type: ignore[misc]
+            except Exception as exc:  # Redis hiccup — degrade to "unknown caps"
+                logger.warning("caps lookup failed for %s: %s", agent_id, exc)
+                return None
+            if int(count) > 0:
+                found.add(agent_id)
+        # echo is always available locally (no-op safe default).
+        found.add("echo")
+        return frozenset(found)

--- a/app/config.py
+++ b/app/config.py
@@ -71,6 +71,12 @@ class Settings:
     agent_role_engineer: str
     agent_role_architect: str
     agent_role_reviewer: str
+    # Worker-delegation role → agent map (orchestrator/router.py). Distinct from
+    # the prompt-workflow roles above (those drive PromptArchitect/Engineer/Reviewer).
+    delegate_role_engineer: str
+    delegate_role_reviewer: str
+    delegate_role_research: str
+    delegate_role_infra: str
 
     enable_terminal_tools: bool
     terminal_timeout: int
@@ -170,6 +176,10 @@ def load_settings() -> Settings:
         agent_role_engineer=os.getenv("AGENT_ROLE_ENGINEER", "codex").strip().lower(),
         agent_role_architect=os.getenv("AGENT_ROLE_ARCHITECT", "glm").strip().lower(),
         agent_role_reviewer=os.getenv("AGENT_ROLE_REVIEWER", "claude").strip().lower(),
+        delegate_role_engineer=os.getenv("DELEGATE_ROLE_ENGINEER", "claude").strip().lower(),
+        delegate_role_reviewer=os.getenv("DELEGATE_ROLE_REVIEWER", "glm").strip().lower(),
+        delegate_role_research=os.getenv("DELEGATE_ROLE_RESEARCH", "codex").strip().lower(),
+        delegate_role_infra=os.getenv("DELEGATE_ROLE_INFRA", "echo").strip().lower(),
         enable_terminal_tools=_env_bool("ENABLE_TERMINAL_TOOLS"),
         terminal_timeout=int(os.getenv("TERMINAL_TIMEOUT", "20")),
         terminal_workdir=terminal_workdir,

--- a/app/interfaces/worker_ws.py
+++ b/app/interfaces/worker_ws.py
@@ -356,6 +356,7 @@ async def dispatch_agent_job(
     *,
     timeout_sec: float = 300.0,
     extra: dict[str, Any] | None = None,
+    model: str = "",
 ) -> AsyncIterator[dict[str, Any]]:
     """Dispatch job ke worker user, yield event sampai job_done/job_error.
 
@@ -434,6 +435,8 @@ async def dispatch_agent_job(
                 "agent": agent,
                 "prompt": enriched_prompt,
             }
+            if model:
+                payload["model"] = model
             if extra:
                 payload["extra"] = extra
             try:

--- a/app/orchestrator/router.py
+++ b/app/orchestrator/router.py
@@ -1,0 +1,120 @@
+"""Role → (agent, model) router for worker delegation.
+
+The orchestrator decides *what kind* of work a step is (a ``role``); this module
+turns that role into a concrete ``(agent, model)`` pair to dispatch to a worker.
+
+Pure & deterministic — no I/O, no globals. Maps are passed in so the caller
+(composition / adapter) owns config sourcing and this stays trivially testable.
+
+Design pillars (see docs/ORCHESTRATOR.md):
+- Each role can map to a different agent/LLM → "every worker a different model".
+- ``reviewer`` should differ from ``engineer`` on purpose (catch blind spots).
+- ``infra`` is privacy-sensitive: it must resolve to a local agent and is never
+  silently rerouted to a cloud agent by capability fallback.
+- Capability-aware: if the user's workers don't have the preferred agent's CLI
+  installed, fall back to an available one — except for ``infra`` (privacy).
+- Per-task override always wins (explicit user/orchestrator intent).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Roles whose work must stay on a local agent — never rerouted to cloud agents
+# by capability fallback. Server ops / sensitive context must not leave the box.
+LOCAL_ONLY_ROLES: frozenset[str] = frozenset({"infra"})
+
+# Agents considered local (run on the user's own machine without sending the
+# task to a third-party cloud model). ``echo`` is the safe local no-op default.
+LOCAL_AGENTS: frozenset[str] = frozenset({"echo", "local", "qwen"})
+
+DEFAULT_ROLE_AGENT: dict[str, str] = {
+    "engineer": "claude",
+    "reviewer": "glm",
+    "research": "codex",
+    "infra": "echo",
+}
+
+DEFAULT_AGENT = "claude"
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    role: str
+    agent: str
+    model: str
+    reason: str = ""
+
+
+def pick(
+    role: str,
+    *,
+    role_agent_map: dict[str, str] | None = None,
+    agent_model_map: dict[str, str] | None = None,
+    available_caps: frozenset[str] | set[str] | None = None,
+    override_agent: str = "",
+    override_model: str = "",
+) -> RouteDecision:
+    """Resolve a role into a concrete ``(agent, model)`` dispatch decision.
+
+    Args:
+        role: logical role (engineer/reviewer/research/infra/...).
+        role_agent_map: role → agent name. Defaults to ``DEFAULT_ROLE_AGENT``.
+        agent_model_map: agent → model string (e.g. {"claude": "sonnet"}).
+            Empty/absent model means "let the agent CLI use its own default".
+        available_caps: agent names that at least one online worker can run.
+            ``None`` means "unknown" → no capability filtering applied.
+        override_agent: explicit agent, wins over role mapping.
+        override_model: explicit model, wins over agent_model_map.
+
+    Returns:
+        RouteDecision with the chosen agent + model + a human-readable reason.
+    """
+    role_agent_map = role_agent_map or DEFAULT_ROLE_AGENT
+    agent_model_map = agent_model_map or {}
+    role_norm = (role or "").strip().lower() or "engineer"
+
+    # 1. Explicit override always wins.
+    if override_agent:
+        agent = override_agent.strip().lower()
+        model = override_model or agent_model_map.get(agent, "")
+        return RouteDecision(role_norm, agent, model, reason="override")
+
+    # 2. Role → preferred agent.
+    preferred = role_agent_map.get(role_norm, DEFAULT_AGENT)
+
+    # 3. Capability-aware fallback (skipped for local-only roles).
+    agent = preferred
+    reason = f"role '{role_norm}' → {preferred}"
+    if available_caps is not None and preferred not in available_caps:
+        if role_norm in LOCAL_ONLY_ROLES:
+            # Privacy: never reroute infra to a cloud agent. Keep preferred even
+            # if no worker advertises it — caller surfaces "no worker" cleanly.
+            reason = f"local-only role '{role_norm}' pinned to {preferred} (no fallback)"
+        else:
+            fallback = _first_available(role_agent_map, available_caps)
+            if fallback:
+                agent = fallback
+                reason = f"role '{role_norm}' preferred {preferred} unavailable → {fallback}"
+            else:
+                reason = f"role '{role_norm}' → {preferred} (no caps advertised, best-effort)"
+
+    model = override_model or agent_model_map.get(agent, "")
+    return RouteDecision(role_norm, agent, model, reason=reason)
+
+
+def _first_available(
+    role_agent_map: dict[str, str],
+    available_caps: frozenset[str] | set[str],
+) -> str:
+    """Pick a deterministic available agent: prefer ones referenced by the map,
+    excluding local-only placeholders, then any advertised cap."""
+    # Prefer agents that some role maps to (stable, meaningful choices).
+    for agent in dict.fromkeys(role_agent_map.values()):
+        if agent in available_caps and agent not in LOCAL_AGENTS:
+            return agent
+    # Otherwise any advertised cloud-capable cap (sorted for determinism).
+    for agent in sorted(available_caps):
+        if agent not in LOCAL_AGENTS:
+            return agent
+    return ""

--- a/app/tui/_worker.py
+++ b/app/tui/_worker.py
@@ -110,15 +110,16 @@ async def _spawn_streaming(
         yield {"type": "error", "message": f"{type(exc).__name__}: {exc}"}
 
 
-async def _agent_echo(prompt: str) -> AsyncIterator[dict[str, Any]]:
+async def _agent_echo(prompt: str, model: str = "") -> AsyncIterator[dict[str, Any]]:
     """Mock agent — balas prompt apa adanya, 2 chunks untuk test stream."""
-    yield {"type": "chunk", "text": f"[echo] received: {prompt}\n"}
+    label = f"[echo:{model}]" if model else "[echo]"
+    yield {"type": "chunk", "text": f"{label} received: {prompt}\n"}
     await asyncio.sleep(0.1)
     yield {"type": "chunk", "text": "[echo] done.\n"}
     yield {"type": "done", "exit_code": 0, "summary": f"echoed {len(prompt)} chars"}
 
 
-async def _agent_codex(prompt: str) -> AsyncIterator[dict[str, Any]]:
+async def _agent_codex(prompt: str, model: str = "") -> AsyncIterator[dict[str, Any]]:
     if not settings.enable_codex:
         yield {"type": "error", "message": "Codex belum aktif. Set ENABLE_CODEX=true di .env."}
         return
@@ -136,15 +137,16 @@ async def _agent_codex(prompt: str) -> AsyncIterator[dict[str, Any]]:
         "--ephemeral",
         "--color", "never",
     ]
-    if settings.codex_model:
-        args.extend(["--model", settings.codex_model])
+    chosen_model = model or settings.codex_model
+    if chosen_model:
+        args.extend(["--model", chosen_model])
     args.append(prompt)
 
     async for event in _spawn_streaming(args, timeout_sec=settings.agent_timeout):
         yield event
 
 
-async def _agent_claude(prompt: str) -> AsyncIterator[dict[str, Any]]:
+async def _agent_claude(prompt: str, model: str = "") -> AsyncIterator[dict[str, Any]]:
     if not settings.enable_claude:
         yield {"type": "error", "message": "Claude belum aktif. Set ENABLE_CLAUDE=true di .env."}
         return
@@ -164,15 +166,16 @@ async def _agent_claude(prompt: str) -> AsyncIterator[dict[str, Any]]:
         args.extend(["--tools", settings.claude_tools])
     if settings.claude_allowed_tools and settings.claude_allowed_tools.lower() != "default":
         args.extend(["--allowedTools", settings.claude_allowed_tools])
-    if settings.claude_model:
-        args.extend(["--model", settings.claude_model])
+    chosen_model = model or settings.claude_model
+    if chosen_model:
+        args.extend(["--model", chosen_model])
     args.append(prompt)
 
     async for event in _spawn_streaming(args, timeout_sec=settings.agent_timeout):
         yield event
 
 
-async def _agent_glm(prompt: str) -> AsyncIterator[dict[str, Any]]:
+async def _agent_glm(prompt: str, model: str = "") -> AsyncIterator[dict[str, Any]]:
     if not settings.enable_glm:
         yield {"type": "error", "message": "GLM belum aktif. Set ENABLE_GLM=true di .env."}
         return
@@ -182,8 +185,9 @@ async def _agent_glm(prompt: str) -> AsyncIterator[dict[str, Any]]:
         return
 
     args = [bin_path]
-    if settings.glm_model:
-        args.extend(["--model", settings.glm_model])
+    chosen_model = model or settings.glm_model
+    if chosen_model:
+        args.extend(["--model", chosen_model])
     args.append(prompt)
 
     async for event in _spawn_streaming(args, timeout_sec=settings.agent_timeout):
@@ -203,6 +207,7 @@ async def _execute_agent(
     job_id: str,
     agent: str,
     prompt: str,
+    model: str = "",
 ) -> None:
     """Jalankan agent → stream chunk via WS → akhiri dengan job_done/job_error."""
     runner = _AGENTS.get(agent)
@@ -215,7 +220,7 @@ async def _execute_agent(
         return
 
     try:
-        async for event in runner(prompt):
+        async for event in runner(prompt, model):
             kind = event.get("type", "")
             if kind == "chunk":
                 await ws.send(json.dumps({
@@ -272,8 +277,9 @@ async def _handle_message(ws: websockets.ClientConnection, raw: str) -> None:
         job_id = str(msg.get("job_id", ""))
         agent = str(msg.get("agent", ""))
         prompt = str(msg.get("prompt", ""))
+        model = str(msg.get("model", ""))
         if job_id and agent:
-            task = asyncio.create_task(_execute_agent(ws, job_id, agent, prompt))
+            task = asyncio.create_task(_execute_agent(ws, job_id, agent, prompt, model))
             _background_tasks.add(task)
             task.add_done_callback(_background_tasks.discard)
     else:

--- a/tests/orchestrator/test_router.py
+++ b/tests/orchestrator/test_router.py
@@ -1,0 +1,124 @@
+"""Tests for the role → (agent, model) router (orchestrator/router.py).
+
+Pure functions — no mocks needed.
+"""
+
+from __future__ import annotations
+
+from app.orchestrator.router import (
+    DEFAULT_ROLE_AGENT,
+    RouteDecision,
+    pick,
+)
+
+_MODELS = {"claude": "sonnet", "codex": "o4", "glm": "glm-4.6"}
+
+
+# ── basic role → agent ─────────────────────────────────────────────────────────
+
+def test_engineer_routes_to_claude_by_default() -> None:
+    d = pick("engineer", agent_model_map=_MODELS)
+    assert d.agent == "claude"
+    assert d.model == "sonnet"
+    assert d.role == "engineer"
+
+
+def test_reviewer_differs_from_engineer() -> None:
+    """Reviewer intentionally uses a different model than engineer (blind spots)."""
+    eng = pick("engineer")
+    rev = pick("reviewer")
+    assert eng.agent != rev.agent
+    assert rev.agent == "glm"
+
+
+def test_research_routes_to_codex() -> None:
+    assert pick("research").agent == "codex"
+
+
+def test_unknown_role_falls_back_to_default_agent() -> None:
+    d = pick("marketing")
+    assert d.agent == "claude"  # DEFAULT_AGENT
+
+
+def test_empty_role_defaults_to_engineer() -> None:
+    d = pick("")
+    assert d.role == "engineer"
+
+
+def test_role_is_normalized_case_insensitive() -> None:
+    assert pick("ENGINEER").agent == "claude"
+    assert pick("  Reviewer ").agent == "glm"
+
+
+# ── custom role→agent map ───────────────────────────────────────────────────────
+
+def test_custom_role_agent_map_overrides_defaults() -> None:
+    d = pick("engineer", role_agent_map={"engineer": "codex"}, agent_model_map=_MODELS)
+    assert d.agent == "codex"
+    assert d.model == "o4"
+
+
+# ── per-task override ───────────────────────────────────────────────────────────
+
+def test_override_agent_wins_over_role() -> None:
+    d = pick("engineer", override_agent="glm", agent_model_map=_MODELS)
+    assert d.agent == "glm"
+    assert d.model == "glm-4.6"
+    assert d.reason == "override"
+
+
+def test_override_model_wins_over_agent_model_map() -> None:
+    d = pick("engineer", override_model="opus", agent_model_map=_MODELS)
+    assert d.agent == "claude"
+    assert d.model == "opus"
+
+
+# ── capability-aware fallback ───────────────────────────────────────────────────
+
+def test_falls_back_when_preferred_agent_unavailable() -> None:
+    """engineer prefers claude; only codex+glm online → fall back to an available."""
+    d = pick("engineer", available_caps={"codex", "glm"})
+    assert d.agent in {"codex", "glm"}
+    assert "unavailable" in d.reason
+
+
+def test_no_fallback_when_preferred_is_available() -> None:
+    d = pick("engineer", available_caps={"claude", "codex"})
+    assert d.agent == "claude"
+
+
+def test_none_caps_means_no_filtering() -> None:
+    d = pick("engineer", available_caps=None)
+    assert d.agent == "claude"
+
+
+# ── privacy: local-only roles never reroute to cloud ────────────────────────────
+
+def test_infra_stays_local_even_when_cloud_agents_available() -> None:
+    """infra must NOT be rerouted to claude/codex/glm by capability fallback."""
+    d = pick("infra", available_caps={"claude", "codex", "glm"})
+    assert d.agent == "echo"  # default infra agent (local), not a cloud agent
+    assert "local-only" in d.reason
+
+
+def test_infra_not_rerouted_to_cloud_on_fallback() -> None:
+    d = pick(
+        "infra",
+        role_agent_map={"infra": "qwen"},
+        available_caps={"claude", "codex"},  # qwen not advertised
+    )
+    # Must stay on qwen (local), never silently jump to claude/codex.
+    assert d.agent == "qwen"
+    assert "local-only" in d.reason
+
+
+# ── value object ────────────────────────────────────────────────────────────────
+
+def test_route_decision_is_frozen() -> None:
+    d = RouteDecision(role="engineer", agent="claude", model="sonnet")
+    assert d.role == "engineer"
+
+
+def test_default_role_agent_map_has_core_roles() -> None:
+    for role in ("engineer", "reviewer", "research", "infra"):
+        assert role in DEFAULT_ROLE_AGENT

--- a/tests/tui/test_worker_model.py
+++ b/tests/tui/test_worker_model.py
@@ -1,0 +1,34 @@
+"""Tests for worker agent model threading (PR-2).
+
+Verifies the per-job model is passed through to agent runners. Uses the echo
+agent (no external CLI) which surfaces the model in its first chunk.
+"""
+
+from __future__ import annotations
+
+from app.tui._worker import _AGENTS, _agent_echo
+
+
+async def _drain(gen):  # type: ignore[no-untyped-def]
+    return [ev async for ev in gen]
+
+
+async def test_echo_agent_accepts_model_kwarg() -> None:
+    events = await _drain(_agent_echo("hello", "test-model"))
+    first = events[0]["text"]
+    assert "echo:test-model" in first
+
+
+async def test_echo_agent_without_model() -> None:
+    events = await _drain(_agent_echo("hello"))
+    assert events[0]["text"].startswith("[echo]")
+
+
+def test_all_agent_runners_accept_model_param() -> None:
+    """Every runner must accept (prompt, model) so dispatch can thread a model."""
+    import inspect
+
+    for name, runner in _AGENTS.items():
+        sig = inspect.signature(runner)
+        params = list(sig.parameters)
+        assert "model" in params, f"agent runner {name!r} missing 'model' param"


### PR DESCRIPTION
## Ringkasan
Implementasi **PR-2** dari `docs/ORCHESTRATOR.md` — pilar utama visi: **tiap worker role bisa menjalankan LLM berbeda**.

## Perubahan
- **`orchestrator/router.py`** — fungsi murni `pick(role) → RouteDecision(agent, model)`:
  - role→agent: engineer→claude, reviewer→glm, research→codex, infra→lokal
  - **reviewer sengaja beda model** dari engineer (tangkap blind spot)
  - **capability-aware**: kalau worker user tak punya CLI agent pilihan, fallback ke yang tersedia (via `k_caps`)
  - **privasi**: role `infra` di-pin ke agent lokal, **tidak pernah** di-reroute ke cloud saat fallback
  - **override per-task**: agent/model eksplisit menang
- **`config.py`** — map `DELEGATE_ROLE_*` (env-overridable), terpisah dari workflow roles.
- **`WorkerDispatchAdapter`** — pakai `pick()`, query `k_caps` untuk agent yang online, teruskan `model`.
- **model threaded end-to-end**: `dispatch_agent_job` payload → worker `_handle_message` → runner (codex/claude/glm/echo semua terima `model`, override `.env` default).

## Validasi lokal
- pytest **593 passed** (+19: 16 router, 3 worker-model)
- ruff ✓ (app/ + tests/, mirror CI) · mypy ✓ (124 files)
- Hexagonal terjaga: router murni (tanpa I/O), adapter yang pegang config + Redis.