### PR TITLE
feat: add portable deploy with postgres profile and backup restore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,12 +118,43 @@ PORT=8080
 DOMAIN=
 
 # ── Control-plane database ───────────────────────────────────────────────────
-# Production: gunakan Neon PostgreSQL connection string.
-# Runtime app sebaiknya pakai pooled URL dari Neon (-pooler).
-# Migration sebaiknya pakai direct URL Neon agar Alembic tidak lewat PgBouncer transaction pooling.
+# Default: SQLite (single-file, zero setup). Cukup untuk single-node, TAPI RAG
+# memakai in-memory store (knowledge hilang saat restart).
+#
+# Untuk RAG persisten + production: aktifkan service Postgres+pgvector bawaan:
+#   docker compose --profile postgres up -d
+# lalu GANTI dua baris di bawah ke koneksi Postgres berikut (sesuaikan password
+# dengan POSTGRES_PASSWORD di bagian "Postgres" lebih bawah):
+#   DATABASE_URL=postgresql+psycopg://octopus:octopus@postgres:5432/octopus
+#   DATABASE_MIGRATION_URL=postgresql+psycopg://octopus:octopus@postgres:5432/octopus
+#
+# Alternatif managed (Neon): pakai pooled URL untuk DATABASE_URL, direct URL
+# untuk DATABASE_MIGRATION_URL (Alembic tidak boleh lewat PgBouncer txn pooling).
 # Jangan commit credential database asli ke repository.
 DATABASE_URL=sqlite:///data/control_plane.sqlite3
 DATABASE_MIGRATION_URL=sqlite:///data/control_plane.sqlite3
+
+# ── Postgres (hanya dipakai kalau profile `postgres` aktif) ──────────────────
+# Kredensial untuk service `postgres` di docker-compose. Ganti password untuk
+# production. Harus konsisten dengan DATABASE_URL di atas.
+POSTGRES_USER=octopus
+POSTGRES_PASSWORD=octopus
+POSTGRES_DB=octopus
+
+# ── GitHub (untuk orchestrator /task — PM→Issue→Worker→Close) ─────────────────
+# Token dengan scope `repo` (classic) atau `Issues: read/write` (fine-grained).
+# Tanpa ini, perintah /task balas 503 (task runner unavailable).
+# Repo tujuan tempat issue task dibuat, format: owner/repo.
+GITHUB_TOKEN=
+GITHUB_REPO=
+
+# ── RAG (Retrieval-Augmented Generation) — memori semantik ───────────────────
+# RAG_ENABLED=true → bot recall konteks relevan sebelum kerja & index hasil.
+# EMBEDDER_BACKEND: fastembed (lokal CPU, default) | ollama | none (matikan RAG).
+# Catatan: RAG persisten butuh Postgres+pgvector (lihat DATABASE_URL).
+RAG_ENABLED=true
+EMBEDDER_BACKEND=fastembed
+RAG_RECALL_K=5
 
 # ── Admin TUI ────────────────────────────────────────────────────────────────
 # Token untuk admin HTTP API (/admin/*).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,30 @@
 services:
 
+  # ── Postgres + pgvector: durable control-plane DB + RAG vector store ─────────
+  # Opsional via profile `postgres`. Tanpa profil ini bot fallback ke SQLite
+  # (data/control_plane.sqlite3) — cukup untuk single-node, tapi RAG pakai
+  # in-memory store (hilang saat restart). Aktifkan untuk RAG persisten:
+  #   docker compose --profile postgres up -d
+  # lalu set DATABASE_URL di .env ke baris postgres (lihat .env.example).
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: aiagent_postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-octopus}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-octopus}
+      POSTGRES_DB: ${POSTGRES_DB:-octopus}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    profiles:
+      - postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-octopus} -d ${POSTGRES_DB:-octopus}"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 10s
+
   # ── Redis: shared state untuk worker tunnel + agent context ──────────────────
   # Privat di network internal backend (tidak ekspos ke host). Worker user
   # talk ke backend via WS; backend yang akses Redis.
@@ -153,6 +178,8 @@ services:
       start_period: 10s
 
 volumes:
+  postgres_data:
+    name: aiagent_postgres_data
   ollama_data:
     name: aiagent_ollama_data
   redis_data:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,133 @@
+# Deploy & Pindah Server — Octopus
+
+Panduan ini menjawab satu pertanyaan: **bagaimana pindah server tanpa setup manual satu per satu.**
+
+Prinsipnya: semua *state* (kredensial, database, memori RAG, worker state) hidup di
+**`.env` + Docker volumes**. Pindah server = backup state → copy satu file →
+restore. Kode & image ditarik otomatis dari GHCR.
+
+---
+
+## 1. Instalasi pertama (server baru, dari nol)
+
+```bash
+# Satu baris — install Docker image + config + jalankan
+curl -fsSL https://raw.githubusercontent.com/CodinginID/ai-agent/main/install.sh | bash
+```
+
+Installer akan: cek Docker, download `docker-compose.yml` + `.env.example`,
+tanya Telegram token, pull image, lalu `docker compose up -d`.
+
+### Isi konfigurasi penting di `.env`
+
+| Variabel | Untuk apa | Wajib? |
+|---|---|---|
+| `TELEGRAM_BOT_TOKEN` | bot Telegram | ya |
+| `GITHUB_TOKEN` + `GITHUB_REPO` | orchestrator `/task` (PM→Issue→Close) | untuk `/task` |
+| `DATABASE_URL` | SQLite (default) atau Postgres | default OK |
+| `RAG_ENABLED` / `EMBEDDER_BACKEND` | memori semantik | default OK |
+| `ADMIN_TOKEN` | admin API | opsional |
+
+`GITHUB_TOKEN`: bikin di GitHub → Settings → Developer settings → Personal
+access token, scope **`repo`** (classic) atau **Issues: read/write** (fine-grained).
+Tanpa ini `/task` balas `503 task runner unavailable`.
+
+---
+
+## 2. Mode database — pilih satu
+
+### SQLite (default, zero-setup)
+Cukup untuk single-node. **Catatan:** RAG pakai in-memory store → knowledge
+hilang saat restart. Tidak perlu konfigurasi apa pun.
+
+### Postgres + pgvector (RAG persisten, disarankan untuk produksi)
+RAG (memori semantik) bertahan lintas restart. Aktifkan profil bawaan:
+
+```bash
+# 1. Aktifkan & jalankan Postgres
+docker compose --profile postgres up -d
+
+# 2. Ganti dua baris ini di .env (password = POSTGRES_PASSWORD):
+DATABASE_URL=postgresql+psycopg://octopus:octopus@postgres:5432/octopus
+DATABASE_MIGRATION_URL=postgresql+psycopg://octopus:octopus@postgres:5432/octopus
+
+# 3. Restart bot — migrasi alembic (termasuk pgvector) jalan otomatis saat start
+docker compose up -d bot
+```
+
+Migrasi `CREATE EXTENSION vector` + tabel `knowledge_chunks` (HNSW cosine index)
+otomatis di Postgres, dan **di-skip otomatis di SQLite** — jadi aman bolak-balik.
+
+---
+
+## 3. Pindah server — TANPA setup manual ⭐
+
+Inti dari portabilitas. Tiga langkah.
+
+### Di server LAMA
+```bash
+cd ~/ai-agent
+./scripts/octopus-backup.sh backup
+# → menghasilkan octopus-backup-<timestamp>.tar.gz
+#   berisi: .env + database (SQLite file / pg_dump) + Redis dump + manifest
+```
+
+### Pindahkan
+```bash
+scp octopus-backup-*.tar.gz user@server-baru:~/ai-agent/
+```
+
+### Di server BARU
+```bash
+# 1. Install sekali (Docker + image + compose) — JANGAN isi token, akan ditimpa
+curl -fsSL https://raw.githubusercontent.com/CodinginID/ai-agent/main/install.sh | bash
+
+# 2. Pulihkan semua state dari backup
+cd ~/ai-agent
+./scripts/octopus-backup.sh restore octopus-backup-*.tar.gz
+
+# 3. Jalankan (restore akan kasih tahu perintah persisnya)
+docker compose --profile telegram up -d
+#   + tambah --profile postgres kalau pakai Postgres
+```
+
+Selesai. `.env`, database, dan memori RAG identik dengan server lama. Tidak ada
+setup token / config manual yang diulang.
+
+---
+
+## 4. Update versi (tanpa kehilangan data)
+
+```bash
+cd ~/ai-agent
+docker compose pull          # tarik image terbaru dari GHCR
+docker compose up -d         # recreate container, volume (data) tetap
+```
+
+Volume (`aiagent_postgres_data`, `aiagent_redis_data`, dst.) tidak ikut terhapus
+saat `up -d` / `pull`. Hanya `docker compose down -v` yang menghapus volume —
+**jangan pakai `-v`** kecuali memang mau reset total.
+
+---
+
+## 5. Pantau saat testing
+
+```bash
+docker compose logs -f bot                      # semua log bot
+docker compose logs -f bot | grep octopus.tasks # khusus lifecycle /task
+# Board task (JSON): GET /tasks via Caddy
+curl -H "Authorization: Bearer $ADMIN_TOKEN" http://localhost:8090/tasks/
+```
+
+Log task terstruktur: `[ROLE][TASK_ID][STATUS] pesan` — gampang di-`grep` per task.
+
+---
+
+## 6. Checklist go-live
+
+- [ ] `.env`: `TELEGRAM_BOT_TOKEN`, `GITHUB_TOKEN`, `GITHUB_REPO` terisi
+- [ ] (opsional) Postgres: profil aktif + `DATABASE_URL` Postgres + restart bot
+- [ ] `docker compose ps` → semua service `healthy`
+- [ ] `curl localhost:8090/health` → `{"status":"ok"}`
+- [ ] Telegram: `/start` → pair, lalu `/task <deskripsi>` → cek issue dibuat di `GITHUB_REPO`
+- [ ] `docker compose logs -f bot | grep octopus.tasks` → lihat lifecycle jalan

--- a/scripts/octopus-backup.sh
+++ b/scripts/octopus-backup.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# ==============================================================
+#  Octopus — Backup & Restore (portabilitas pindah server)
+#
+#  Tujuan: pindah server TANPA setup manual satu per satu.
+#  Backup membungkus SEMUA state (.env, database, Redis, volume
+#  manifest) jadi satu tarball. Restore memulihkannya di server baru.
+#
+#  Pakai:
+#    ./scripts/octopus-backup.sh backup            # buat octopus-backup-<ts>.tar.gz
+#    ./scripts/octopus-backup.sh restore <file>    # pulihkan dari tarball
+#
+#  Pindah server (ringkas):
+#    server lama : ./scripts/octopus-backup.sh backup
+#    scp octopus-backup-*.tar.gz user@server-baru:~/ai-agent/
+#    server baru : curl -fsSL .../install.sh | bash   (sekali, untuk docker+image)
+#                  ./scripts/octopus-backup.sh restore octopus-backup-*.tar.gz
+# ==============================================================
+set -euo pipefail
+
+cd "$(dirname "$0")/.."   # repo root
+ROOT="$(pwd)"
+TS="$(date +%Y%m%d-%H%M%S)"
+COMPOSE="docker compose"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+info()  { echo -e "${CYAN}[INFO]${NC} $1"; }
+ok()    { echo -e "${GREEN}[OK]${NC}   $1"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
+die()   { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+# Apakah DATABASE_URL menunjuk Postgres?
+_is_postgres() {
+    grep -qE '^DATABASE_URL=postgresql' "$ROOT/.env" 2>/dev/null
+}
+
+backup() {
+    local stage="$ROOT/.backup-stage-$TS"
+    local out="$ROOT/octopus-backup-$TS.tar.gz"
+    mkdir -p "$stage"
+    info "Membuat backup → $(basename "$out")"
+
+    # 1. .env (kredensial + config) — inti portabilitas
+    [[ -f "$ROOT/.env" ]] && cp "$ROOT/.env" "$stage/.env" && ok ".env"
+
+    # 2. Database
+    if _is_postgres; then
+        info "Postgres terdeteksi — pg_dump..."
+        $COMPOSE exec -T postgres pg_dumpall -U "${POSTGRES_USER:-octopus}" \
+            > "$stage/postgres.sql" 2>/dev/null \
+            && ok "postgres.sql" || warn "pg_dump gagal (service jalan?)"
+    else
+        info "SQLite terdeteksi — copy file DB..."
+        if [[ -f "$ROOT/data/control_plane.sqlite3" ]]; then
+            cp "$ROOT/data/control_plane.sqlite3" "$stage/control_plane.sqlite3"
+            ok "control_plane.sqlite3"
+        else
+            warn "file SQLite belum ada (bot belum pernah jalan?)"
+        fi
+    fi
+
+    # 3. Redis (worker state, job store, task events) — best-effort
+    if $COMPOSE ps --status running 2>/dev/null | grep -q redis; then
+        $COMPOSE exec -T redis redis-cli SAVE >/dev/null 2>&1 || true
+        $COMPOSE cp redis:/data/dump.rdb "$stage/redis-dump.rdb" 2>/dev/null \
+            && ok "redis-dump.rdb" || warn "redis dump dilewati"
+    fi
+
+    # 4. Manifest (untuk verifikasi di sisi restore)
+    {
+        echo "created_at=$TS"
+        echo "db_mode=$(_is_postgres && echo postgres || echo sqlite)"
+        echo "git_head=$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    } > "$stage/MANIFEST"
+    ok "MANIFEST"
+
+    tar -czf "$out" -C "$stage" .
+    rm -rf "$stage"
+    ok "Backup selesai: $out"
+    echo ""
+    echo -e "  Pindah ke server baru:"
+    echo -e "    ${YELLOW}scp $(basename "$out") user@server-baru:~/ai-agent/${NC}"
+    echo -e "    ${YELLOW}./scripts/octopus-backup.sh restore $(basename "$out")${NC}"
+}
+
+restore() {
+    local file="${1:-}"
+    [[ -n "$file" && -f "$file" ]] || die "Pakai: $0 restore <file.tar.gz>"
+    local stage="$ROOT/.restore-stage-$TS"
+    mkdir -p "$stage"
+    tar -xzf "$file" -C "$stage"
+    info "Manifest:"; cat "$stage/MANIFEST" 2>/dev/null | sed 's/^/    /'
+
+    # 1. .env
+    if [[ -f "$stage/.env" ]]; then
+        [[ -f "$ROOT/.env" ]] && cp "$ROOT/.env" "$ROOT/.env.before-restore-$TS"
+        cp "$stage/.env" "$ROOT/.env"
+        ok ".env dipulihkan (backup lama → .env.before-restore-$TS)"
+    fi
+
+    local db_mode; db_mode="$(grep -oP '(?<=^db_mode=).*' "$stage/MANIFEST" 2>/dev/null || echo sqlite)"
+
+    # 2. Database — start service yang relevan dulu
+    if [[ "$db_mode" == "postgres" ]]; then
+        info "Menyalakan Postgres untuk restore..."
+        $COMPOSE --profile postgres up -d postgres
+        sleep 8
+        if [[ -f "$stage/postgres.sql" ]]; then
+            $COMPOSE exec -T postgres psql -U "${POSTGRES_USER:-octopus}" \
+                < "$stage/postgres.sql" >/dev/null 2>&1 \
+                && ok "postgres restored" || warn "psql restore ada warning (cek manual)"
+        fi
+    else
+        mkdir -p "$ROOT/data"
+        if [[ -f "$stage/control_plane.sqlite3" ]]; then
+            cp "$stage/control_plane.sqlite3" "$ROOT/data/control_plane.sqlite3"
+            ok "SQLite DB dipulihkan"
+        fi
+    fi
+
+    # 3. Redis
+    if [[ -f "$stage/redis-dump.rdb" ]]; then
+        $COMPOSE up -d redis; sleep 3
+        $COMPOSE cp "$stage/redis-dump.rdb" redis:/data/dump.rdb 2>/dev/null \
+            && $COMPOSE restart redis && ok "Redis dipulihkan" || warn "Redis restore dilewati"
+    fi
+
+    rm -rf "$stage"
+    ok "Restore selesai."
+    echo ""
+    echo -e "  Jalankan semua service:"
+    if [[ "$db_mode" == "postgres" ]]; then
+        echo -e "    ${YELLOW}$COMPOSE --profile postgres --profile telegram up -d${NC}"
+    else
+        echo -e "    ${YELLOW}$COMPOSE --profile telegram up -d${NC}"
+    fi
+}
+
+case "${1:-}" in
+    backup)  backup ;;
+    restore) restore "${2:-}" ;;
+    *) die "Pakai: $0 {backup|restore <file>}" ;;
+esac


### PR DESCRIPTION
## What
Answers the operational need: **pindah server tanpa setup manual satu per satu**, plus makes RAG persistence a one-flag opt-in.

## How
### 1. Postgres + pgvector service (opt-in)
- New `postgres` service in docker-compose using `pgvector/pgvector:pg16`, behind a `postgres` **profile** so default (SQLite) deploys are unchanged — non-breaking.
- New volume `aiagent_postgres_data`. Compose validated in both default and `--profile postgres` modes.
- Activates RAG persistence: alembic migration already does `CREATE EXTENSION vector` + `knowledge_chunks` (HNSW cosine) on Postgres, auto-skipped on SQLite.

### 2. Backup / restore script (`scripts/octopus-backup.sh`)
- `backup` → one tarball with `.env` + database (SQLite file or `pg_dumpall`) + Redis dump + manifest.
- `restore <file>` → restores everything on a fresh host; auto-detects SQLite vs Postgres from the manifest, brings up the right services.
- **Pindah server = backup → scp → restore.** No re-entering tokens/config.

### 3. `.env.example` completed
- Added `GITHUB_TOKEN`/`GITHUB_REPO` (for `/task`), `POSTGRES_*`, `RAG_ENABLED`/`EMBEDDER_BACKEND`/`RAG_RECALL_K`, with the exact Postgres `DATABASE_URL` to copy.

### 4. `docs/DEPLOY.md`
- First install, SQLite-vs-Postgres choice, **3-step server migration**, safe update (no data loss), live monitoring, go-live checklist.

## Safety
- Default behaviour unchanged (SQLite, no postgres service) — existing single-node installs keep working untouched.
- No app code changed; ruff clean. Infra + docs only.

## Note
This is infra/ops tooling — no Python logic touched, so the 639-test suite is unaffected (ruff verified green).