### PR TITLE
feat: add task observability with structured logs and tasks board

### DIFF
--- a/app/adapters/redis_client.py
+++ b/app/adapters/redis_client.py
@@ -119,6 +119,11 @@ def k_task_stream(user_id: str) -> str:
     return f"task:stream:{user_id}"
 
 
+def k_task_events() -> str:
+    """Stream of task lifecycle events for the /tasks board — PR-5."""
+    return "task:events"
+
+
 def k_agent_ctx(session_id: str) -> str:
     return f"agent:ctx:{session_id}"
 

--- a/app/adapters/task_observer.py
+++ b/app/adapters/task_observer.py
@@ -1,0 +1,109 @@
+"""Task observability adapter — structured stdout log + Redis events stream (PR-5).
+
+Two best-effort sinks, mirroring the audit adapter's split:
+
+1. **stdout** via the stdlib logger — every event becomes a one-line
+   ``[ROLE][TASK_ID][STATUS] message`` record. Captured by ``docker logs -f`` /
+   ``docker service logs`` so the user can follow a task live with no extra infra.
+2. **Redis stream** (``task:events``, capped) — structured rows the ``GET /tasks``
+   board reads back to show recent tasks and their last status without SSH.
+
+Implements ``app.ports.task_events.TaskObserver``. Methods are sync and never
+raise — observability must not break task execution.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from app.adapters.redis_client import get_sync_client, k_task_events
+
+logger = logging.getLogger("octopus.tasks")
+
+_MAX_EVENTS = 5000
+
+
+def _emit(task_id: str, role: str, status: str, message: str, **extra: str) -> None:
+    """Log to stdout and append to the Redis events stream. Best-effort."""
+    logger.info("[%s][%s][%s] %s", role, task_id, status, message)
+    try:
+        client = get_sync_client()
+        fields = {
+            "ts": datetime.now(UTC).isoformat(),
+            "task_id": task_id,
+            "role": role,
+            "status": status,
+            "message": message[:500],
+            **extra,
+        }
+        client.xadd(
+            k_task_events(),
+            cast("dict[Any, Any]", fields),
+            maxlen=_MAX_EVENTS,
+            approximate=True,
+        )
+    except Exception as exc:  # Redis hiccup must not break the task.
+        logger.warning("task event stream append failed: %s", exc)
+
+
+class LoggingTaskObserver:
+    """Concrete TaskObserver — structured stdout + Redis events stream."""
+
+    def task_started(self, task_id: str, user_id: str, request: str) -> None:
+        _emit(task_id, "pm", "started", request[:120], user_id=user_id)
+
+    def issue_opened(self, task_id: str, issue_number: int, issue_url: str) -> None:
+        _emit(
+            task_id, "pm", "issue_opened", f"issue #{issue_number}",
+            issue_number=str(issue_number), issue_url=issue_url,
+        )
+
+    def step_started(self, task_id: str, order: int, role: str, description: str) -> None:
+        _emit(task_id, role, "step_started", f"step {order}: {description[:100]}", order=str(order))
+
+    def step_finished(self, task_id: str, order: int, role: str, ok: bool, detail: str) -> None:
+        status = "step_ok" if ok else "step_failed"
+        _emit(task_id, role, status, f"step {order}: {detail[:100]}", order=str(order))
+
+    def task_finished(self, task_id: str, *, closed: bool, ok: bool, note: str) -> None:
+        status = "closed" if closed else ("done" if ok else "failed")
+        _emit(task_id, "pm", status, note[:200])
+
+
+async def recent_task_events(limit: int = 100) -> list[dict[str, str]]:
+    """Read recent task events (newest first) from the Redis events stream.
+
+    Uses the async client since the /tasks endpoint is async. Best-effort: an
+    unreachable Redis yields an empty list rather than failing the request.
+    """
+    from app.adapters.redis_client import get_client
+
+    try:
+        client = get_client()
+        entries = await client.xrevrange(k_task_events(), count=max(1, limit))
+    except Exception as exc:
+        logger.warning("task events read failed: %s", exc)
+        return []
+
+    out: list[dict[str, str]] = []
+    for entry_id, fields in entries:
+        row = {str(k): str(v) for k, v in fields.items()}
+        row["id"] = str(entry_id)
+        out.append(row)
+    return out
+
+
+def latest_task_states(events: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Collapse the event log into one row per task_id (its most recent event).
+
+    Events arrive newest-first, so the first time we see a task_id is its latest
+    state — exactly what a board wants to show.
+    """
+    seen: dict[str, dict[str, str]] = {}
+    for ev in events:
+        tid = ev.get("task_id", "")
+        if tid and tid not in seen:
+            seen[tid] = ev
+    return list(seen.values())

--- a/app/composition.py
+++ b/app/composition.py
@@ -169,12 +169,14 @@ def build_task_runner() -> TaskRunner:
     caller (endpoint) maps that to a 503 so the failure is explicit, not silent.
     """
     from app.adapters.github import GitHubAdapter
+    from app.adapters.task_observer import LoggingTaskObserver
 
     github = GitHubAdapter(token=settings.github_token, repo=settings.github_repo)
     return TaskRunner(
         pm=PMAgent(ai_provider=_ollama()),
         github=github,
         dispatch=WorkerDispatchAdapter(),
+        observer=LoggingTaskObserver(),
     )
 
 

--- a/app/interfaces/tasks.py
+++ b/app/interfaces/tasks.py
@@ -55,6 +55,44 @@ class TaskRunResponse(BaseModel):
     outcomes: list[StepOutcomeOut]
 
 
+class TaskEventOut(BaseModel):
+    id: str
+    ts: str = ""
+    task_id: str = ""
+    role: str = ""
+    status: str = ""
+    message: str = ""
+    issue_number: str = ""
+    issue_url: str = ""
+
+
+class TaskBoardResponse(BaseModel):
+    tasks: list[TaskEventOut]
+    events: list[TaskEventOut]
+
+
+@router.get("/", response_model=TaskBoardResponse)
+async def task_board(
+    authorization: str | None = Header(default=None),
+    limit: int = 100,
+) -> TaskBoardResponse:
+    """Task board — recent task events + one collapsed row per task (last state).
+
+    Read-only observability view (PR-5): no SSH needed to see what tasks ran and
+    how they ended. Any authenticated caller (admin or session) may read.
+    """
+    from app.adapters.task_observer import latest_task_states, recent_task_events
+
+    _resolve_caller(authorization)  # auth only; board is not user-scoped
+
+    events = await recent_task_events(limit=limit)
+    states = latest_task_states(events)
+    return TaskBoardResponse(
+        tasks=[TaskEventOut(**ev) for ev in states],
+        events=[TaskEventOut(**ev) for ev in events],
+    )
+
+
 @router.post("/run", response_model=TaskRunResponse)
 async def run_task(
     req: Annotated[TaskRunRequest, Body(...)],

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -19,6 +20,9 @@ def _is_dev() -> bool:
 
 def _setup_file_logging(log_dir: Path) -> None:
     log_dir.mkdir(parents=True, exist_ok=True)
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
     handler = RotatingFileHandler(
         log_dir / "server.log",
         maxBytes=5 * 1024 * 1024,
@@ -29,7 +33,16 @@ def _setup_file_logging(log_dir: Path) -> None:
         "%(asctime)s %(levelname)-8s %(name)s  %(message)s",
         datefmt="%Y-%m-%dT%H:%M:%S",
     ))
-    logging.getLogger().addHandler(handler)
+    root.addHandler(handler)
+
+    # Stdout handler so structured task logs ([ROLE][TASK_ID][STATUS]) are
+    # captured by `docker logs -f` / `docker service logs` — the user's live view.
+    stdout = logging.StreamHandler(sys.stdout)
+    stdout.setFormatter(logging.Formatter(
+        "%(asctime)s %(levelname)-8s %(name)s  %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    ))
+    root.addHandler(stdout)
 
 
 def _run_migrations() -> None:

--- a/app/orchestrator/task_runner.py
+++ b/app/orchestrator/task_runner.py
@@ -22,11 +22,13 @@ Hexagonal: depends on ``PMAgentPort``, ``GitHubIssuesPort`` and
 from __future__ import annotations
 
 import logging
+import uuid
 from dataclasses import dataclass, field
 
 from app.agents.pm import TaskPlan
 from app.ports.github_issues import GitHubIssuesPort
 from app.ports.pm_agent import PMAgentPort
+from app.ports.task_events import NullTaskObserver, TaskObserver
 from app.ports.worker_dispatch import AsyncWorkerDispatchPort
 
 logger = logging.getLogger(__name__)
@@ -102,12 +104,18 @@ class TaskRunner:
     github: GitHubIssuesPort
     dispatch: AsyncWorkerDispatchPort
     labels: list[str] = field(default_factory=lambda: ["octopus-task"])
+    observer: TaskObserver = field(default_factory=NullTaskObserver)
 
     async def run(self, user_id: str, request: str, context: str = "") -> TaskResult:
+        task_id = uuid.uuid4().hex[:12]
+        self.observer.task_started(task_id, user_id, request)
         plan = self.pm.plan(request, context)
 
         # No actionable steps → don't open an issue; nothing to track.
         if not plan.steps:
+            self.observer.task_finished(
+                task_id, closed=False, ok=False, note="no steps to execute",
+            )
             return TaskResult(
                 plan=plan, issue_number=None, issue_url="",
                 note="no steps to execute",
@@ -118,10 +126,12 @@ class TaskRunner:
             body=_issue_body(request, plan),
             labels=self.labels,
         )
+        self.observer.issue_opened(task_id, issue.number, issue.url)
 
         outcomes: list[StepOutcome] = []
         for step in sorted(plan.steps, key=lambda s: s.order):
             role = role_for_action(step.action)
+            self.observer.step_started(task_id, step.order, role, step.description)
             result = await self.dispatch.dispatch_async(user_id, role, step.description)
             detail = (result.summary or result.output or result.error)[:500]
             outcome = StepOutcome(
@@ -132,6 +142,7 @@ class TaskRunner:
                 detail=detail,
             )
             outcomes.append(outcome)
+            self.observer.step_finished(task_id, step.order, role, result.ok, detail)
 
             status = "✅" if result.ok else "❌"
             await self.github.comment_issue(
@@ -140,19 +151,22 @@ class TaskRunner:
             )
             if not result.ok:
                 # Stop on first failure — leave issue open for resume/retry.
+                note = f"stopped at step {step.order} ({role}): {result.error or 'failed'}"
+                self.observer.task_finished(task_id, closed=False, ok=False, note=note)
                 return TaskResult(
                     plan=plan,
                     issue_number=issue.number,
                     issue_url=issue.url,
                     outcomes=outcomes,
                     closed=False,
-                    note=f"stopped at step {step.order} ({role}): {result.error or 'failed'}",
+                    note=note,
                 )
 
         await self.github.close_issue(
             issue.number,
             comment=f"All {len(outcomes)} steps completed ✅ — closing.",
         )
+        self.observer.task_finished(task_id, closed=True, ok=True, note="completed")
         return TaskResult(
             plan=plan,
             issue_number=issue.number,

--- a/app/ports/task_events.py
+++ b/app/ports/task_events.py
@@ -1,0 +1,52 @@
+"""Port for observing task lifecycle events — structured observability (PR-5).
+
+The TaskRunner emits lifecycle events (plan ready, issue opened, step started /
+finished, task closed / failed) through this port. A concrete adapter turns
+each into a structured log line ``[TIME][ROLE][TASK_ID][STATUS]`` on stdout
+(captured by ``docker logs``) and an entry on the Redis audit stream (read back
+by ``GET /tasks``).
+
+Keeping it a Protocol means the orchestrator never imports the audit adapter —
+domain depends on the port, and tests inject a recording fake or the no-op.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class TaskObserver(Protocol):
+    def task_started(self, task_id: str, user_id: str, request: str) -> None: ...
+
+    def issue_opened(self, task_id: str, issue_number: int, issue_url: str) -> None: ...
+
+    def step_started(
+        self, task_id: str, order: int, role: str, description: str,
+    ) -> None: ...
+
+    def step_finished(
+        self, task_id: str, order: int, role: str, ok: bool, detail: str,
+    ) -> None: ...
+
+    def task_finished(
+        self, task_id: str, *, closed: bool, ok: bool, note: str,
+    ) -> None: ...
+
+
+class NullTaskObserver:
+    """No-op observer — the default so TaskRunner works without wiring."""
+
+    def task_started(self, task_id: str, user_id: str, request: str) -> None:
+        return None
+
+    def issue_opened(self, task_id: str, issue_number: int, issue_url: str) -> None:
+        return None
+
+    def step_started(self, task_id: str, order: int, role: str, description: str) -> None:
+        return None
+
+    def step_finished(self, task_id: str, order: int, role: str, ok: bool, detail: str) -> None:
+        return None
+
+    def task_finished(self, task_id: str, *, closed: bool, ok: bool, note: str) -> None:
+        return None

--- a/docs/ORCHESTRATOR.md
+++ b/docs/ORCHESTRATOR.md
@@ -175,9 +175,17 @@ Tiap item = satu PR (sesuai aturan repo: satu concern, conventional commit, CI h
   `/tasks/run`, tampilkan link issue + status tiap step + apakah ditutup.
 - Test: 7 endpoint test (closed/failed/no-step/503/admin-needs-email).
 
-### PR-5 — Observability *(opsional, mempertajam)*
-- Structured log `[TIME][ROLE][TASK_ID][STATUS]` + korelasi `job_id`/`issue`.
-- Endpoint `/tasks` untuk TUI task board (data sudah di job_store + issue).
+### PR-5 — Observability ✅ DONE (#TBD)
+- Port `app/ports/task_events.py` (`TaskObserver` Protocol + `NullTaskObserver` no-op).
+- Adapter `app/adapters/task_observer.py` (`LoggingTaskObserver`): tiap event →
+  (1) structured stdout `[ROLE][TASK_ID][STATUS] message` (logger `octopus.tasks`,
+  ke-capture `docker logs -f`/`docker service logs`), (2) Redis Stream `task:events` (capped 5000).
+- TaskRunner emit lifecycle: task_started → issue_opened → step_started/finished → task_finished.
+- Endpoint `GET /tasks` (board): event terbaru + 1 baris per task (state terakhir),
+  via `recent_task_events` + `latest_task_states`. Read-only, auth admin/session.
+- `main.py`: tambah StreamHandler stdout (root INFO) supaya log task kelihatan di `docker logs`.
+- Test: 11 (observer emit/collapse/best-effort + runner lifecycle + board endpoint).
+- **Tanpa infra baru** — no Grafana/Prometheus/Loki; cukup `docker logs -f` + Redis + `/tasks`.
 
 ---
 

--- a/tests/adapters/test_task_observer.py
+++ b/tests/adapters/test_task_observer.py
@@ -1,0 +1,102 @@
+"""Unit tests for task observability — LoggingTaskObserver + board helpers (PR-5).
+
+Redis sync/async clients are faked; we verify events are appended with the
+right structured fields, that a failing Redis never raises, and that the board
+helpers collapse the event log to one row per task (latest state).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.adapters import task_observer as obs
+from app.adapters.task_observer import (
+    LoggingTaskObserver,
+    latest_task_states,
+)
+
+
+class FakeSyncRedis:
+    def __init__(self) -> None:
+        self.added: list[tuple[str, dict[str, str]]] = []
+
+    def xadd(self, key: str, fields: dict[str, str], maxlen: int = 0, approximate: bool = True) -> str:
+        self.added.append((key, dict(fields)))
+        return f"{len(self.added)}-0"
+
+
+class BrokenSyncRedis:
+    def xadd(self, *a: Any, **k: Any) -> str:
+        raise RuntimeError("redis down")
+
+
+@pytest.fixture
+def fake_sync(monkeypatch: pytest.MonkeyPatch) -> FakeSyncRedis:
+    f = FakeSyncRedis()
+    monkeypatch.setattr(obs, "get_sync_client", lambda: f)
+    return f
+
+
+def test_task_started_emits_event(fake_sync: FakeSyncRedis) -> None:
+    LoggingTaskObserver().task_started("t1", "u1", "build the thing")
+    assert len(fake_sync.added) == 1
+    key, fields = fake_sync.added[0]
+    assert key == "task:events"
+    assert fields["task_id"] == "t1"
+    assert fields["status"] == "started"
+    assert fields["role"] == "pm"
+    assert fields["user_id"] == "u1"
+
+
+def test_issue_opened_carries_issue_fields(fake_sync: FakeSyncRedis) -> None:
+    LoggingTaskObserver().issue_opened("t1", 42, "https://gh/issues/42")
+    _, fields = fake_sync.added[0]
+    assert fields["issue_number"] == "42"
+    assert fields["issue_url"] == "https://gh/issues/42"
+    assert fields["status"] == "issue_opened"
+
+
+def test_step_finished_status_reflects_ok(fake_sync: FakeSyncRedis) -> None:
+    o = LoggingTaskObserver()
+    o.step_finished("t1", 1, "engineer", True, "done")
+    o.step_finished("t1", 2, "infra", False, "boom")
+    assert fake_sync.added[0][1]["status"] == "step_ok"
+    assert fake_sync.added[1][1]["status"] == "step_failed"
+
+
+def test_task_finished_status_variants(fake_sync: FakeSyncRedis) -> None:
+    o = LoggingTaskObserver()
+    o.task_finished("a", closed=True, ok=True, note="completed")
+    o.task_finished("b", closed=False, ok=True, note="done no issue")
+    o.task_finished("c", closed=False, ok=False, note="stopped")
+    assert fake_sync.added[0][1]["status"] == "closed"
+    assert fake_sync.added[1][1]["status"] == "done"
+    assert fake_sync.added[2][1]["status"] == "failed"
+
+
+def test_emit_swallows_redis_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(obs, "get_sync_client", lambda: BrokenSyncRedis())
+    # Must not raise — observability is best-effort.
+    LoggingTaskObserver().task_started("t1", "u1", "x")
+
+
+def test_latest_task_states_collapses_to_one_row_per_task() -> None:
+    # Newest-first event log (as xrevrange returns).
+    events = [
+        {"task_id": "t1", "status": "closed", "id": "5-0"},
+        {"task_id": "t2", "status": "step_ok", "id": "4-0"},
+        {"task_id": "t1", "status": "step_ok", "id": "3-0"},
+        {"task_id": "t1", "status": "started", "id": "2-0"},
+        {"task_id": "t2", "status": "started", "id": "1-0"},
+    ]
+    states = latest_task_states(events)
+    by_task = {s["task_id"]: s["status"] for s in states}
+    assert by_task == {"t1": "closed", "t2": "step_ok"}
+    assert len(states) == 2
+
+
+def test_latest_task_states_ignores_blank_task_id() -> None:
+    events = [{"task_id": "", "status": "x", "id": "1-0"}]
+    assert latest_task_states(events) == []

--- a/tests/interfaces/test_tasks_endpoints.py
+++ b/tests/interfaces/test_tasks_endpoints.py
@@ -143,3 +143,33 @@ def test_admin_requires_as_email(monkeypatch: pytest.MonkeyPatch, fake: FakeTask
     resp = c.post("/tasks/run", json={"request": "x"})
     assert resp.status_code == 400
     assert "as_email" in resp.json()["detail"]
+
+
+# ── GET /tasks board (PR-5) ──────────────────────────────────────────────────
+
+
+def test_board_returns_collapsed_tasks_and_events(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    events = [
+        {"id": "3-0", "task_id": "t1", "role": "pm", "status": "closed", "message": "done"},
+        {"id": "2-0", "task_id": "t1", "role": "engineer", "status": "step_ok", "message": "x"},
+        {"id": "1-0", "task_id": "t2", "role": "pm", "status": "started", "message": "y"},
+    ]
+
+    async def _fake_recent(limit: int = 100) -> list[dict[str, str]]:
+        return events
+
+    monkeypatch.setattr(tasks_iface, "_resolve_caller", lambda _a: (USER, "user"))
+    import app.adapters.task_observer as obs_mod
+
+    monkeypatch.setattr(obs_mod, "recent_task_events", _fake_recent)
+
+    resp = client.get("/tasks/")
+    assert resp.status_code == 200
+    body = resp.json()
+    # 3 raw events, collapsed to 2 tasks (t1 latest=closed, t2=started).
+    assert len(body["events"]) == 3
+    statuses = {t["task_id"]: t["status"] for t in body["tasks"]}
+    assert statuses == {"t1": "closed", "t2": "started"}
+

--- a/tests/orchestrator/test_task_runner.py
+++ b/tests/orchestrator/test_task_runner.py
@@ -170,3 +170,75 @@ async def test_issue_body_lists_steps() -> None:
     assert gh.created is not None
     assert "do X" in gh.created["body"]
     assert "octopus-task" in (gh.created["labels"] or [])
+
+
+# ── observability (PR-5) ─────────────────────────────────────────────────────────
+
+class _RecordingObserver:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+
+    def task_started(self, task_id, user_id, request):  # type: ignore[no-untyped-def]
+        self.events.append(("task_started", task_id))
+
+    def issue_opened(self, task_id, issue_number, issue_url):  # type: ignore[no-untyped-def]
+        self.events.append(("issue_opened", str(issue_number)))
+
+    def step_started(self, task_id, order, role, description):  # type: ignore[no-untyped-def]
+        self.events.append(("step_started", f"{order}:{role}"))
+
+    def step_finished(self, task_id, order, role, ok, detail):  # type: ignore[no-untyped-def]
+        self.events.append(("step_finished", f"{order}:{ok}"))
+
+    def task_finished(self, task_id, *, closed, ok, note):  # type: ignore[no-untyped-def]
+        self.events.append(("task_finished", f"closed={closed},ok={ok}"))
+
+
+@pytest.mark.asyncio
+async def test_observer_receives_full_lifecycle_on_success() -> None:
+    plan = _plan([
+        TaskStep(order=1, description="write", action="file_write", params={}),
+    ])
+    obs = _RecordingObserver()
+    runner = TaskRunner(
+        pm=_FakePM(plan),
+        github=_FakeGitHub(),
+        dispatch=_FakeDispatch([DispatchResult(output="ok", ok=True)]),
+        observer=obs,
+    )
+    await runner.run("user-1", "req")
+    names = [e[0] for e in obs.events]
+    assert names == [
+        "task_started", "issue_opened", "step_started", "step_finished", "task_finished",
+    ]
+    assert obs.events[-1][1] == "closed=True,ok=True"
+
+
+@pytest.mark.asyncio
+async def test_observer_task_finished_on_failure() -> None:
+    plan = _plan([
+        TaskStep(order=1, description="x", action="file_write", params={}),
+    ])
+    obs = _RecordingObserver()
+    runner = TaskRunner(
+        pm=_FakePM(plan),
+        github=_FakeGitHub(),
+        dispatch=_FakeDispatch([DispatchResult(output="", ok=False, error="boom")]),
+        observer=obs,
+    )
+    await runner.run("user-1", "req")
+    assert ("task_finished", "closed=False,ok=False") in obs.events
+
+
+@pytest.mark.asyncio
+async def test_observer_no_steps_still_finishes() -> None:
+    obs = _RecordingObserver()
+    runner = TaskRunner(
+        pm=_FakePM(_plan([], title="Direct")),
+        github=_FakeGitHub(),
+        dispatch=_FakeDispatch([]),
+        observer=obs,
+    )
+    await runner.run("user-1", "chat")
+    names = [e[0] for e in obs.events]
+    assert names == ["task_started", "task_finished"]


### PR DESCRIPTION
## What
PR-5 — observability for the orchestrator task chain, so a running task can be followed live with **no extra infra** (no Grafana/Prometheus/Loki).

## How — 3 sinks, all reusing what's already in the stack
1. **Structured stdout log** — `LoggingTaskObserver` emits `[ROLE][TASK_ID][STATUS] message` on logger `octopus.tasks`. `main.py` now adds a stdout StreamHandler so these are captured by `docker logs -f` / `docker service logs` — the user's live view.
2. **Redis Stream** `task:events` (capped 5000) — structured rows for the board.
3. **`GET /tasks`** board endpoint — recent events + one collapsed row per task (latest state), via `recent_task_events` + `latest_task_states`. Read-only, admin/session auth.

## Hexagonal
- New port `app/ports/task_events.py` — `TaskObserver` Protocol + `NullTaskObserver` no-op (default, so TaskRunner runs unwired).
- TaskRunner takes an `observer` field and emits: `task_started → issue_opened → step_started/finished → task_finished`. Domain depends on the port; `composition.build_task_runner()` injects the concrete `LoggingTaskObserver`.
- Observer methods are best-effort: a Redis failure logs a warning, never breaks task execution.

## How you'll watch it during testing
```
docker compose logs -f bot | grep octopus.tasks
# or swarm:  docker service logs -f octopus_bot
# or board:  GET /tasks  → JSON of recent tasks + per-step events
```

## Tests
11 new: observer emits correct fields per lifecycle method, status variants (closed/done/failed, step_ok/step_failed), **best-effort swallows Redis failure**, board collapse-to-latest logic, TaskRunner fires full lifecycle (success + failure + no-steps), GET /tasks endpoint.

```
629 passed (+11) · ruff (app+tests) · mypy (131 files) all green
```