### PR TITLE
feat: add read-only web dashboard and enriched health endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,11 @@ COPY alembic.ini .
 COPY alembic/ ./alembic/
 COPY app/ ./app/
 
+# Baked build version — surfaced by GET /health. release.yml passes the tag via
+# --build-arg APP_VERSION=<tag>; defaults to "dev" for local builds.
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
+
 RUN mkdir -p /app/data
 
 CMD ["python", "-m", "app.main"]

--- a/app/interfaces/dashboard.py
+++ b/app/interfaces/dashboard.py
@@ -1,0 +1,208 @@
+"""Read-only web dashboard for Octopus.
+
+Serves a single self-contained HTML page at ``GET /dashboard``. The page holds
+no secrets: the admin token is entered by the user, kept in ``localStorage``, and
+sent as a Bearer header from the browser to the existing JSON APIs (``/health``,
+``/tasks/``). It auto-refreshes every few seconds so you can glance at what
+Octopus is doing right now without SSH or curl.
+
+Kept as one inline HTML string (no build step, no static-file mounting) to match
+the project's "no extra infra" stance.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+router = APIRouter(tags=["dashboard"])
+
+_PAGE = """<!DOCTYPE html>
+<html lang="id">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Octopus Dashboard</title>
+<style>
+  :root { --bg:#0d1117; --panel:#161b22; --border:#30363d; --fg:#e6edf3;
+          --muted:#8b949e; --ok:#3fb950; --warn:#d29922; --bad:#f85149; --acc:#58a6ff; }
+  * { box-sizing:border-box; }
+  body { margin:0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+         background:var(--bg); color:var(--fg); font-size:14px; }
+  header { display:flex; align-items:center; gap:12px; padding:14px 20px;
+           border-bottom:1px solid var(--border); background:var(--panel); position:sticky; top:0; }
+  header h1 { font-size:16px; margin:0; font-weight:600; }
+  header .spacer { flex:1; }
+  .pill { padding:3px 10px; border-radius:999px; font-size:12px; font-weight:600; }
+  .pill.ok { background:rgba(63,185,80,.15); color:var(--ok); }
+  .pill.degraded { background:rgba(210,153,34,.15); color:var(--warn); }
+  .pill.unknown { background:rgba(139,148,158,.15); color:var(--muted); }
+  main { padding:20px; max-width:1000px; margin:0 auto; }
+  .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:12px; margin-bottom:20px; }
+  .card { background:var(--panel); border:1px solid var(--border); border-radius:8px; padding:14px; }
+  .card .label { color:var(--muted); font-size:12px; text-transform:uppercase; letter-spacing:.04em; }
+  .card .value { font-size:20px; font-weight:600; margin-top:6px; }
+  .dot { display:inline-block; width:8px; height:8px; border-radius:50%; margin-right:6px; vertical-align:middle; }
+  .dot.ok { background:var(--ok); } .dot.down { background:var(--bad); } .dot.unknown { background:var(--muted); }
+  h2 { font-size:14px; color:var(--muted); text-transform:uppercase; letter-spacing:.04em; margin:24px 0 10px; }
+  table { width:100%; border-collapse:collapse; background:var(--panel); border:1px solid var(--border); border-radius:8px; overflow:hidden; }
+  th,td { text-align:left; padding:9px 12px; border-bottom:1px solid var(--border); font-size:13px; }
+  th { color:var(--muted); font-weight:600; font-size:11px; text-transform:uppercase; }
+  tr:last-child td { border-bottom:none; }
+  .status { font-weight:600; }
+  .status.closed,.status.done,.status.step_ok { color:var(--ok); }
+  .status.failed,.status.step_failed { color:var(--bad); }
+  .status.started,.status.step_started,.status.issue_opened { color:var(--acc); }
+  a { color:var(--acc); text-decoration:none; } a:hover { text-decoration:underline; }
+  .muted { color:var(--muted); }
+  .empty { text-align:center; color:var(--muted); padding:24px; }
+  .login { max-width:360px; margin:80px auto; text-align:center; }
+  .login input { width:100%; padding:10px; margin:12px 0; background:var(--bg); border:1px solid var(--border);
+                 border-radius:6px; color:var(--fg); font-size:14px; }
+  .login button, .btn { padding:9px 16px; background:var(--acc); color:#0d1117; border:none; border-radius:6px;
+                        font-weight:600; cursor:pointer; font-size:13px; }
+  .btn.ghost { background:transparent; color:var(--muted); border:1px solid var(--border); }
+  .err { color:var(--bad); font-size:13px; min-height:18px; }
+  code { background:var(--bg); padding:1px 5px; border-radius:4px; font-size:12px; }
+</style>
+</head>
+<body>
+<div id="app"></div>
+<script>
+const $ = (id) => document.getElementById(id);
+const TOKEN_KEY = "octopus_admin_token";
+let timer = null;
+
+function getToken() { return localStorage.getItem(TOKEN_KEY) || ""; }
+function setToken(t) { localStorage.setItem(TOKEN_KEY, t); }
+function clearToken() { localStorage.removeItem(TOKEN_KEY); }
+
+function esc(s) {
+  return String(s == null ? "" : s).replace(/[&<>"']/g, (c) =>
+    ({ "&":"&amp;", "<":"&lt;", ">":"&gt;", '"':"&quot;", "'":"&#39;" }[c]));
+}
+
+async function api(path) {
+  const r = await fetch(path, { headers: { "Authorization": "Bearer " + getToken() } });
+  if (r.status === 401) { const e = new Error("unauthorized"); e.code = 401; throw e; }
+  if (!r.ok) throw new Error("HTTP " + r.status);
+  return r.json();
+}
+
+function renderLogin(msg) {
+  if (timer) { clearInterval(timer); timer = null; }
+  $("app").innerHTML = `
+    <div class="login">
+      <h1>&#128375; Octopus Dashboard</h1>
+      <p class="muted">Masukkan admin token untuk memantau.</p>
+      <input id="tok" type="password" placeholder="ADMIN_TOKEN" autofocus>
+      <div class="err" id="loginErr">${esc(msg || "")}</div>
+      <button onclick="doLogin()">Masuk</button>
+    </div>`;
+  $("tok").addEventListener("keydown", (e) => { if (e.key === "Enter") doLogin(); });
+}
+
+function doLogin() {
+  const t = $("tok").value.trim();
+  if (!t) { $("loginErr").textContent = "Token tidak boleh kosong."; return; }
+  setToken(t);
+  start();
+}
+
+function renderShell() {
+  $("app").innerHTML = `
+    <header>
+      <h1>&#128375; Octopus</h1>
+      <span class="pill unknown" id="statusPill">memuat...</span>
+      <div class="spacer"></div>
+      <span class="muted" id="lastUpdate"></span>
+      <button class="btn ghost" onclick="logout()">Keluar</button>
+    </header>
+    <main>
+      <div class="grid" id="statCards"></div>
+      <h2>Task Aktif</h2>
+      <div id="tasksBox"></div>
+      <h2>Timeline Event</h2>
+      <div id="eventsBox"></div>
+    </main>`;
+}
+
+function statCard(label, value) {
+  return `<div class="card"><div class="label">${esc(label)}</div><div class="value">${value}</div></div>`;
+}
+
+function renderHealth(h) {
+  const st = h.status || "unknown";
+  const pill = $("statusPill");
+  pill.className = "pill " + (st === "ok" ? "ok" : st === "degraded" ? "degraded" : "unknown");
+  pill.textContent = st.toUpperCase();
+  const deps = h.dependencies || {};
+  const depDots = Object.keys(deps).map((k) => {
+    const v = deps[k]; const cls = v === "ok" ? "ok" : "down";
+    return `<div><span class="dot ${cls}"></span>${esc(k)}: <span class="muted">${esc(v)}</span></div>`;
+  }).join("");
+  $("statCards").innerHTML =
+    statCard("Versi", "<code>" + esc(h.version || "?") + "</code>") +
+    statCard("Status", esc(st)) +
+    `<div class="card"><div class="label">Dependencies</div><div class="value" style="font-size:13px;line-height:1.9">${depDots || "-"}</div></div>`;
+}
+
+function renderTasks(tasks) {
+  if (!tasks || !tasks.length) { $("tasksBox").innerHTML = `<div class="card empty">Tidak ada task.</div>`; return; }
+  const rows = tasks.map((t) => {
+    const issue = t.issue_url ? `<a href="${esc(t.issue_url)}" target="_blank">#${esc(t.issue_number)}</a>` : "-";
+    return `<tr>
+      <td><code>${esc((t.task_id || "").slice(0, 8))}</code></td>
+      <td class="status ${esc(t.status)}">${esc(t.status)}</td>
+      <td>${esc(t.role)}</td>
+      <td>${esc(t.message)}</td>
+      <td>${issue}</td></tr>`;
+  }).join("");
+  $("tasksBox").innerHTML =
+    `<table><thead><tr><th>Task</th><th>Status</th><th>Role</th><th>Pesan</th><th>Issue</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+function renderEvents(events) {
+  if (!events || !events.length) { $("eventsBox").innerHTML = `<div class="card empty">Belum ada event.</div>`; return; }
+  const rows = events.map((e) => `<tr>
+      <td class="muted">${esc((e.ts || "").replace("T", " ").slice(0, 19))}</td>
+      <td><code>${esc((e.task_id || "").slice(0, 8))}</code></td>
+      <td>${esc(e.role)}</td>
+      <td class="status ${esc(e.status)}">${esc(e.status)}</td>
+      <td>${esc(e.message)}</td></tr>`).join("");
+  $("eventsBox").innerHTML =
+    `<table><thead><tr><th>Waktu</th><th>Task</th><th>Role</th><th>Status</th><th>Pesan</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+async function refresh() {
+  try {
+    const [health, board] = await Promise.all([api("/health"), api("/tasks/")]);
+    renderHealth(health);
+    renderTasks(board.tasks);
+    renderEvents(board.events);
+    $("lastUpdate").textContent = "Diperbarui " + new Date().toLocaleTimeString("id-ID");
+  } catch (e) {
+    if (e.code === 401) { clearToken(); renderLogin("Token salah atau kadaluarsa."); }
+  }
+}
+
+function start() {
+  renderShell();
+  refresh();
+  if (timer) clearInterval(timer);
+  timer = setInterval(refresh, 5000);
+}
+
+function logout() { clearToken(); renderLogin(""); }
+
+if (getToken()) start(); else renderLogin("");
+</script>
+</body>
+</html>
+"""
+
+
+@router.get("/dashboard", response_class=HTMLResponse)
+async def dashboard() -> HTMLResponse:
+    """Serve the self-contained read-only dashboard page."""
+    return HTMLResponse(content=_PAGE)

--- a/app/interfaces/gateway.py
+++ b/app/interfaces/gateway.py
@@ -9,6 +9,8 @@ from app.interfaces.admin import router as admin_router
 from app.interfaces.auth import router as auth_router
 from app.interfaces.chat import router as chat_router
 from app.interfaces.context import router as context_router
+from app.interfaces.dashboard import router as dashboard_router
+from app.interfaces.health import router as health_router
 from app.interfaces.skills import router as skills_router
 from app.interfaces.tasks import router as tasks_router
 from app.interfaces.worker_ws import router as worker_ws_router
@@ -51,31 +53,5 @@ app.include_router(skills_router)
 app.include_router(tasks_router)
 app.include_router(workflow_router)
 app.include_router(worker_ws_router)
-
-
-@app.get("/health")
-async def health() -> dict[str, object]:
-    """Public health endpoint — git HEAD, compose services, app status."""
-    import asyncio
-
-    from app.config import settings
-    from app.executor.runner import run_safe
-
-    def _check() -> dict[str, object]:
-        git_head, _ = run_safe(
-            ["git", "rev-parse", "--short", "HEAD"],
-            cwd=settings.project_dir,
-            timeout=5,
-        )
-        _, compose_rc = run_safe(
-            ["docker", "compose", "ps"],
-            cwd=settings.project_dir,
-            timeout=5,
-        )
-        return {
-            "status": "ok",
-            "git_head": git_head.strip(),
-            "compose": "ok" if compose_rc == 0 else "unavailable",
-        }
-
-    return await asyncio.to_thread(_check)
+app.include_router(health_router)
+app.include_router(dashboard_router)

--- a/app/interfaces/health.py
+++ b/app/interfaces/health.py
@@ -1,0 +1,103 @@
+"""Health endpoint — aggregated, best-effort dependency status.
+
+Replaces the old inline ``/health`` in ``gateway.py``. Reports:
+
+* ``version``   — git short SHA baked at build time (``APP_VERSION`` env) with a
+  runtime ``git rev-parse`` fallback for local dev.
+* ``dependencies`` — redis / ollama / database reachability. Each probe is
+  best-effort: a failure yields ``"down"`` (never a 500), and any dependency
+  down flips the top-level ``status`` to ``"degraded"``.
+
+Kept dependency-light and free of side effects so the dashboard can poll it
+every few seconds without cost.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+import httpx
+from fastapi import APIRouter
+
+from app.config import settings
+from app.executor.runner import run_safe
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["health"])
+
+_PROBE_TIMEOUT_SEC = 3.0
+
+
+def _version() -> str:
+    """Baked build version, falling back to a runtime git lookup for dev."""
+    baked = os.getenv("APP_VERSION", "").strip()
+    if baked:
+        return baked
+    git_head, rc = run_safe(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=settings.project_dir,
+        timeout=5,
+    )
+    return git_head.strip() if rc == 0 and git_head.strip() else "unknown"
+
+
+async def _check_redis() -> bool:
+    from app.adapters import redis_client
+
+    return await redis_client.ping()
+
+
+async def _check_ollama() -> bool:
+    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_SEC) as client:
+        resp = await client.get(f"{settings.ollama_host}/api/tags")
+        return resp.status_code == 200
+
+
+async def _check_database() -> bool:
+    from sqlalchemy import text
+
+    from app.adapters.database.session import (
+        create_database_engine,
+        create_session_factory,
+        session_scope,
+    )
+
+    def _probe() -> bool:
+        engine = create_database_engine(settings.database_url)
+        try:
+            factory = create_session_factory(engine)
+            with session_scope(factory) as session:
+                session.execute(text("SELECT 1"))
+            return True
+        finally:
+            engine.dispose()
+
+    return await asyncio.to_thread(_probe)
+
+
+async def _safe(probe: object, name: str) -> str:
+    try:
+        ok = await probe()  # type: ignore[operator]
+        return "ok" if ok else "down"
+    except Exception as exc:
+        logger.warning("health probe %s failed: %s", name, exc)
+        return "down"
+
+
+@router.get("/health")
+async def health() -> dict[str, object]:
+    """Aggregated health — version + best-effort dependency probes."""
+    redis_status, ollama_status, db_status = await asyncio.gather(
+        _safe(_check_redis, "redis"),
+        _safe(_check_ollama, "ollama"),
+        _safe(_check_database, "database"),
+    )
+    deps = {"redis": redis_status, "ollama": ollama_status, "database": db_status}
+    overall = "ok" if all(v == "ok" for v in deps.values()) else "degraded"
+    return {
+        "status": overall,
+        "version": _version(),
+        "dependencies": deps,
+    }

--- a/tests/interfaces/test_dashboard_endpoint.py
+++ b/tests/interfaces/test_dashboard_endpoint.py
@@ -1,0 +1,46 @@
+"""Tests for the read-only web dashboard route.
+
+The dashboard is a single self-contained HTML page served by FastAPI. It ships
+no secrets: the browser supplies the admin token from localStorage and calls the
+existing JSON APIs (/health, /tasks) client-side. These tests assert the route
+serves HTML and that the shell references the data endpoints it polls.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.interfaces import dashboard as dash_iface
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    app = FastAPI()
+    app.include_router(dash_iface.router)
+    yield TestClient(app)
+
+
+def test_dashboard_serves_html(client: TestClient) -> None:
+    resp = client.get("/dashboard")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert "<!DOCTYPE html>" in resp.text or "<!doctype html>" in resp.text.lower()
+
+
+def test_dashboard_references_data_endpoints(client: TestClient) -> None:
+    body = client.get("/dashboard").text
+    # The page polls the existing JSON APIs client-side.
+    assert "/tasks/" in body
+    assert "/health" in body
+
+
+def test_dashboard_has_no_baked_secret(client: TestClient) -> None:
+    body = client.get("/dashboard").text
+    # Token is entered by the user and kept in localStorage, never embedded.
+    assert "localStorage" in body
+    # The auth header is built from getToken() at runtime, not a baked value.
+    assert 'Bearer " + getToken()' in body

--- a/tests/interfaces/test_health_endpoint.py
+++ b/tests/interfaces/test_health_endpoint.py
@@ -1,0 +1,88 @@
+"""Tests for the enriched /health endpoint.
+
+Health aggregates best-effort dependency checks (redis, ollama, database) and a
+baked version string. Each dependency probe is monkeypatched so the test never
+touches real infra; this proves the HTTP contract and the degraded-vs-ok logic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.interfaces import health as health_iface
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    async def _ok_redis() -> bool:
+        return True
+
+    async def _ok_ollama() -> bool:
+        return True
+
+    async def _ok_db() -> bool:
+        return True
+
+    monkeypatch.setattr(health_iface, "_check_redis", _ok_redis)
+    monkeypatch.setattr(health_iface, "_check_ollama", _ok_ollama)
+    monkeypatch.setattr(health_iface, "_check_database", _ok_db)
+    monkeypatch.setattr(health_iface, "_version", lambda: "abc1234")
+
+    app = FastAPI()
+    app.include_router(health_iface.router)
+    yield TestClient(app)
+
+
+def test_health_ok_when_all_deps_up(client: TestClient) -> None:
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["version"] == "abc1234"
+    assert body["dependencies"] == {"redis": "ok", "ollama": "ok", "database": "ok"}
+
+
+def test_health_degraded_when_a_dep_down(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _ok() -> bool:
+        return True
+
+    async def _down() -> bool:
+        return False
+
+    monkeypatch.setattr(health_iface, "_check_redis", _ok)
+    monkeypatch.setattr(health_iface, "_check_ollama", _down)
+    monkeypatch.setattr(health_iface, "_check_database", _ok)
+    monkeypatch.setattr(health_iface, "_version", lambda: "v1")
+
+    app = FastAPI()
+    app.include_router(health_iface.router)
+    c = TestClient(app)
+
+    body = c.get("/health").json()
+    assert body["status"] == "degraded"
+    assert body["dependencies"]["ollama"] == "down"
+
+
+def test_health_never_raises_on_probe_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _boom() -> bool:
+        raise RuntimeError("connection refused")
+
+    async def _ok() -> bool:
+        return True
+
+    monkeypatch.setattr(health_iface, "_check_redis", _boom)
+    monkeypatch.setattr(health_iface, "_check_ollama", _ok)
+    monkeypatch.setattr(health_iface, "_check_database", _ok)
+    monkeypatch.setattr(health_iface, "_version", lambda: "v1")
+
+    app = FastAPI()
+    app.include_router(health_iface.router)
+    c = TestClient(app)
+
+    resp = c.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["dependencies"]["redis"] == "down"


### PR DESCRIPTION
## Ringkasan
Menambah **antarmuka web read-only** untuk memantau apa yang sedang Octopus kerjakan, plus memperkaya endpoint /health.

## Perubahan
- **`GET /dashboard`** — halaman HTML mandiri (vanilla JS, tanpa build step). Auto-refresh tiap 5 detik, polling /health + /tasks/. Menampilkan status server, task aktif, dan timeline event (dengan link ke GitHub issue).
  - Token-gated: admin token dimasukkan user, disimpan di localStorage, dikirim sbagai Bearer dari browser. Tidak ada secret yang di-bake.
- **`GET /health` diperkaya** — sekarang lapor `version` (baked APP_VERSION + fallback git) & `dependencies` (redis/ollama/database), dengan status `ok`/`degraded`. Menggantikan health lama yang lapor 'not a git repository' di container.
  - Dipindah dari inline gateway.py ke modul `app/interfaces/health.py` (hexagonal: satu concern per modul).
- **Dockerfile** — `ARG APP_VERSION` di-bake ke env untuk /health.

## Testing
- 9 test baru (health: ok/degraded/probe-error; dashboard: html/endpoints/no-secret) — TDD
- Full suite: **645 passed**, ruff clean, mypy clean

## Cara pakai setelah deploy
Buka `http://<host>:8090/dashboard` → masukkan ADMIN_TOKEN → pantau.