### PR TITLE
fix: bake APP_VERSION build arg in compose for /health version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,11 @@ services:
   # build: dipakai saat `docker compose up --build` (developer lokal)
   bot:
     image: ghcr.io/codinginid/ai-agent:latest
-    build: .
+    build:
+      context: .
+      args:
+        # Baked into GET /health. Override with APP_VERSION env when building.
+        APP_VERSION: ${APP_VERSION:-dev}
     container_name: aiagent_bot
     env_file: .env
     environment:


### PR DESCRIPTION
Deklarasi `build.args.APP_VERSION` di service bot supaya `docker compose build --build-arg APP_VERSION=<sha>` benar-benar ter-bake ke image → /health lapor versi git yang tepat (bukan 'dev').

Verified live: /health sekarang lapor version=ec2a392 (git HEAD).