### PR TITLE
feat: wire task runner to tasks endpoint and task command

### DIFF
--- a/app/composition.py
+++ b/app/composition.py
@@ -27,6 +27,7 @@ from app.adapters.ollama import OllamaAdapter
 from app.adapters.rate_limit import RedisRateLimiter
 from app.adapters.redis_client import get_sync_client
 from app.adapters.worker_dispatch import WorkerDispatchAdapter
+from app.agents.pm import PMAgent
 from app.config import BASE_DIR, settings
 from app.domain.use_cases import HandleMessageUseCase
 from app.executor.actions import ActionRegistry
@@ -36,6 +37,7 @@ from app.intents.parser import IntentParser
 from app.memory.context_store import ProjectContextStore
 from app.orchestrator.approval import PendingPlanStore
 from app.orchestrator.plans import PlanGenerator
+from app.orchestrator.task_runner import TaskRunner
 from app.orchestrator.workflow import WorkflowOrchestrator
 from app.ports.embedder import Embedder
 from app.ports.knowledge_store import KnowledgeStore
@@ -158,6 +160,22 @@ def _workflow_orchestrator() -> WorkflowOrchestrator:
 def build_workflow_orchestrator() -> WorkflowOrchestrator:
     """Compose the architect→engineer→reviewer orchestrator (prompt fallback)."""
     return _workflow_orchestrator()
+
+
+def build_task_runner() -> TaskRunner:
+    """Compose the PM→Issue→Worker→Close task runner (orchestrator end-to-end).
+
+    Raises ``GitHubUnavailableError`` when GITHUB_TOKEN/REPO are unset — the
+    caller (endpoint) maps that to a 503 so the failure is explicit, not silent.
+    """
+    from app.adapters.github import GitHubAdapter
+
+    github = GitHubAdapter(token=settings.github_token, repo=settings.github_repo)
+    return TaskRunner(
+        pm=PMAgent(ai_provider=_ollama()),
+        github=github,
+        dispatch=WorkerDispatchAdapter(),
+    )
 
 
 def build_use_case() -> HandleMessageUseCase:

--- a/app/interfaces/gateway.py
+++ b/app/interfaces/gateway.py
@@ -10,6 +10,7 @@ from app.interfaces.auth import router as auth_router
 from app.interfaces.chat import router as chat_router
 from app.interfaces.context import router as context_router
 from app.interfaces.skills import router as skills_router
+from app.interfaces.tasks import router as tasks_router
 from app.interfaces.worker_ws import router as worker_ws_router
 from app.interfaces.workflow import router as workflow_router
 
@@ -47,6 +48,7 @@ app.include_router(admin_router)
 app.include_router(chat_router)
 app.include_router(context_router)
 app.include_router(skills_router)
+app.include_router(tasks_router)
 app.include_router(workflow_router)
 app.include_router(worker_ws_router)
 

--- a/app/interfaces/tasks.py
+++ b/app/interfaces/tasks.py
@@ -1,0 +1,106 @@
+"""HTTP endpoint for the orchestrator task runner — PM→Issue→Worker→Close.
+
+Flow:
+1. Client POSTs ``/tasks/run`` with ``{"request": "...", "as_email": "x@y.com"}``.
+2. Auth: same model as ``/chat/send`` — Bearer ADMIN_TOKEN (admin runs a task
+   as user X via ``as_email``) or a session token (runs as that user).
+3. Backend builds the ``TaskRunner`` via composition and runs the chain: PM
+   decomposes the request → a GitHub Issue records it → each step dispatches to
+   a worker (routed by role) → the issue is commented per step and closed on
+   success.
+
+Unlike ``/chat/send`` this returns a single JSON ``TaskResult`` (not SSE): a
+task is a durable unit recorded in the issue, so the issue URL is the live view,
+and the response is just the final summary.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Header, HTTPException, status
+from pydantic import BaseModel
+
+from app.adapters.github import GitHubUnavailableError
+from app.composition import build_task_runner
+from app.interfaces.chat import _resolve_admin_target, _resolve_caller
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+
+class TaskRunRequest(BaseModel):
+    request: str
+    context: str = ""
+    # Only used when the caller is the admin token (run a task as user X).
+    as_email: str | None = None
+
+
+class StepOutcomeOut(BaseModel):
+    order: int
+    description: str
+    role: str
+    ok: bool
+    detail: str = ""
+
+
+class TaskRunResponse(BaseModel):
+    ok: bool
+    issue_number: int | None
+    issue_url: str
+    closed: bool
+    note: str
+    summary: str
+    outcomes: list[StepOutcomeOut]
+
+
+@router.post("/run", response_model=TaskRunResponse)
+async def run_task(
+    req: Annotated[TaskRunRequest, Body(...)],
+    authorization: str | None = Header(default=None),
+) -> TaskRunResponse:
+    request_text = req.request.strip()
+    if not request_text:
+        raise HTTPException(status_code=400, detail="request is empty")
+
+    caller_user_id, mode = _resolve_caller(authorization)
+    if mode == "admin":
+        if not req.as_email:
+            raise HTTPException(
+                status_code=400,
+                detail="admin token requires 'as_email' field",
+            )
+        user_id = _resolve_admin_target(req.as_email)
+    else:
+        user_id = caller_user_id
+
+    try:
+        runner = build_task_runner()
+    except GitHubUnavailableError as exc:
+        # Explicit, not silent — task tracking needs GitHub configured.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"task runner unavailable: {exc}",
+        ) from exc
+
+    result = await runner.run(user_id, request_text, req.context)
+
+    return TaskRunResponse(
+        ok=result.ok,
+        issue_number=result.issue_number,
+        issue_url=result.issue_url,
+        closed=result.closed,
+        note=result.note,
+        summary=result.plan.summary,
+        outcomes=[
+            StepOutcomeOut(
+                order=o.order,
+                description=o.description,
+                role=o.role,
+                ok=o.ok,
+                detail=o.detail,
+            )
+            for o in result.outcomes
+        ],
+    )

--- a/docs/ORCHESTRATOR.md
+++ b/docs/ORCHESTRATOR.md
@@ -167,6 +167,14 @@ Tiap item = satu PR (sesuai aturan repo: satu concern, conventional commit, CI h
   reflect → `close_issue` saat semua step satisfied.
 - Test: plan 2-step → mock github + mock dispatcher → issue dibuat, dikomentari, ditutup.
 
+### Wiring end-to-end ✅ DONE (#TBD)
+- `composition.build_task_runner()` — rakit `PMAgent` + `GitHubAdapter` + `WorkerDispatchAdapter`.
+- Endpoint Core `POST /tasks/run` (`app/interfaces/tasks.py`) — auth admin/session
+  sama seperti `/chat/send`; 503 eksplisit kalau GITHUB_TOKEN/REPO kosong.
+- Command Telegram `/task <deskripsi>` (`telegram-adapter/main.py`) → panggil
+  `/tasks/run`, tampilkan link issue + status tiap step + apakah ditutup.
+- Test: 7 endpoint test (closed/failed/no-step/503/admin-needs-email).
+
 ### PR-5 — Observability *(opsional, mempertajam)*
 - Structured log `[TIME][ROLE][TASK_ID][STATUS]` + korelasi `job_id`/`issue`.
 - Endpoint `/tasks` untuk TUI task board (data sudah di job_store + issue).

--- a/telegram-adapter/main.py
+++ b/telegram-adapter/main.py
@@ -148,6 +148,27 @@ async def _call_core(user_email: str, user_text: str) -> tuple[str, list[str]]:
 
     return final_text, status_log
 
+async def _run_task(user_email: str, request_text: str) -> dict | None:
+    """POST ke Core /tasks/run. Return TaskResult dict atau None kalau gagal."""
+    headers = {
+        "Authorization": f"Bearer {ADMIN_TOKEN}",
+        "Content-Type": "application/json",
+    }
+    payload = {"request": request_text, "as_email": user_email}
+    try:
+        async with httpx.AsyncClient(timeout=300) as client:
+            resp = await client.post(
+                f"{CORE_URL}/tasks/run", headers=headers, json=payload
+            )
+        if resp.status_code == 503:
+            return {"_unavailable": resp.json().get("detail", "task runner unavailable")}
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:
+        logger.warning("run_task failed: %s", exc)
+        return None
+
+
 # ── Handlers ──────────────────────────────────────────────────────────────────
 
 _NOT_PAIRED_MSG = (
@@ -204,6 +225,70 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.message.reply_text(_NOT_PAIRED_MSG)
 
 
+async def task_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """/task <request> — jalankan orchestrator: PM→Issue→Worker→Close."""
+    assert update.message is not None
+    user = update.effective_user
+    if user is None:
+        return
+
+    request_text = " ".join(context.args or []).strip()
+    if not request_text:
+        await update.message.reply_text(
+            "Pakai format: `/task <deskripsi tugas>`\n\n"
+            "Contoh: `/task tambah endpoint health check dengan test`",
+            parse_mode="Markdown",
+        )
+        return
+
+    user_info = await _resolve_user(user.id)
+    if user_info is None:
+        await update.message.reply_text(_NOT_PAIRED_MSG)
+        return
+    email = user_info.get("email", "")
+    if not email:
+        await update.message.reply_text("❌ Akun belum punya email — coba pair ulang.")
+        return
+
+    status_msg = await update.message.reply_text(
+        "🧩 Merencanakan task & membuat GitHub Issue..."
+    )
+
+    result = await _run_task(email, request_text)
+    if result is None:
+        await status_msg.edit_text("❌ Gagal menjalankan task (Core tidak merespons).")
+        return
+    if result.get("_unavailable"):
+        await status_msg.edit_text(f"⚠️ {result['_unavailable']}")
+        return
+
+    lines: list[str] = []
+    issue_url = result.get("issue_url", "")
+    issue_number = result.get("issue_number")
+    if issue_number:
+        lines.append(f"📋 Issue [#{issue_number}]({issue_url})")
+    summary = result.get("summary", "")
+    if summary:
+        lines.append(f"_{summary}_")
+    lines.append("")
+    for o in result.get("outcomes", []):
+        mark = "✅" if o.get("ok") else "❌"
+        lines.append(f"{mark} {o.get('order')}. {o.get('description')} ({o.get('role')})")
+    lines.append("")
+    if result.get("closed"):
+        lines.append("🎉 Semua step selesai — issue ditutup.")
+    elif not result.get("outcomes"):
+        lines.append(f"📭 {result.get('note', 'tidak ada step untuk dijalankan')}")
+    else:
+        lines.append(f"⏸️ {result.get('note', 'berhenti')} — issue tetap terbuka untuk resume.")
+
+    reply = "\n".join(lines)
+    if len(reply) > MAX_TELEGRAM_CHARS:
+        reply = reply[:MAX_TELEGRAM_CHARS] + "\n…(dipotong)"
+    with contextlib.suppress(Exception):
+        await status_msg.edit_text(reply, parse_mode="Markdown")
+
+
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not update.message or not update.message.text:
         return
@@ -251,6 +336,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 def build_app() -> Application:
     app = Application.builder().token(BOT_TOKEN).build()
     app.add_handler(CommandHandler("start", cmd_start))
+    app.add_handler(CommandHandler("task", task_cmd))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
     return app
 

--- a/tests/interfaces/test_tasks_endpoints.py
+++ b/tests/interfaces/test_tasks_endpoints.py
@@ -1,0 +1,145 @@
+"""Endpoint tests for /tasks/run — wires the PM→Issue→Worker→Close runner.
+
+The TaskRunner is replaced by a fake (so no real PM / GitHub / worker is hit);
+auth is patched the same way the workflow endpoint tests do. This proves the
+HTTP contract: a request runs the chain and the JSON result mirrors TaskResult.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.adapters.github import GitHubUnavailableError
+from app.agents.pm import TaskPlan, TaskStep
+from app.interfaces import tasks as tasks_iface
+from app.orchestrator.task_runner import StepOutcome, TaskResult
+
+USER = "user-1"
+
+
+class FakeTaskRunner:
+    def __init__(self) -> None:
+        self.result: TaskResult | None = None
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def run(self, user_id: str, request: str, context: str = "") -> TaskResult:
+        self.calls.append((user_id, request, context))
+        assert self.result is not None
+        return self.result
+
+
+def _plan() -> TaskPlan:
+    return TaskPlan(
+        title="Add health endpoint",
+        summary="add a /health route with a test",
+        steps=[TaskStep(order=1, description="write route", action="file_write", params={})],
+        estimated_complexity="simple",
+    )
+
+
+@pytest.fixture
+def fake() -> FakeTaskRunner:
+    return FakeTaskRunner()
+
+
+@pytest.fixture
+def client(fake: FakeTaskRunner, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setattr(tasks_iface, "build_task_runner", lambda: fake)
+    monkeypatch.setattr(tasks_iface, "_resolve_caller", lambda _a: (USER, "user"))
+    app = FastAPI()
+    app.include_router(tasks_iface.router)
+    yield TestClient(app)
+
+
+def test_empty_request_rejected(client: TestClient) -> None:
+    assert client.post("/tasks/run", json={"request": "  "}).status_code == 400
+
+
+def test_run_returns_closed_task(client: TestClient, fake: FakeTaskRunner) -> None:
+    plan = _plan()
+    fake.result = TaskResult(
+        plan=plan,
+        issue_number=42,
+        issue_url="https://github.com/o/r/issues/42",
+        outcomes=[StepOutcome(order=1, description="write route", role="engineer", ok=True, detail="done")],
+        closed=True,
+        note="completed",
+    )
+
+    resp = client.post("/tasks/run", json={"request": "add health endpoint"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["issue_number"] == 42
+    assert body["closed"] is True
+    assert body["summary"] == "add a /health route with a test"
+    assert body["outcomes"][0]["role"] == "engineer"
+    assert fake.calls == [(USER, "add health endpoint", "")]
+
+
+def test_run_passes_context(client: TestClient, fake: FakeTaskRunner) -> None:
+    fake.result = TaskResult(plan=_plan(), issue_number=1, issue_url="u", outcomes=[
+        StepOutcome(order=1, description="x", role="engineer", ok=True),
+    ], closed=True)
+
+    resp = client.post("/tasks/run", json={"request": "do x", "context": "repo foo"})
+
+    assert resp.status_code == 200
+    assert fake.calls[0][2] == "repo foo"
+
+
+def test_run_failed_task_left_open(client: TestClient, fake: FakeTaskRunner) -> None:
+    fake.result = TaskResult(
+        plan=_plan(),
+        issue_number=7,
+        issue_url="https://github.com/o/r/issues/7",
+        outcomes=[StepOutcome(order=1, description="write route", role="engineer", ok=False, detail="boom")],
+        closed=False,
+        note="stopped at step 1 (engineer): boom",
+    )
+
+    body = client.post("/tasks/run", json={"request": "x"}).json()
+
+    assert body["ok"] is False
+    assert body["closed"] is False
+    assert "stopped at step 1" in body["note"]
+
+
+def test_run_no_steps_no_issue(client: TestClient, fake: FakeTaskRunner) -> None:
+    empty_plan = TaskPlan(title="", summary="nothing to do", steps=[], estimated_complexity="simple")
+    fake.result = TaskResult(plan=empty_plan, issue_number=None, issue_url="", note="no steps to execute")
+
+    body = client.post("/tasks/run", json={"request": "hi"}).json()
+
+    assert body["ok"] is False
+    assert body["issue_number"] is None
+    assert body["outcomes"] == []
+
+
+def test_run_503_when_github_unconfigured(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _boom() -> object:
+        raise GitHubUnavailableError("GITHUB_TOKEN tidak diisi.")
+
+    monkeypatch.setattr(tasks_iface, "build_task_runner", _boom)
+    resp = client.post("/tasks/run", json={"request": "x"})
+    assert resp.status_code == 503
+    assert "unavailable" in resp.json()["detail"]
+
+
+def test_admin_requires_as_email(monkeypatch: pytest.MonkeyPatch, fake: FakeTaskRunner) -> None:
+    monkeypatch.setattr(tasks_iface, "build_task_runner", lambda: fake)
+    monkeypatch.setattr(tasks_iface, "_resolve_caller", lambda _a: ("__ADMIN__", "admin"))
+    app = FastAPI()
+    app.include_router(tasks_iface.router)
+    c = TestClient(app)
+
+    resp = c.post("/tasks/run", json={"request": "x"})
+    assert resp.status_code == 400
+    assert "as_email" in resp.json()["detail"]


### PR DESCRIPTION
## What
Wires the orchestrator chain (PM→Issue→Worker→Close) to **real entry points** so a user can trigger it end-to-end. Until now TaskRunner + queue + router existed and were unit-tested but nothing called them.

## How
- **`composition.build_task_runner()`** — assembles `PMAgent` + `GitHubAdapter` + `WorkerDispatchAdapter` (hexagonal: depends on ports).
- **`POST /tasks/run`** (`app/interfaces/tasks.py`) — new Core endpoint. Same auth model as `/chat/send` (admin token + `as_email`, or session token). Returns a single JSON `TaskResult` (issue url + per-step outcomes + closed/note). Maps `GitHubUnavailableError` → **503** so a missing GITHUB_TOKEN/REPO fails explicitly, not silently.
- **`/task <deskripsi>`** Telegram command (`telegram-adapter/main.py`) — calls `/tasks/run`, renders the issue link, per-step status, and whether it closed.
- Registered the router in `gateway.py`.

## Why a single JSON (not SSE like /chat)
A task is a durable unit recorded in the GitHub Issue — the issue is the live view, so the response just needs the final summary.

## Tests
7 new endpoint tests (fake TaskRunner + patched auth): closed task, context passthrough, failed task left open, no-step plan (no issue), **503 when GitHub unconfigured**, admin-requires-as_email, empty request rejected.

```
618 passed (+7) · ruff (app+tests+adapter) · mypy (129 files) all green
```

## Result
The orchestrator is now triggerable end-to-end: `/task add health endpoint with tests` → PM plans → GitHub Issue opens → each step routes to a worker by role → issue commented per step → closed on success.