### PR TITLE
feat: add task-level rag memory for planning recall

### DIFF
--- a/app/adapters/task_memory.py
+++ b/app/adapters/task_memory.py
@@ -1,0 +1,101 @@
+"""Task-level RAG memory adapter — recall before planning, index after closing.
+
+Reuses the existing RAG building blocks (``Embedder`` + ``KnowledgeStore``) but
+operates at task granularity, tagging chunks with ``meta["kind"] == "task_plan"``
+so task memory never mixes with the step-output chunks ``worker_ws`` indexes.
+Recall filters on that tag.
+
+Best-effort throughout: a missing embedder (RAG disabled) or any backend error
+degrades to "no extra context" / "skip index" rather than failing the task.
+Scoped to the user's default project, mirroring ``worker_ws`` resolution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.ports.embedder import Embedder
+    from app.ports.knowledge_store import KnowledgeStore
+
+logger = logging.getLogger(__name__)
+
+_KIND = "task_plan"
+MAX_EMBED_CHARS = 4000
+MAX_RECALL_CONTEXT_CHARS = 1500
+
+
+def _resolve_project_id(user_id: str) -> str:
+    from app.adapters.database.repositories import ControlPlaneRepository
+    from app.composition import _session_factory
+
+    with _session_factory()() as session:
+        repo = ControlPlaneRepository(session)
+        project = repo.get_or_create_default_project(user_id)
+        project_id = project.id
+        session.commit()
+    return project_id
+
+
+class RagTaskMemory:
+    """Concrete TaskMemoryPort backed by Embedder + KnowledgeStore."""
+
+    def __init__(
+        self,
+        embedder: Embedder | None,
+        store: KnowledgeStore,
+        recall_k: int = 3,
+    ) -> None:
+        self._embedder = embedder
+        self._store = store
+        self._k = recall_k
+
+    async def recall_for_planning(
+        self, user_id: str, request: str, base_context: str,
+    ) -> str:
+        if self._embedder is None or not request.strip():
+            return base_context
+        try:
+            project_id = await asyncio.to_thread(_resolve_project_id, user_id)
+            q_emb = await asyncio.to_thread(self._embedder.embed, request[:MAX_EMBED_CHARS])
+            # Over-fetch then filter to task_plan chunks; recall has no meta filter.
+            hits = await self._store.recall(project_id, q_emb, k=self._k * 4)
+        except Exception as exc:
+            logger.warning("task memory recall failed: %s", exc)
+            return base_context
+
+        task_hits = [h for h in hits if h.chunk.meta.get("kind") == _KIND][: self._k]
+        if not task_hits:
+            return base_context
+
+        lines = ["Task serupa di masa lalu (untuk referensi perencanaan):"]
+        total = 0
+        for i, hit in enumerate(task_hits, 1):
+            text = hit.chunk.text
+            if total + len(text) > MAX_RECALL_CONTEXT_CHARS:
+                text = text[: MAX_RECALL_CONTEXT_CHARS - total]
+                lines.append(f"[{i}] (truncated) {text}…")
+                break
+            lines.append(f"[{i}] {text}")
+            total += len(text)
+
+        recall_block = "\n".join(lines)
+        return f"{recall_block}\n\n---\n\n{base_context}" if base_context else recall_block
+
+    async def index_task(
+        self, user_id: str, request: str, summary: str, outcome_note: str,
+    ) -> None:
+        if self._embedder is None:
+            return
+        text = f"Request: {request}\nRingkasan: {summary}\nHasil: {outcome_note}"[:MAX_EMBED_CHARS]
+        try:
+            project_id = await asyncio.to_thread(_resolve_project_id, user_id)
+            emb = await asyncio.to_thread(self._embedder.embed, text)
+            await self._store.index(
+                project_id, text, emb,
+                meta={"kind": _KIND, "request": request[:200]},
+            )
+        except Exception as exc:
+            logger.warning("task memory index failed: %s", exc)

--- a/app/composition.py
+++ b/app/composition.py
@@ -169,6 +169,7 @@ def build_task_runner() -> TaskRunner:
     caller (endpoint) maps that to a 503 so the failure is explicit, not silent.
     """
     from app.adapters.github import GitHubAdapter
+    from app.adapters.task_memory import RagTaskMemory
     from app.adapters.task_observer import LoggingTaskObserver
 
     github = GitHubAdapter(token=settings.github_token, repo=settings.github_repo)
@@ -177,6 +178,11 @@ def build_task_runner() -> TaskRunner:
         github=github,
         dispatch=WorkerDispatchAdapter(),
         observer=LoggingTaskObserver(),
+        memory=RagTaskMemory(
+            embedder=_embedder(),
+            store=_knowledge_store(),
+            recall_k=settings.rag_recall_k,
+        ),
     )
 
 

--- a/app/orchestrator/task_runner.py
+++ b/app/orchestrator/task_runner.py
@@ -29,6 +29,7 @@ from app.agents.pm import TaskPlan
 from app.ports.github_issues import GitHubIssuesPort
 from app.ports.pm_agent import PMAgentPort
 from app.ports.task_events import NullTaskObserver, TaskObserver
+from app.ports.task_memory import NullTaskMemory, TaskMemoryPort
 from app.ports.worker_dispatch import AsyncWorkerDispatchPort
 
 logger = logging.getLogger(__name__)
@@ -105,11 +106,14 @@ class TaskRunner:
     dispatch: AsyncWorkerDispatchPort
     labels: list[str] = field(default_factory=lambda: ["octopus-task"])
     observer: TaskObserver = field(default_factory=NullTaskObserver)
+    memory: TaskMemoryPort = field(default_factory=NullTaskMemory)
 
     async def run(self, user_id: str, request: str, context: str = "") -> TaskResult:
         task_id = uuid.uuid4().hex[:12]
         self.observer.task_started(task_id, user_id, request)
-        plan = self.pm.plan(request, context)
+        # Task-level RAG: enrich planning context with similar past tasks.
+        planning_context = await self.memory.recall_for_planning(user_id, request, context)
+        plan = self.pm.plan(request, planning_context)
 
         # No actionable steps → don't open an issue; nothing to track.
         if not plan.steps:
@@ -167,6 +171,10 @@ class TaskRunner:
             comment=f"All {len(outcomes)} steps completed ✅ — closing.",
         )
         self.observer.task_finished(task_id, closed=True, ok=True, note="completed")
+        # Index this completed task so future planning can recall it.
+        await self.memory.index_task(
+            user_id, request, plan.summary, f"completed {len(outcomes)} steps",
+        )
         return TaskResult(
             plan=plan,
             issue_number=issue.number,

--- a/app/ports/task_memory.py
+++ b/app/ports/task_memory.py
@@ -1,0 +1,47 @@
+"""Port for task-level RAG memory — recall before planning, index after closing.
+
+Distinct from the *step-output* RAG already wired in ``worker_ws`` (which embeds
+each worker's output to enrich the next dispatch). This layer remembers whole
+**tasks**: before the PM decomposes a request, recall summaries of similar past
+tasks and feed them as planning context; after a task closes, index its summary
+so future planning benefits.
+
+Keeping it a Protocol means TaskRunner depends on the port, not the embedder /
+knowledge-store adapters — tests inject a recording fake or the no-op default.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class TaskMemoryPort(Protocol):
+    async def recall_for_planning(
+        self, user_id: str, request: str, base_context: str,
+    ) -> str:
+        """Return ``base_context`` augmented with similar past-task summaries.
+
+        Must be best-effort: on any failure return ``base_context`` unchanged —
+        planning memory is an enhancement, never a critical path.
+        """
+        ...
+
+    async def index_task(
+        self, user_id: str, request: str, summary: str, outcome_note: str,
+    ) -> None:
+        """Persist a closed task's summary for future planning recall."""
+        ...
+
+
+class NullTaskMemory:
+    """No-op task memory — the default so TaskRunner works without wiring."""
+
+    async def recall_for_planning(
+        self, user_id: str, request: str, base_context: str,
+    ) -> str:
+        return base_context
+
+    async def index_task(
+        self, user_id: str, request: str, summary: str, outcome_note: str,
+    ) -> None:
+        return None

--- a/docs/ORCHESTRATOR.md
+++ b/docs/ORCHESTRATOR.md
@@ -175,6 +175,16 @@ Tiap item = satu PR (sesuai aturan repo: satu concern, conventional commit, CI h
   `/tasks/run`, tampilkan link issue + status tiap step + apakah ditutup.
 - Test: 7 endpoint test (closed/failed/no-step/503/admin-needs-email).
 
+### Task-level RAG memory ✅ DONE (#TBD)
+- Port `app/ports/task_memory.py` (`TaskMemoryPort` + `NullTaskMemory` no-op default).
+- Adapter `app/adapters/task_memory.py` (`RagTaskMemory`): reuse `Embedder` +
+  `KnowledgeStore`, tag chunk `meta.kind="task_plan"` (tidak campur dgn step-output
+  RAG di `worker_ws`). **Recall sebelum PM plan** (enrich planning context dgn task
+  serupa) + **index ringkasan task setelah close** (belajar untuk task berikutnya).
+- Best-effort: embedder None / backend error → degrade ke base context, task tetap jalan.
+- Beda lapisan dari step-output RAG: ini *task-level* (perencanaan), itu *step-level* (dispatch).
+- Test: 10 (recall filter-by-kind, best-effort, index tagging + runner integration).
+
 ### PR-5 — Observability ✅ DONE (#TBD)
 - Port `app/ports/task_events.py` (`TaskObserver` Protocol + `NullTaskObserver` no-op).
 - Adapter `app/adapters/task_observer.py` (`LoggingTaskObserver`): tiap event →

--- a/tests/adapters/test_task_memory.py
+++ b/tests/adapters/test_task_memory.py
@@ -1,0 +1,133 @@
+"""Unit tests for RagTaskMemory — task-level planning recall + index (RAG).
+
+Embedder and KnowledgeStore are fakes; the DB project resolver is monkeypatched.
+We verify: recall filters to task_plan chunks and prepends them, an unset
+embedder / backend error degrades gracefully, and index tags chunks correctly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.adapters import task_memory as tm
+from app.adapters.task_memory import RagTaskMemory
+from app.ports.knowledge_store import KnowledgeChunk, RecallResult
+
+
+class FakeEmbedder:
+    @property
+    def dimension(self) -> int:
+        return 3
+
+    def embed(self, text: str) -> list[float]:
+        return [float(len(text)), 1.0, 0.0]
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return [self.embed(t) for t in texts]
+
+
+class FakeStore:
+    def __init__(self, hits: list[RecallResult] | None = None) -> None:
+        self._hits = hits or []
+        self.indexed: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def index(self, project_id, text, embedding, meta=None):  # type: ignore[no-untyped-def]
+        self.indexed.append((project_id, text, dict(meta or {})))
+        return "chunk-1"
+
+    async def recall(self, project_id, query_embedding, k=5):  # type: ignore[no-untyped-def]
+        return self._hits
+
+    async def delete_project(self, project_id):  # type: ignore[no-untyped-def]
+        return 0
+
+
+class BrokenStore(FakeStore):
+    async def recall(self, project_id, query_embedding, k=5):  # type: ignore[no-untyped-def]
+        raise RuntimeError("pgvector down")
+
+
+def _chunk(text: str, kind: str) -> RecallResult:
+    return RecallResult(
+        chunk=KnowledgeChunk(id="c", project_id="p1", text=text, meta={"kind": kind}),
+        score=0.9,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _patch_project(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tm, "_resolve_project_id", lambda _u: "p1")
+
+
+@pytest.mark.asyncio
+async def test_recall_disabled_when_embedder_none() -> None:
+    mem = RagTaskMemory(embedder=None, store=FakeStore())
+    out = await mem.recall_for_planning("u1", "build X", "base ctx")
+    assert out == "base ctx"
+
+
+@pytest.mark.asyncio
+async def test_recall_prepends_only_task_plan_chunks() -> None:
+    store = FakeStore(hits=[
+        _chunk("past task: add auth", "task_plan"),
+        _chunk("step output noise", "step_output"),
+        _chunk("past task: add cache", "task_plan"),
+    ])
+    mem = RagTaskMemory(embedder=FakeEmbedder(), store=store, recall_k=3)
+
+    out = await mem.recall_for_planning("u1", "add login", "ORIGINAL")
+
+    assert "add auth" in out
+    assert "add cache" in out
+    assert "step output noise" not in out   # filtered: wrong kind
+    assert out.strip().endswith("ORIGINAL")  # base context preserved at the end
+
+
+@pytest.mark.asyncio
+async def test_recall_no_task_hits_returns_base() -> None:
+    store = FakeStore(hits=[_chunk("only step output", "step_output")])
+    mem = RagTaskMemory(embedder=FakeEmbedder(), store=store)
+    out = await mem.recall_for_planning("u1", "x", "BASE")
+    assert out == "BASE"
+
+
+@pytest.mark.asyncio
+async def test_recall_swallows_backend_error() -> None:
+    mem = RagTaskMemory(embedder=FakeEmbedder(), store=BrokenStore())
+    out = await mem.recall_for_planning("u1", "x", "BASE")
+    assert out == "BASE"
+
+
+@pytest.mark.asyncio
+async def test_recall_respects_k_limit() -> None:
+    hits = [_chunk(f"task {i}", "task_plan") for i in range(10)]
+    store = FakeStore(hits=hits)
+    mem = RagTaskMemory(embedder=FakeEmbedder(), store=store, recall_k=2)
+    out = await mem.recall_for_planning("u1", "x", "")
+    # Only k=2 task chunks rendered (lines [1] and [2], no [3]).
+    assert "[1]" in out and "[2]" in out
+    assert "[3]" not in out
+
+
+@pytest.mark.asyncio
+async def test_index_tags_chunk_as_task_plan() -> None:
+    store = FakeStore()
+    mem = RagTaskMemory(embedder=FakeEmbedder(), store=store)
+
+    await mem.index_task("u1", "add login", "implement OAuth", "completed 3 steps")
+
+    assert len(store.indexed) == 1
+    _project, text, meta = store.indexed[0]
+    assert meta["kind"] == "task_plan"
+    assert meta["request"] == "add login"
+    assert "implement OAuth" in text
+
+
+@pytest.mark.asyncio
+async def test_index_noop_when_embedder_none() -> None:
+    store = FakeStore()
+    mem = RagTaskMemory(embedder=None, store=store)
+    await mem.index_task("u1", "x", "y", "z")
+    assert store.indexed == []

--- a/tests/orchestrator/test_task_runner.py
+++ b/tests/orchestrator/test_task_runner.py
@@ -242,3 +242,77 @@ async def test_observer_no_steps_still_finishes() -> None:
     await runner.run("user-1", "chat")
     names = [e[0] for e in obs.events]
     assert names == ["task_started", "task_finished"]
+
+
+# ── task-level RAG memory ─────────────────────────────────────────────────────────
+
+class _CapturingPM:
+    """PM that records the context it was planned with."""
+
+    def __init__(self, plan: TaskPlan) -> None:
+        self._plan = plan
+        self.seen_context: str | None = None
+
+    def plan(self, request: str, context: str = "") -> TaskPlan:
+        self.seen_context = context
+        return self._plan
+
+
+class _RecordingMemory:
+    def __init__(self, recall_value: str) -> None:
+        self._recall = recall_value
+        self.indexed: list[tuple[str, str, str, str]] = []
+
+    async def recall_for_planning(self, user_id, request, base_context):  # type: ignore[no-untyped-def]
+        return self._recall
+
+    async def index_task(self, user_id, request, summary, outcome_note):  # type: ignore[no-untyped-def]
+        self.indexed.append((user_id, request, summary, outcome_note))
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_feeds_planning_context() -> None:
+    pm = _CapturingPM(_plan([
+        TaskStep(order=1, description="x", action="file_write", params={}),
+    ]))
+    mem = _RecordingMemory("PAST TASK CONTEXT")
+    runner = TaskRunner(
+        pm=pm,
+        github=_FakeGitHub(),
+        dispatch=_FakeDispatch([DispatchResult(output="ok", ok=True)]),
+        memory=mem,
+    )
+    await runner.run("user-1", "do it", context="orig")
+    assert pm.seen_context == "PAST TASK CONTEXT"
+
+
+@pytest.mark.asyncio
+async def test_memory_indexes_task_on_success() -> None:
+    mem = _RecordingMemory("")
+    runner = TaskRunner(
+        pm=_FakePM(_plan([
+            TaskStep(order=1, description="x", action="file_write", params={}),
+        ])),
+        github=_FakeGitHub(),
+        dispatch=_FakeDispatch([DispatchResult(output="ok", ok=True)]),
+        memory=mem,
+    )
+    await runner.run("user-1", "do it")
+    assert len(mem.indexed) == 1
+    assert mem.indexed[0][0] == "user-1"
+    assert mem.indexed[0][1] == "do it"
+
+
+@pytest.mark.asyncio
+async def test_memory_not_indexed_on_failure() -> None:
+    mem = _RecordingMemory("")
+    runner = TaskRunner(
+        pm=_FakePM(_plan([
+            TaskStep(order=1, description="x", action="file_write", params={}),
+        ])),
+        github=_FakeGitHub(),
+        dispatch=_FakeDispatch([DispatchResult(output="", ok=False, error="boom")]),
+        memory=mem,
+    )
+    await runner.run("user-1", "do it")
+    assert mem.indexed == []   # failed task is not memorized


### PR DESCRIPTION
## What
Connects **RAG to the TaskRunner** so the orchestrator *learns across tasks*: before the PM decomposes a request it recalls summaries of similar past tasks, and after a task closes it indexes its own summary for future recall.

## Why this layer (not duplicate of existing RAG)
`worker_ws` already does **step-output RAG** — it embeds each worker's output to enrich the *next dispatch*. That stays untouched. This PR adds a distinct **task-level** layer at the *planning* stage:
- Chunks tagged `meta.kind="task_plan"` so the two never mix; recall filters on the tag.
- Operates on whole-task summaries, feeding `PMAgent.plan()` — a layer the step-output RAG never touched.

## How
- New port `app/ports/task_memory.py` — `TaskMemoryPort` + `NullTaskMemory` no-op (default, so TaskRunner runs unwired).
- `app/adapters/task_memory.py` — `RagTaskMemory` reuses the existing `Embedder` + `KnowledgeStore` (no new infra). `recall_for_planning` prepends similar past-task context; `index_task` stores the summary on success.
- TaskRunner: recall before `pm.plan()`, index after `close_issue()`. **Failed tasks are not memorized** (only completed ones).
- `composition.build_task_runner()` injects `RagTaskMemory(_embedder(), _knowledge_store(), rag_recall_k)`.

## Best-effort
Embedder None (RAG_ENABLED=false) or any backend error → degrade to base context / skip index. Planning memory never breaks task execution.

## Tests
10 new: recall filters to task_plan chunks only, respects k-limit, returns base on no-hits / error / no-embedder; index tags chunk + noop without embedder; TaskRunner feeds recalled context into the PM and indexes on success but **not on failure**.

```
639 passed (+10) · ruff (app+tests) · mypy (133 files) all green
```