### PR TITLE
feat: add durable task queue via redis streams

### DIFF
--- a/app/adapters/redis_client.py
+++ b/app/adapters/redis_client.py
@@ -114,6 +114,11 @@ def k_job_stream(job_id: str) -> str:
     return f"job:stream:{job_id}"
 
 
+def k_task_stream(user_id: str) -> str:
+    """Durable task-step queue (Redis Stream) per user — GAP-2."""
+    return f"task:stream:{user_id}"
+
+
 def k_agent_ctx(session_id: str) -> str:
     return f"agent:ctx:{session_id}"
 

--- a/app/adapters/task_queue.py
+++ b/app/adapters/task_queue.py
@@ -1,0 +1,142 @@
+"""Durable task queue via Redis Streams (GAP-2).
+
+Why Streams (not a plain list / BRPOP): a consumer group gives us a *pending
+entries list* (PEL). When a message is read it stays pending until acked, so if
+the backend crashes mid-step the message is not lost — a later ``reclaim`` picks
+up anything idle beyond a threshold and re-delivers it. That is the resume-after-
+restart property the orchestrator needs and an in-process loop cannot provide.
+
+No Celery/RQ: Redis is already in the swarm stack, and Streams cover enqueue,
+at-least-once delivery, ack, and crash recovery on their own.
+
+State per message:
+    enqueued (XADD) → delivered (XREADGROUP, now in PEL) → acked (XACK, leaves PEL)
+                                                        ↘ idle too long → reclaimed
+
+Implements ``app.ports.task_queue.TaskQueuePort``. Hexagonal: the orchestrator
+depends on the port; only ``main``/composition wires this concrete adapter.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, cast
+
+from app.adapters.redis_client import get_client, k_task_stream
+from app.ports.task_queue import QueuedStep
+
+logger = logging.getLogger(__name__)
+
+GROUP = "dispatchers"
+# Cap stream growth — acked entries are trimmed approximately, far above the
+# expected in-flight depth so we never drop an un-consumed step.
+_MAXLEN = 10_000
+
+
+def _decode(value: Any) -> str:
+    """Redis may return bytes or str depending on client decode settings."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return str(value)
+
+
+def _decode_fields(raw: dict[Any, Any]) -> dict[str, str]:
+    return {_decode(k): _decode(v) for k, v in raw.items()}
+
+
+@dataclass
+class TaskQueueAdapter:
+    """Per-user durable step queue. One stream + one shared consumer group;
+    each backend instance is a distinct consumer (``consumer_name``)."""
+
+    user_id: str
+    consumer_name: str
+
+    @property
+    def _key(self) -> str:
+        return k_task_stream(self.user_id)
+
+    async def _ensure_group(self) -> None:
+        """Create the consumer group idempotently (mkstream so the stream exists
+        even before the first enqueue). Swallow BUSYGROUP — already created."""
+        client = get_client()
+        try:
+            await client.xgroup_create(
+                self._key, GROUP, id="0", mkstream=True,
+            )
+        except Exception as exc:  # redis.ResponseError: BUSYGROUP
+            if "BUSYGROUP" not in str(exc):
+                raise
+
+    async def enqueue(self, fields: dict[str, str]) -> str:
+        client = get_client()
+        # redis-py's stub types the field mapping invariantly over a broad
+        # bytes|str|int|float union; our str→str payload is a valid subset.
+        message_id = await client.xadd(
+            self._key,
+            cast("dict[Any, Any]", fields),
+            maxlen=_MAXLEN,
+            approximate=True,
+        )
+        return _decode(message_id)
+
+    async def consume(self, count: int = 1, block_ms: int = 0) -> list[QueuedStep]:
+        await self._ensure_group()
+        client = get_client()
+        # ">" = only messages never delivered to any consumer in this group.
+        resp = await client.xreadgroup(
+            GROUP,
+            self.consumer_name,
+            {self._key: ">"},
+            count=count,
+            block=block_ms or None,
+        )
+        return self._flatten(resp)
+
+    async def ack(self, message_id: str) -> None:
+        client = get_client()
+        await client.xack(self._key, GROUP, message_id)
+
+    async def reclaim(self, min_idle_ms: int, count: int = 10) -> list[QueuedStep]:
+        """Re-claim messages idle longer than ``min_idle_ms`` — the crash-recovery
+        path. Uses XAUTOCLAIM (Redis 6.2+) to transfer ownership of stale pending
+        entries to this consumer and return them for re-processing."""
+        await self._ensure_group()
+        client = get_client()
+        # XAUTOCLAIM returns (next_cursor, claimed_entries, deleted_ids).
+        result = await client.xautoclaim(
+            self._key,
+            GROUP,
+            self.consumer_name,
+            min_idle_time=min_idle_ms,
+            start_id="0-0",
+            count=count,
+        )
+        entries = result[1] if len(result) >= 2 else []
+        return self._to_steps(entries, reclaimed=True)
+
+    def _flatten(self, resp: Any) -> list[QueuedStep]:
+        """XREADGROUP returns [(stream_key, [(id, fields), ...])]."""
+        if not resp:
+            return []
+        steps: list[QueuedStep] = []
+        for _stream, entries in resp:
+            steps.extend(self._to_steps(entries, reclaimed=False))
+        return steps
+
+    def _to_steps(self, entries: Any, *, reclaimed: bool) -> list[QueuedStep]:
+        steps: list[QueuedStep] = []
+        for entry_id, raw_fields in entries or []:
+            if raw_fields is None:
+                # XAUTOCLAIM can surface ids whose payload was trimmed/deleted;
+                # nothing to process, but the id should still be ackable.
+                continue
+            steps.append(
+                QueuedStep(
+                    message_id=_decode(entry_id),
+                    fields=_decode_fields(raw_fields),
+                    delivery_count=2 if reclaimed else 1,
+                )
+            )
+        return steps

--- a/app/ports/task_queue.py
+++ b/app/ports/task_queue.py
@@ -1,0 +1,54 @@
+"""Port for a durable task queue — survives backend restart (GAP-2).
+
+The orchestrator enqueues task steps as messages on a stream; a consumer
+(the dispatcher) reads them in a consumer group, processes each, and acks on
+success. Messages that were delivered but never acked (the backend crashed
+mid-step) can be re-claimed and re-delivered — that is the durability guarantee
+an in-process loop cannot give.
+
+Depending on a Protocol (not the concrete ``TaskQueueAdapter``) keeps the
+orchestrator hexagonal-clean and testable with an in-memory fake.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class QueuedStep:
+    """One delivered queue message.
+
+    ``message_id`` is the stream entry id used to ack/claim. ``fields`` is the
+    decoded payload (str→str) the consumer needs to dispatch the step.
+    ``delivery_count`` is how many times this message has been delivered — >1
+    means it was re-claimed after a crash, so the consumer can decide to give
+    up after N attempts instead of looping forever.
+    """
+
+    message_id: str
+    fields: dict[str, str] = field(default_factory=dict)
+    delivery_count: int = 1
+
+
+class TaskQueuePort(Protocol):
+    async def enqueue(self, fields: dict[str, str]) -> str:
+        """Append a step to the queue. Returns the stream message id."""
+        ...
+
+    async def consume(
+        self, count: int = 1, block_ms: int = 0,
+    ) -> list[QueuedStep]:
+        """Read up to ``count`` new messages for this consumer (XREADGROUP)."""
+        ...
+
+    async def ack(self, message_id: str) -> None:
+        """Acknowledge a processed message so it leaves the pending list."""
+        ...
+
+    async def reclaim(
+        self, min_idle_ms: int, count: int = 10,
+    ) -> list[QueuedStep]:
+        """Re-claim messages idle longer than ``min_idle_ms`` (crash recovery)."""
+        ...

--- a/docs/ORCHESTRATOR.md
+++ b/docs/ORCHESTRATOR.md
@@ -153,11 +153,13 @@ Tiap item = satu PR (sesuai aturan repo: satu concern, conventional commit, CI h
 - Capability-aware pick di `worker_ws._pick_worker` (pakai `k_caps`).
 - Test: matriks role × caps → agent/model benar; fallback saat cap absen.
 
-### PR-3 — Task queue durable *(GAP-2)*
-- Adapter `app/adapters/task_queue.py` pakai **Redis Streams** (`XADD`/`XREADGROUP`).
-  Tidak perlu Celery/RQ — Redis sudah ada di stack swarm.
-- Step di-*enqueue*, konsumer = dispatcher; ack saat `job_done`, re-deliver saat crash.
-- Test: enqueue → consume → ack; pending re-claim setelah "crash".
+### PR-3 — Task queue durable *(GAP-2)* ✅ DONE (#TBD)
+- Adapter `app/adapters/task_queue.py` pakai **Redis Streams** (`XADD`/`XREADGROUP`
+  + consumer group `dispatchers`). Tidak perlu Celery/RQ — Redis sudah ada di stack.
+- Step di-*enqueue*, konsumer = dispatcher; `ack` saat selesai, `reclaim`
+  (`XAUTOCLAIM`, idle > threshold) re-deliver pending yang nyangkut saat crash.
+- Port `app/ports/task_queue.py` (`TaskQueuePort`, `QueuedStep`) — hexagonal.
+- Test: enqueue → consume → ack; pending re-claim setelah "crash" (10 test).
 
 ### PR-4 — Rantai PM → Issue → Worker → Close *(GAP-3)*
 - `app/orchestrator/task_runner.py`: `TaskPlan` → buat GitHub Issue (PRD + steps

--- a/tests/adapters/test_task_queue.py
+++ b/tests/adapters/test_task_queue.py
@@ -1,0 +1,238 @@
+"""Unit tests for TaskQueueAdapter — durable queue via Redis Streams (GAP-2).
+
+Redis is replaced by an in-memory fake that models the parts of consumer-group
+semantics we rely on: a stream of (id, fields), a pending entries list (PEL)
+per group with idle timing, XACK removal, and XAUTOCLAIM re-delivery. This lets
+us prove enqueue → consume → ack and the crash-recovery (reclaim) path without
+a real Redis.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.adapters.task_queue import GROUP, TaskQueueAdapter
+
+
+class FakeStreamRedis:
+    """Minimal Redis-Streams fake: one stream, one group, a PEL with idle time."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, dict[str, dict[str, str]]] = {}  # key -> {id: fields}
+        self._seq = 0
+        self._groups: dict[str, dict[str, str]] = {}  # key -> last-delivered cursor
+        # PEL: key -> {id: idle_ms}. idle_ms is set explicitly by tests.
+        self._pending: dict[str, dict[str, int]] = {}
+
+    def _next_id(self) -> str:
+        self._seq += 1
+        return f"{self._seq}-0"
+
+    async def xadd(
+        self, key: str, fields: dict[str, str], maxlen: int = 0, approximate: bool = True
+    ) -> str:
+        entry_id = self._next_id()
+        self._entries.setdefault(key, {})[entry_id] = dict(fields)
+        return entry_id
+
+    async def xgroup_create(
+        self, key: str, group: str, id: str = "0", mkstream: bool = False
+    ) -> bool:
+        gkey = f"{key}:{group}"
+        if gkey in self._groups:
+            raise RuntimeError("BUSYGROUP Consumer Group name already exists")
+        self._entries.setdefault(key, {})
+        self._groups[gkey] = id
+        self._pending.setdefault(key, {})
+        return True
+
+    async def xreadgroup(
+        self,
+        group: str,
+        consumer: str,
+        streams: dict[str, str],
+        count: int = 1,
+        block: int | None = None,
+    ) -> list[Any]:
+        out: list[Any] = []
+        for key in streams:
+            entries = self._entries.get(key, {})
+            pending = self._pending.setdefault(key, {})
+            gkey = f"{key}:{group}"
+            cursor = self._groups.get(gkey, "0")
+            new: list[tuple[str, dict[str, str]]] = []
+            for eid, fields in entries.items():
+                if eid in pending:
+                    continue
+                if self._id_gt(eid, cursor):
+                    new.append((eid, fields))
+                if len(new) >= count:
+                    break
+            for eid, _ in new:
+                pending[eid] = 0  # freshly delivered → idle 0
+                self._groups[gkey] = eid
+            if new:
+                out.append((key, new))
+        return out
+
+    async def xack(self, key: str, group: str, message_id: str) -> int:
+        pending = self._pending.get(key, {})
+        return 1 if pending.pop(message_id, None) is not None else 0
+
+    async def xautoclaim(
+        self,
+        key: str,
+        group: str,
+        consumer: str,
+        min_idle_time: int,
+        start_id: str = "0-0",
+        count: int = 10,
+    ) -> tuple[str, list[Any], list[str]]:
+        pending = self._pending.get(key, {})
+        entries = self._entries.get(key, {})
+        claimed: list[tuple[str, dict[str, str] | None]] = []
+        for eid, idle in sorted(pending.items()):
+            if idle >= min_idle_time:
+                claimed.append((eid, entries.get(eid)))
+                pending[eid] = 0  # claimed → idle resets
+            if len(claimed) >= count:
+                break
+        return "0-0", claimed, []
+
+    @staticmethod
+    def _id_gt(a: str, b: str) -> bool:
+        return int(a.split("-")[0]) > int(b.split("-")[0])
+
+    # Test helper: simulate time passing for delivered-but-unacked messages.
+    def age_pending(self, key: str, idle_ms: int) -> None:
+        for eid in self._pending.get(key, {}):
+            self._pending[key][eid] = idle_ms
+
+
+@pytest.fixture
+def fake(monkeypatch: pytest.MonkeyPatch) -> FakeStreamRedis:
+    f = FakeStreamRedis()
+    monkeypatch.setattr("app.adapters.task_queue.get_client", lambda: f)
+    return f
+
+
+@pytest.fixture
+def queue() -> TaskQueueAdapter:
+    return TaskQueueAdapter(user_id="u1", consumer_name="backend-a")
+
+
+# ── enqueue → consume → ack ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enqueue_returns_message_id(fake: FakeStreamRedis, queue: TaskQueueAdapter) -> None:
+    mid = await queue.enqueue({"step": "1", "desc": "do thing"})
+    assert mid
+    assert "-" in mid
+
+
+@pytest.mark.asyncio
+async def test_consume_returns_enqueued_step(
+    fake: FakeStreamRedis, queue: TaskQueueAdapter
+) -> None:
+    await queue.enqueue({"step": "1", "desc": "build"})
+
+    steps = await queue.consume(count=10)
+
+    assert len(steps) == 1
+    assert steps[0].fields == {"step": "1", "desc": "build"}
+    assert steps[0].delivery_count == 1
+
+
+@pytest.mark.asyncio
+async def test_consume_respects_count(fake: FakeStreamRedis, queue: TaskQueueAdapter) -> None:
+    for i in range(5):
+        await queue.enqueue({"step": str(i)})
+
+    first = await queue.consume(count=2)
+    assert len(first) == 2
+
+    rest = await queue.consume(count=10)
+    assert len(rest) == 3
+
+
+@pytest.mark.asyncio
+async def test_consumed_messages_not_redelivered_until_acked(
+    fake: FakeStreamRedis, queue: TaskQueueAdapter
+) -> None:
+    await queue.enqueue({"step": "1"})
+    await queue.consume(count=10)
+
+    # Already in PEL (delivered, unacked) → a fresh ">" read sees nothing new.
+    again = await queue.consume(count=10)
+    assert again == []
+
+
+@pytest.mark.asyncio
+async def test_ack_removes_from_pending(fake: FakeStreamRedis, queue: TaskQueueAdapter) -> None:
+    await queue.enqueue({"step": "1"})
+    steps = await queue.consume(count=10)
+    await queue.ack(steps[0].message_id)
+
+    # Nothing left pending → reclaim finds nothing even at idle 0.
+    fake.age_pending(queue._key, 999_999)
+    reclaimed = await queue.reclaim(min_idle_ms=1)
+    assert reclaimed == []
+
+
+# ── crash recovery: reclaim ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reclaim_redelivers_stale_pending(
+    fake: FakeStreamRedis, queue: TaskQueueAdapter
+) -> None:
+    await queue.enqueue({"step": "1", "desc": "half done"})
+    await queue.consume(count=10)  # delivered but never acked (simulated crash)
+
+    fake.age_pending(queue._key, 60_000)  # 60s idle
+
+    reclaimed = await queue.reclaim(min_idle_ms=30_000)
+
+    assert len(reclaimed) == 1
+    assert reclaimed[0].fields == {"step": "1", "desc": "half done"}
+    assert reclaimed[0].delivery_count == 2  # marks it as a redelivery
+
+
+@pytest.mark.asyncio
+async def test_reclaim_ignores_fresh_pending(
+    fake: FakeStreamRedis, queue: TaskQueueAdapter
+) -> None:
+    await queue.enqueue({"step": "1"})
+    await queue.consume(count=10)  # idle 0
+
+    reclaimed = await queue.reclaim(min_idle_ms=30_000)
+    assert reclaimed == []
+
+
+@pytest.mark.asyncio
+async def test_consume_creates_group_idempotently(
+    fake: FakeStreamRedis, queue: TaskQueueAdapter
+) -> None:
+    # Two consumes in a row must not raise on BUSYGROUP.
+    await queue.enqueue({"step": "1"})
+    await queue.consume(count=1)
+    await queue.enqueue({"step": "2"})
+    second = await queue.consume(count=10)
+    assert len(second) == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_queue_consume_returns_empty(
+    fake: FakeStreamRedis, queue: TaskQueueAdapter
+) -> None:
+    assert await queue.consume(count=10) == []
+
+
+@pytest.mark.asyncio
+async def test_group_constant_used(fake: FakeStreamRedis, queue: TaskQueueAdapter) -> None:
+    await queue.enqueue({"step": "1"})
+    await queue.consume(count=1)
+    assert f"{queue._key}:{GROUP}" in fake._groups


### PR DESCRIPTION
## What
Adds a **durable task queue** (GAP-2 in ORCHESTRATOR.md) so orchestrator steps survive a backend restart — the property an in-process loop cannot give.

## How
- **`app/adapters/task_queue.py`** — Redis Streams + consumer group `dispatchers`:
  - `enqueue` (XADD), `consume` (XREADGROUP `>`), `ack` (XACK)
  - `reclaim` (XAUTOCLAIM, idle > threshold) → re-delivers pending entries stuck when the backend crashed mid-step. `delivery_count=2` marks redeliveries so the consumer can cap retries.
- **`app/ports/task_queue.py`** — `TaskQueuePort` Protocol + `QueuedStep` value object (hexagonal).
- **`redis_client.py`** — `k_task_stream(user_id)` key helper.
- No Celery/RQ — Redis is already in the stack.

## Tests
10 new tests with an in-memory Redis-Streams fake (PEL + idle timing): enqueue→consume→ack, no redelivery until acked, ack removes from pending, **reclaim re-delivers stale pending** (crash recovery), reclaim ignores fresh pending, idempotent group creation.

611 passed (+10) · ruff (app+tests) · mypy (128 files) all green.

## Note
Adapter is tested + ready; wiring into the dispatcher loop is a separate concern (next PR), kept out to keep this one-concern.