### PR TITLE
feat: add task runner chaining pm plan to github issue lifecycle

### DIFF
--- a/app/adapters/worker_dispatch.py
+++ b/app/adapters/worker_dispatch.py
@@ -48,13 +48,13 @@ class WorkerDispatchAdapter:
 
     def dispatch(self, user_id: str, role: str, prompt: str) -> DispatchResult:
         try:
-            return asyncio.run(self._dispatch_async(user_id, role, prompt))
+            return asyncio.run(self.dispatch_async(user_id, role, prompt))
         except RuntimeError as exc:
             # e.g. "asyncio.run() cannot be called from a running event loop"
             logger.warning("worker dispatch could not run: %s", exc)
             return DispatchResult(output="", ok=False, error=f"dispatch runtime error: {exc}")
 
-    async def _dispatch_async(
+    async def dispatch_async(
         self, user_id: str, role: str, prompt: str,
     ) -> DispatchResult:
         from app.interfaces.worker_ws import (

--- a/app/orchestrator/task_runner.py
+++ b/app/orchestrator/task_runner.py
@@ -1,0 +1,163 @@
+"""TaskRunner — PM plan → GitHub Issue → worker dispatch → close (PR-4).
+
+Turns a free-text request into a durable, auditable task:
+
+    1. PLAN    : PMAgent decomposes the request into ordered steps (TaskPlan).
+    2. RECORD  : create a GitHub Issue (PRD body + steps checklist) as the
+                 single source of truth for the task.
+    3. EXECUTE : dispatch each step to a worker, routed by role (engineer/
+                 reviewer/research/infra → different LLMs via the router).
+    4. LOG     : comment each step's outcome on the issue (attempt trail).
+    5. CLOSE   : close the issue with a summary when all steps succeed; leave
+                 it open with a failure comment otherwise (resume later).
+
+Why an issue: unlike an ephemeral in-process loop, the task survives restart,
+is auditable, and is collaboratively visible — the trait that makes Octopus
+feel like an engineering OS rather than a chatbot.
+
+Hexagonal: depends on ``PMAgentPort``, ``GitHubIssuesPort`` and
+``AsyncWorkerDispatchPort`` — never on concrete adapters.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from app.agents.pm import TaskPlan
+from app.ports.github_issues import GitHubIssuesPort
+from app.ports.pm_agent import PMAgentPort
+from app.ports.worker_dispatch import AsyncWorkerDispatchPort
+
+logger = logging.getLogger(__name__)
+
+# Step action prefix → worker role. Server/repo ops stay local (infra);
+# file authoring is engineering; everything else explores/reads (research).
+_ACTION_ROLE_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("file_write", "engineer"),
+    ("file_edit", "engineer"),
+    ("docker_", "infra"),
+    ("git_", "infra"),
+    ("server_", "infra"),
+    ("memory_", "infra"),
+    ("disk_", "infra"),
+    ("terminal", "infra"),
+)
+_DEFAULT_STEP_ROLE = "research"
+
+
+def role_for_action(action: str) -> str:
+    """Map a TaskStep action to a worker role (pure, deterministic)."""
+    a = (action or "").strip().lower()
+    for prefix, role in _ACTION_ROLE_PREFIXES:
+        if a == prefix or a.startswith(prefix):
+            return role
+    return _DEFAULT_STEP_ROLE
+
+
+def _issue_body(request: str, plan: TaskPlan) -> str:
+    lines = [
+        f"**Request:** {request}",
+        "",
+        f"**Summary:** {plan.summary}",
+        f"**Complexity:** {plan.estimated_complexity}",
+        "",
+        "### Steps",
+    ]
+    if plan.steps:
+        for s in plan.steps:
+            lines.append(f"- [ ] {s.order}. {s.description} (`{s.action}`)")
+    else:
+        lines.append("_(no steps — direct response)_")
+    lines += ["", "_Tracked automatically by Octopus TaskRunner._"]
+    return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class StepOutcome:
+    order: int
+    description: str
+    role: str
+    ok: bool
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class TaskResult:
+    plan: TaskPlan
+    issue_number: int | None
+    issue_url: str
+    outcomes: list[StepOutcome] = field(default_factory=list)
+    closed: bool = False
+    note: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.outcomes) and all(o.ok for o in self.outcomes)
+
+
+@dataclass
+class TaskRunner:
+    pm: PMAgentPort
+    github: GitHubIssuesPort
+    dispatch: AsyncWorkerDispatchPort
+    labels: list[str] = field(default_factory=lambda: ["octopus-task"])
+
+    async def run(self, user_id: str, request: str, context: str = "") -> TaskResult:
+        plan = self.pm.plan(request, context)
+
+        # No actionable steps → don't open an issue; nothing to track.
+        if not plan.steps:
+            return TaskResult(
+                plan=plan, issue_number=None, issue_url="",
+                note="no steps to execute",
+            )
+
+        issue = await self.github.create_issue(
+            title=plan.title or f"Task: {request[:60]}",
+            body=_issue_body(request, plan),
+            labels=self.labels,
+        )
+
+        outcomes: list[StepOutcome] = []
+        for step in sorted(plan.steps, key=lambda s: s.order):
+            role = role_for_action(step.action)
+            result = await self.dispatch.dispatch_async(user_id, role, step.description)
+            detail = (result.summary or result.output or result.error)[:500]
+            outcome = StepOutcome(
+                order=step.order,
+                description=step.description,
+                role=role,
+                ok=result.ok,
+                detail=detail,
+            )
+            outcomes.append(outcome)
+
+            status = "✅" if result.ok else "❌"
+            await self.github.comment_issue(
+                issue.number,
+                f"{status} **Step {step.order}** ({role}): {step.description}\n\n```\n{detail}\n```",
+            )
+            if not result.ok:
+                # Stop on first failure — leave issue open for resume/retry.
+                return TaskResult(
+                    plan=plan,
+                    issue_number=issue.number,
+                    issue_url=issue.url,
+                    outcomes=outcomes,
+                    closed=False,
+                    note=f"stopped at step {step.order} ({role}): {result.error or 'failed'}",
+                )
+
+        await self.github.close_issue(
+            issue.number,
+            comment=f"All {len(outcomes)} steps completed ✅ — closing.",
+        )
+        return TaskResult(
+            plan=plan,
+            issue_number=issue.number,
+            issue_url=issue.url,
+            outcomes=outcomes,
+            closed=True,
+            note="completed",
+        )

--- a/app/ports/github_issues.py
+++ b/app/ports/github_issues.py
@@ -1,0 +1,23 @@
+"""Port for GitHub Issues — task records for the orchestrator task runner.
+
+The task runner uses an issue as the durable record of a multi-step task:
+create on start, comment per step (attempt log), close on completion. Depending
+on a Protocol (not the concrete ``GitHubAdapter``) keeps the orchestrator
+testable and hexagonal-clean.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from app.adapters.github import GitHubIssue
+
+
+class GitHubIssuesPort(Protocol):
+    async def create_issue(
+        self, title: str, body: str = "", labels: list[str] | None = None,
+    ) -> GitHubIssue: ...
+
+    async def comment_issue(self, issue_number: int, body: str) -> None: ...
+
+    async def close_issue(self, issue_number: int, comment: str = "") -> None: ...

--- a/app/ports/worker_dispatch.py
+++ b/app/ports/worker_dispatch.py
@@ -36,3 +36,9 @@ class DispatchResult:
 
 class WorkerDispatchPort(Protocol):
     def dispatch(self, user_id: str, role: str, prompt: str) -> DispatchResult: ...
+
+
+class AsyncWorkerDispatchPort(Protocol):
+    async def dispatch_async(
+        self, user_id: str, role: str, prompt: str,
+    ) -> DispatchResult: ...

--- a/tests/orchestrator/test_task_runner.py
+++ b/tests/orchestrator/test_task_runner.py
@@ -1,0 +1,172 @@
+"""Tests for TaskRunner — PM plan → issue → dispatch → close (PR-4).
+
+GitHub + worker dispatch + PM agent are all mocked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.adapters.github import GitHubIssue
+from app.agents.pm import TaskPlan, TaskStep
+from app.orchestrator.task_runner import TaskRunner, role_for_action
+from app.ports.worker_dispatch import DispatchResult
+
+# ── role_for_action (pure) ──────────────────────────────────────────────────────
+
+def test_role_for_action_file_write_is_engineer() -> None:
+    assert role_for_action("file_write") == "engineer"
+    assert role_for_action("file_edit") == "engineer"
+
+
+def test_role_for_action_docker_and_git_are_infra() -> None:
+    assert role_for_action("docker_restart") == "infra"
+    assert role_for_action("git_commit") == "infra"
+    assert role_for_action("terminal") == "infra"
+
+
+def test_role_for_action_unknown_is_research() -> None:
+    assert role_for_action("something_else") == "research"
+
+
+# ── fakes ────────────────────────────────────────────────────────────────────────
+
+class _FakePM:
+    def __init__(self, plan: TaskPlan) -> None:
+        self._plan = plan
+
+    def plan(self, request: str, context: str = "") -> TaskPlan:
+        return self._plan
+
+
+class _FakeGitHub:
+    def __init__(self) -> None:
+        self.created: dict | None = None
+        self.comments: list[tuple[int, str]] = []
+        self.closed: tuple[int, str] | None = None
+        self._n = 0
+
+    async def create_issue(self, title, body="", labels=None):  # type: ignore[no-untyped-def]
+        self._n += 1
+        self.created = {"title": title, "body": body, "labels": labels}
+        return GitHubIssue(number=self._n, title=title, url=f"http://x/{self._n}", state="open")
+
+    async def comment_issue(self, issue_number, body):  # type: ignore[no-untyped-def]
+        self.comments.append((issue_number, body))
+
+    async def close_issue(self, issue_number, comment=""):  # type: ignore[no-untyped-def]
+        self.closed = (issue_number, comment)
+
+
+class _FakeDispatch:
+    def __init__(self, results: list[DispatchResult]) -> None:
+        self._results = list(results)
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def dispatch_async(self, user_id, role, prompt):  # type: ignore[no-untyped-def]
+        self.calls.append((user_id, role, prompt))
+        return self._results.pop(0)
+
+
+def _plan(steps: list[TaskStep], title="Do the thing") -> TaskPlan:
+    return TaskPlan(title=title, summary="because", steps=steps, estimated_complexity="medium")
+
+
+# ── happy path ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_successful_two_step_task_creates_comments_and_closes() -> None:
+    plan = _plan([
+        TaskStep(order=1, description="write module", action="file_write", params={}),
+        TaskStep(order=2, description="restart service", action="docker_restart", params={}),
+    ])
+    gh = _FakeGitHub()
+    dispatch = _FakeDispatch([
+        DispatchResult(output="written", summary="exit 0", ok=True),
+        DispatchResult(output="restarted", summary="exit 0", ok=True),
+    ])
+    runner = TaskRunner(pm=_FakePM(plan), github=gh, dispatch=dispatch)
+
+    result = await runner.run("user-1", "build and restart")
+
+    assert result.ok is True
+    assert result.closed is True
+    assert gh.created is not None
+    assert gh.closed is not None and gh.closed[0] == result.issue_number
+    # One comment per step.
+    assert len(gh.comments) == 2
+    # Roles routed correctly per step action.
+    assert dispatch.calls[0][1] == "engineer"   # file_write
+    assert dispatch.calls[1][1] == "infra"       # docker_restart
+
+
+@pytest.mark.asyncio
+async def test_steps_executed_in_order() -> None:
+    plan = _plan([
+        TaskStep(order=2, description="second", action="terminal", params={}),
+        TaskStep(order=1, description="first", action="terminal", params={}),
+    ])
+    gh = _FakeGitHub()
+    dispatch = _FakeDispatch([
+        DispatchResult(output="a", ok=True),
+        DispatchResult(output="b", ok=True),
+    ])
+    runner = TaskRunner(pm=_FakePM(plan), github=gh, dispatch=dispatch)
+    await runner.run("user-1", "ordered")
+    # Despite plan order, runner sorts by .order → "first" dispatched first.
+    assert dispatch.calls[0][2] == "first"
+    assert dispatch.calls[1][2] == "second"
+
+
+# ── failure path ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_failure_stops_and_leaves_issue_open() -> None:
+    plan = _plan([
+        TaskStep(order=1, description="step one", action="file_write", params={}),
+        TaskStep(order=2, description="step two", action="terminal", params={}),
+    ])
+    gh = _FakeGitHub()
+    dispatch = _FakeDispatch([
+        DispatchResult(output="", ok=False, error="no worker online"),
+    ])
+    runner = TaskRunner(pm=_FakePM(plan), github=gh, dispatch=dispatch)
+
+    result = await runner.run("user-1", "will fail")
+
+    assert result.ok is False
+    assert result.closed is False
+    assert gh.closed is None             # issue stays open
+    assert len(gh.comments) == 1         # only the failed step commented
+    assert len(dispatch.calls) == 1      # stopped after first failure
+    assert "no worker online" in result.note
+
+
+# ── no-steps path ────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_no_steps_does_not_create_issue() -> None:
+    plan = _plan([], title="Direct")
+    gh = _FakeGitHub()
+    dispatch = _FakeDispatch([])
+    runner = TaskRunner(pm=_FakePM(plan), github=gh, dispatch=dispatch)
+
+    result = await runner.run("user-1", "just chat")
+
+    assert result.issue_number is None
+    assert gh.created is None
+    assert result.note == "no steps to execute"
+
+
+@pytest.mark.asyncio
+async def test_issue_body_lists_steps() -> None:
+    plan = _plan([
+        TaskStep(order=1, description="do X", action="file_write", params={}),
+    ])
+    gh = _FakeGitHub()
+    dispatch = _FakeDispatch([DispatchResult(output="ok", ok=True)])
+    runner = TaskRunner(pm=_FakePM(plan), github=gh, dispatch=dispatch)
+    await runner.run("user-1", "req")
+    assert gh.created is not None
+    assert "do X" in gh.created["body"]
+    assert "octopus-task" in (gh.created["labels"] or [])


### PR DESCRIPTION
## Ringkasan
Implementasi **PR-4** dari `docs/ORCHESTRATOR.md` — menyambung **PM Agent → GitHub Issue → Worker → Close**. Inilah yang membuat octopus terasa seperti **AI Engineering OS**, bukan chatbot: task jadi **durable, auditable, resume-able**.

## Alur
1. **PLAN** — PMAgent dekomposisi request → `TaskPlan` (steps berurutan)
2. **RECORD** — buat GitHub Issue (PRD body + checklist steps) sebagai sumber kebenaran
3. **EXECUTE** — tiap step di-dispatch ke worker, **routing by role** (engineer/reviewer/research/infra → LLM berbeda via router PR-2)
4. **LOG** — comment hasil tiap step di issue (jejak attempt)
5. **CLOSE** — tutup issue + ringkasan saat semua sukses; kalau gagal, **issue dibiarkan terbuka** dengan catatan (bisa di-resume)

## Perubahan
- **`orchestrator/task_runner.py`** — `TaskRunner` + `role_for_action()` (pure: file_write→engineer, docker_/git_/terminal→infra, lainnya→research) + `StepOutcome`/`TaskResult`
- **`ports/github_issues.py`** — `GitHubIssuesPort` (Protocol)
- **`ports/worker_dispatch.py`** — `AsyncWorkerDispatchPort`; adapter expose `dispatch_async` publik (sync `dispatch` membungkusnya)
- **8 test baru**: happy-path 2-step (cek routing role + comment + close), urutan step, gagal→stop+issue tetap terbuka, no-steps→tak buat issue, isi body

## Validasi lokal
- pytest **601 passed** (+8)
- ruff ✓ (app/ + tests/) · mypy ✓ (126 files)
- Hexagonal terjaga: TaskRunner cuma bergantung pada **port** (PMAgentPort, GitHubIssuesPort, AsyncWorkerDispatchPort).