### PR TITLE
feat: E2E pasukan — worker connect + command→task runner + gather-room live

### DIFF
--- a/app/adapters/github.py
+++ b/app/adapters/github.py
@@ -8,9 +8,13 @@ Requires:
 
 from __future__ import annotations
 
+import itertools
+import logging
 from dataclasses import dataclass
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 
 class GitHubUnavailableError(Exception):
@@ -167,3 +171,33 @@ class GitHubAdapter:
                 timeout=30,
             )
         self._raise_for_status(resp, "update_issue_label")
+
+
+class NullGitHubAdapter:
+    """In-memory issues adapter — task tracking tanpa GitHub (mode portable/mock).
+
+    Implements ``GitHubIssuesPort`` sehingga ``TaskRunner`` tetap jalan saat
+    GITHUB_TOKEN/REPO belum diisi: task tetap didekomposisi & didispatch ke
+    pasukan, hanya jejak issue-nya lokal (tidak ada sumber kebenaran eksternal).
+    """
+
+    def __init__(self) -> None:
+        self._counter = itertools.count(1)
+
+    async def create_issue(
+        self, title: str, body: str = "", labels: list[str] | None = None,
+    ) -> GitHubIssue:
+        number = next(self._counter)
+        logger.info("null-github: create_issue #%d %r", number, title[:60])
+        return GitHubIssue(
+            number=number,
+            title=title,
+            url=f"local://task/{number}",
+            state="open",
+        )
+
+    async def comment_issue(self, issue_number: int, body: str) -> None:
+        logger.debug("null-github: comment #%d %r", issue_number, body[:80])
+
+    async def close_issue(self, issue_number: int, comment: str = "") -> None:
+        logger.info("null-github: close_issue #%d", issue_number)

--- a/app/composition.py
+++ b/app/composition.py
@@ -173,19 +173,31 @@ def build_workflow_orchestrator() -> WorkflowOrchestrator:
 def build_task_runner() -> TaskRunner:
     """Compose the PM→Issue→Worker→Close task runner (orchestrator end-to-end).
 
-    Raises ``GitHubUnavailableError`` when GITHUB_TOKEN/REPO are unset — the
-    caller (endpoint) maps that to a 503 so the failure is explicit, not silent.
+    GitHub opsional: kalau GITHUB_TOKEN/REPO belum diisi, pakai
+    ``NullGitHubAdapter`` (jejak issue lokal) supaya task tetap didekomposisi &
+    didispatch ke pasukan (mode portable/mock), bukan gagal 503.
     """
-    from app.adapters.github import GitHubAdapter
+    from app.adapters.github import (
+        GitHubAdapter,
+        GitHubUnavailableError,
+        NullGitHubAdapter,
+    )
     from app.adapters.task_memory import RagTaskMemory
     from app.adapters.task_observer import LoggingTaskObserver
+    from app.interfaces.room import RoomTaskObserver
+    from app.ports.github_issues import GitHubIssuesPort
 
-    github = GitHubAdapter(token=settings.github_token, repo=settings.github_repo)
+    github: GitHubIssuesPort
+    try:
+        github = GitHubAdapter(token=settings.github_token, repo=settings.github_repo)
+    except GitHubUnavailableError:
+        github = NullGitHubAdapter()
+
     return TaskRunner(
         pm=PMAgent(),
         github=github,
         dispatch=WorkerDispatchAdapter(),
-        observer=LoggingTaskObserver(),
+        observer=RoomTaskObserver(LoggingTaskObserver()),
         memory=RagTaskMemory(
             embedder=_embedder(),
             store=_knowledge_store(),

--- a/app/interfaces/room.py
+++ b/app/interfaces/room.py
@@ -67,6 +67,68 @@ def publish_room_event(event_type: str, **data: Any) -> None:
     _bus.publish({"type": event_type, **data})
 
 
+# Role worker (TaskRunner) → avatar roster yang mewakili di ruangan.
+_ROLE_AVATAR: dict[str, str] = {
+    "engineer": "nadia",
+    "infra": "dewi",
+    "reviewer": "rangga",
+    "research": "yusuf",
+}
+
+
+class RoomTaskObserver:
+    """TaskObserver → RoomBus: bikin gather-room hidup saat TaskRunner jalan.
+
+    Publish ``activity`` (feed) + ``agent.status`` (avatar) per fase task, lalu
+    delegasi ke ``inner`` (LoggingTaskObserver) supaya papan ``/tasks`` & log
+    tetap terisi. Best-effort — kegagalan publish tak boleh menggagalkan task.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    @staticmethod
+    def _avatar(role: str) -> str:
+        return _ROLE_AVATAR.get(role, "yusuf")
+
+    def task_started(self, task_id: str, user_id: str, request: str) -> None:
+        publish_room_event("agent.status", id="octo", status="working")
+        publish_room_event("activity", level="info", text=f"Octo memecah tugas: {request[:120]}")
+        self._inner.task_started(task_id, user_id, request)
+
+    def issue_opened(self, task_id: str, issue_number: int, issue_url: str) -> None:
+        publish_room_event("activity", level="info", text=f"Tugas dicatat (#{issue_number})")
+        self._inner.issue_opened(task_id, issue_number, issue_url)
+
+    def step_started(self, task_id: str, order: int, role: str, description: str) -> None:
+        avatar = self._avatar(role)
+        publish_room_event("agent.status", id=avatar, status="working")
+        publish_room_event(
+            "activity", level="info",
+            text=f"Langkah {order} → {role}: {description[:100]}",
+        )
+        self._inner.step_started(task_id, order, role, description)
+
+    def step_finished(self, task_id: str, order: int, role: str, ok: bool, detail: str) -> None:
+        avatar = self._avatar(role)
+        publish_room_event("agent.status", id=avatar, status="idle")
+        publish_room_event(
+            "activity",
+            level="done" if ok else "error",
+            text=f"Langkah {order} ({role}) {'selesai' if ok else 'gagal'}",
+        )
+        self._inner.step_finished(task_id, order, role, ok, detail)
+
+    def task_finished(self, task_id: str, *, closed: bool, ok: bool, note: str) -> None:
+        publish_room_event("agent.status", id="octo", status="idle")
+        publish_room_event(
+            "activity",
+            level="done" if ok else "error",
+            text=f"Tugas {'selesai' if ok else 'berhenti'}: {note[:120]}",
+        )
+        self._inner.task_finished(task_id, closed=closed, ok=ok, note=note)
+
+
 def _snapshot() -> dict[str, Any]:
     return {
         "type": "room.snapshot",

--- a/app/interfaces/room.py
+++ b/app/interfaces/room.py
@@ -75,6 +75,14 @@ _ROLE_AVATAR: dict[str, str] = {
     "research": "yusuf",
 }
 
+# Role worker (backend) → Role kartu kanban di frontend (types.ts).
+_ROLE_CARD: dict[str, str] = {
+    "engineer": "coder",
+    "infra": "deployer",
+    "reviewer": "reviewer",
+    "research": "researcher",
+}
+
 
 class RoomTaskObserver:
     """TaskObserver → RoomBus: bikin gather-room hidup saat TaskRunner jalan.
@@ -91,6 +99,10 @@ class RoomTaskObserver:
     def _avatar(role: str) -> str:
         return _ROLE_AVATAR.get(role, "yusuf")
 
+    @staticmethod
+    def _card_id(task_id: str, order: int) -> str:
+        return f"{task_id}-{order}"
+
     def task_started(self, task_id: str, user_id: str, request: str) -> None:
         publish_room_event("agent.status", id="octo", status="working")
         publish_room_event("activity", level="info", text=f"Octo memecah tugas: {request[:120]}")
@@ -104,6 +116,13 @@ class RoomTaskObserver:
         avatar = self._avatar(role)
         publish_room_event("agent.status", id=avatar, status="working")
         publish_room_event(
+            "task.card",
+            id=self._card_id(task_id, order),
+            desc=description[:100],
+            role=_ROLE_CARD.get(role, "researcher"),
+            col="doing",
+        )
+        publish_room_event(
             "activity", level="info",
             text=f"Langkah {order} → {role}: {description[:100]}",
         )
@@ -112,6 +131,11 @@ class RoomTaskObserver:
     def step_finished(self, task_id: str, order: int, role: str, ok: bool, detail: str) -> None:
         avatar = self._avatar(role)
         publish_room_event("agent.status", id=avatar, status="idle")
+        publish_room_event(
+            "task.card",
+            id=self._card_id(task_id, order),
+            col="done" if ok else "todo",
+        )
         publish_room_event(
             "activity",
             level="done" if ok else "error",
@@ -129,13 +153,31 @@ class RoomTaskObserver:
         self._inner.task_finished(task_id, closed=closed, ok=ok, note=note)
 
 
-def _snapshot() -> dict[str, Any]:
+def _snapshot(workers: int = 0) -> dict[str, Any]:
     return {
         "type": "room.snapshot",
         "agents": [dict(a, status="idle") for a in _ROSTER],
         "tasks": [],
         "approvals": [],
+        "workers": workers,
     }
+
+
+async def _worker_count_for(user_id: str, mode: str) -> int:
+    """Hitung pasukan online untuk room caller. Admin → user demo (room tunggal)."""
+    from app.adapters.worker_registry import worker_count
+    from app.interfaces.chat import _resolve_admin_target
+
+    target = user_id
+    if mode == "admin":
+        try:
+            target = _resolve_admin_target("demo@local")
+        except Exception:
+            return 0
+    try:
+        return await worker_count(target)
+    except Exception:
+        return 0
 
 
 def _sse(event: dict[str, Any]) -> str:
@@ -145,14 +187,15 @@ def _sse(event: dict[str, Any]) -> str:
 
 @router.get("/state")
 async def room_state(authorization: str | None = Header(default=None)) -> JSONResponse:
-    _resolve_caller(authorization)  # gate: session/admin token (401 kalau tidak)
-    return JSONResponse(_snapshot())
+    user_id, mode = _resolve_caller(authorization)  # gate: 401 kalau token invalid
+    workers = await _worker_count_for(user_id, mode)
+    return JSONResponse(_snapshot(workers))
 
 
-async def _room_stream() -> AsyncIterator[str]:
+async def _room_stream(workers: int = 0) -> AsyncIterator[str]:
     q = _bus.subscribe()
     try:
-        yield _sse(_snapshot())
+        yield _sse(_snapshot(workers))
         while True:
             try:
                 event = await asyncio.wait_for(q.get(), timeout=15.0)
@@ -167,5 +210,6 @@ async def _room_stream() -> AsyncIterator[str]:
 async def room_stream(
     authorization: str | None = Header(default=None),
 ) -> StreamingResponse:
-    _resolve_caller(authorization)
-    return StreamingResponse(_room_stream(), media_type="text/event-stream")
+    user_id, mode = _resolve_caller(authorization)
+    workers = await _worker_count_for(user_id, mode)
+    return StreamingResponse(_room_stream(workers), media_type="text/event-stream")

--- a/app/interfaces/worker_ws.py
+++ b/app/interfaces/worker_ws.py
@@ -255,6 +255,7 @@ async def worker_socket(
         "worker_id": worker_id,
         "user_id": user_id,
     })
+    _publish_worker_presence("worker.online", worker_id)
 
     try:
         while True:
@@ -315,6 +316,17 @@ async def worker_socket(
             await unregister(user_id, worker_id)
         except Exception:
             logger.exception("failed to unregister worker")
+        _publish_worker_presence("worker.offline", worker_id)
+
+
+def _publish_worker_presence(event_type: str, worker_id: str) -> None:
+    """Umumkan pasukan online/offline ke gather-room. Best-effort, lazy import
+    (hindari circular: room → chat → worker_ws)."""
+    try:
+        from app.interfaces.room import publish_room_event
+        publish_room_event(event_type, id=worker_id)
+    except Exception:
+        logger.debug("gagal publish presence worker", exc_info=True)
 
 
 # ── Public helpers untuk dispatcher (Fase B2) ─────────────────────────────────

--- a/scripts/test_worker.py
+++ b/scripts/test_worker.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Worker uji minimal — pasukan tiruan untuk E2E testing dispatch.
+
+Bicara protokol WS worker (`/ws/worker`): register → capabilities → heartbeat,
+lalu balas setiap `job` dengan `job_chunk` + `job_done` (echo, tanpa CLI asli).
+
+Env:
+    WORKER_WS_URL   default ws://aiagent_web/ws/worker
+    WORKER_SESSION  session token (wajib)
+    WORKER_DEVICE   nama device tampil di roster (default test-worker)
+    WORKER_AGENTS   comma list agent yang "installed" (default codex,claude,glm)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import websockets
+
+WS_URL = os.environ.get("WORKER_WS_URL", "ws://aiagent_web/ws/worker")
+SESSION = os.environ.get("WORKER_SESSION", "")
+DEVICE = os.environ.get("WORKER_DEVICE", "test-worker")
+AGENTS = [a.strip() for a in os.environ.get("WORKER_AGENTS", "codex,claude,glm").split(",") if a.strip()]
+
+
+async def _heartbeat(ws: websockets.WebSocketClientProtocol) -> None:
+    while True:
+        await asyncio.sleep(20)
+        await ws.send(json.dumps({"type": "heartbeat"}))
+
+
+async def _handle_job(ws: websockets.WebSocketClientProtocol, msg: dict) -> None:
+    job_id = msg.get("job_id", "")
+    agent = msg.get("agent", "?")
+    prompt = msg.get("prompt", "")
+    print(f"[job] {job_id} agent={agent} prompt={prompt[:80]!r}", flush=True)
+    await ws.send(json.dumps({
+        "type": "job_chunk",
+        "job_id": job_id,
+        "text": f"[{DEVICE}/{agent}] menerima tugas: {prompt[:120]}\n",
+    }))
+    await asyncio.sleep(0.5)
+    await ws.send(json.dumps({
+        "type": "job_done",
+        "job_id": job_id,
+        "summary": f"selesai (mock worker) oleh {agent} di {DEVICE}",
+    }))
+    print(f"[job] {job_id} done", flush=True)
+
+
+async def main() -> None:
+    if not SESSION:
+        raise SystemExit("WORKER_SESSION belum diset")
+    url = f"{WS_URL}?session={SESSION}"
+    print(f"[worker] connecting {WS_URL} device={DEVICE} agents={AGENTS}", flush=True)
+    async with websockets.connect(url, max_size=None) as ws:
+        hb = asyncio.create_task(_heartbeat(ws))
+        # advertise capabilities segera setelah connect
+        await ws.send(json.dumps({
+            "type": "capabilities",
+            "device_name": DEVICE,
+            "agents": {a: {"installed": True} for a in AGENTS},
+        }))
+        try:
+            async for raw in ws:
+                msg = json.loads(raw)
+                kind = msg.get("type", "")
+                if kind == "registered":
+                    print(f"[worker] registered worker_id={msg.get('worker_id')}", flush=True)
+                elif kind == "job":
+                    await _handle_job(ws, msg)
+                elif kind == "heartbeat_ack":
+                    pass
+                else:
+                    print(f"[worker] <- {kind}: {msg}", flush=True)
+        finally:
+            hb.cancel()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/test_worker.py
+++ b/scripts/test_worker.py
@@ -49,14 +49,10 @@ async def _handle_job(ws: websockets.WebSocketClientProtocol, msg: dict) -> None
     print(f"[job] {job_id} done", flush=True)
 
 
-async def main() -> None:
-    if not SESSION:
-        raise SystemExit("WORKER_SESSION belum diset")
+async def _session_once() -> None:
     url = f"{WS_URL}?session={SESSION}"
-    print(f"[worker] connecting {WS_URL} device={DEVICE} agents={AGENTS}", flush=True)
     async with websockets.connect(url, max_size=None) as ws:
         hb = asyncio.create_task(_heartbeat(ws))
-        # advertise capabilities segera setelah connect
         await ws.send(json.dumps({
             "type": "capabilities",
             "device_name": DEVICE,
@@ -76,6 +72,21 @@ async def main() -> None:
                     print(f"[worker] <- {kind}: {msg}", flush=True)
         finally:
             hb.cancel()
+
+
+async def main() -> None:
+    if not SESSION:
+        raise SystemExit("WORKER_SESSION belum diset")
+    print(f"[worker] connecting {WS_URL} device={DEVICE} agents={AGENTS}", flush=True)
+    # Auto-reconnect: tahan restart proxy/bot (koneksi WS lewat nginx bisa putus).
+    while True:
+        try:
+            await _session_once()
+        except Exception as exc:
+            print(f"[worker] disconnected: {exc} — reconnect 3s", flush=True)
+        else:
+            print("[worker] connection closed — reconnect 3s", flush=True)
+        await asyncio.sleep(3)
 
 
 if __name__ == "__main__":

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -22,6 +22,13 @@ server {
         proxy_buffering off;
         proxy_read_timeout 3600s;
     }
+    location /tasks/ {
+        proxy_pass http://bot:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Connection "";
+        proxy_read_timeout 3600s;
+    }
     location /auth/ {
         proxy_pass http://bot:8080;
         proxy_set_header Host $host;

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -30,6 +30,16 @@ server {
         proxy_pass http://bot:8080/health;
     }
 
+    # ── Worker WebSocket (/ws/worker) : pasukan connect via origin publik ──────
+    location /ws/ {
+        proxy_pass http://bot:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 3600s;
+    }
+
     # ── SPA fallback ──────────────────────────────────────────────────────────
     location / {
         try_files $uri /index.html;

--- a/web/src/net/api.ts
+++ b/web/src/net/api.ts
@@ -92,6 +92,37 @@ export async function sendCommand(payload: CommandPayload): Promise<boolean> {
   }
 }
 
+export interface TaskOutcome {
+  order: number;
+  description: string;
+  role: string;
+  ok: boolean;
+  detail: string;
+}
+export interface TaskRunResult {
+  ok: boolean;
+  issue_url: string;
+  summary: string;
+  note: string;
+  outcomes: TaskOutcome[];
+}
+
+/** POST perintah ke Manajer IT (TaskRunner): PM pecah tugas → dispatch per-role
+ *  ke pasukan. Progres live muncul di /room/stream; ini kembalikan hasil akhir. */
+export async function runTask(request: string): Promise<TaskRunResult | null> {
+  try {
+    const resp = await fetch(`${API_BASE}/tasks/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body: JSON.stringify({ request, as_email: "demo@local" }),
+    });
+    if (!resp.ok) return null;
+    return (await resp.json()) as TaskRunResult;
+  } catch {
+    return null;
+  }
+}
+
 async function _decide(path: string, planId: string): Promise<boolean> {
   try {
     const resp = await fetch(`${API_BASE}${path}`, {

--- a/web/src/state/store.ts
+++ b/web/src/state/store.ts
@@ -120,6 +120,10 @@ interface RoomState {
   selectedId: string | null;
   theme: Theme;
   managerName: string;
+  /** pasukan (worker) online — dari /room/state + event worker.online/offline */
+  workers: number;
+  /** true begitu backend nyata mengendalikan ruangan → matikan spawner mock */
+  live: boolean;
 
   // actions
   select: (id: string | null) => void;
@@ -179,14 +183,18 @@ export const useStore = create<RoomState>((set, get) => {
       });
     }
   };
-  const setCol = (board: BoardCard[], id: number, col: BoardCol): void => {
+  const setCol = (
+    board: BoardCard[],
+    id: number | string,
+    col: BoardCol,
+  ): void => {
     const c = board.find((bc) => bc.id === id);
     if (c) {
       c.col = col;
       if (col === "done") c.doneT = 0;
     }
   };
-  const removeCard = (board: BoardCard[], id: number): void => {
+  const removeCard = (board: BoardCard[], id: number | string): void => {
     const i = board.findIndex((c) => c.id === id);
     if (i >= 0) board.splice(i, 1);
   };
@@ -272,6 +280,8 @@ export const useStore = create<RoomState>((set, get) => {
     selectedId: null,
     theme: initialTheme(),
     managerName: MANAGER,
+    workers: 0,
+    live: false,
 
     select: (id) => set({ selectedId: id }),
 
@@ -293,22 +303,21 @@ export const useStore = create<RoomState>((set, get) => {
     submitCommand: (text) => {
       const txt = text.trim();
       if (!txt) return;
-      const risky =
-        /(restart|deploy|hapus|reboot|rotasi|kredensial|drop|matikan|down)/i.test(
-          txt,
-        );
-      const review = /(perbaiki|fix|refactor|tulis|buat|implement|kode|optimasi)/i.test(
-        txt,
-      );
-      let role: Role = "coder";
-      if (/(deploy|restart|backup|kredensial|reboot)/i.test(txt)) role = "deployer";
-      else if (/(test|uji|scan)/i.test(txt)) role = "tester";
-      else if (/(review|periksa)/i.test(txt)) role = "reviewer";
-      else if (/(cek|audit|analisa|riset|profil|disk|log)/i.test(txt))
-        role = "researcher";
+      const safe = escapeHtml(txt);
+
+      // Ruangan kini dikendalikan backend nyata → matikan simulasi mock.
+      set((s) => ({
+        live: true,
+        events: feedInto(
+          s.events,
+          `📩 <b>${MANAGER}</b> menerima perintahmu: “${safe}”`,
+          "work",
+        ),
+      }));
 
       // Kirim ke Manajer IT nyata (TaskRunner): PM pecah tugas → dispatch
-      // per-role ke pasukan. Progres live via /room/stream; hasil akhir → feed.
+      // per-role ke pasukan. Kartu kanban + avatar digerakkan event
+      // /room/stream (task.card); hasil akhir → feed.
       void runTask(txt).then((res) => {
         if (!res) return;
         set((s) => ({
@@ -320,21 +329,6 @@ export const useStore = create<RoomState>((set, get) => {
             res.ok ? "done" : "error",
           ),
         }));
-      });
-      const safe = escapeHtml(txt);
-      set((s) => {
-        const agents = s.agents.map((a) => ({ ...a }));
-        const board = s.board.map((c) => ({ ...c }));
-        const queue = [...s.queue];
-        const approvals = s.approvals;
-        let events = feedInto(
-          s.events,
-          `📩 <b>${MANAGER}</b> menerima perintahmu: “${safe}”`,
-          "work",
-        );
-        const task: Task = { id: ++taskSeq, desc: safe, role, risky, review };
-        events = assign(task, agents, board, events, approvals, queue);
-        return { agents, board, queue, events };
       });
     },
 
@@ -368,6 +362,43 @@ export const useStore = create<RoomState>((set, get) => {
           return {
             serverApprovals: s.serverApprovals.filter((a) => a.planId !== planId),
           };
+        }
+        if (type === "room.snapshot") {
+          const w = Number((ev as { workers?: unknown }).workers ?? 0);
+          return { workers: Number.isFinite(w) ? w : 0, live: w > 0 || s.live };
+        }
+        if (type === "worker.online") {
+          return {
+            workers: s.workers + 1,
+            live: true,
+            events: feedInto(s.events, "🟢 Pasukan bergabung (worker online)", "done"),
+          };
+        }
+        if (type === "worker.offline") {
+          return {
+            workers: Math.max(0, s.workers - 1),
+            events: feedInto(s.events, "⚪ Pasukan keluar (worker offline)", "idle"),
+          };
+        }
+        if (type === "task.card") {
+          const id = String((ev as { id?: unknown }).id ?? "");
+          if (!id) return {};
+          const col = String((ev as { col?: unknown }).col ?? "") as BoardCol;
+          const board = s.board.map((c) => ({ ...c }));
+          // Kartu baru (doing) → animasikan avatar role terkait via mesin assign.
+          if (col === "doing" && !board.some((c) => c.id === id)) {
+            const desc = escapeHtml(String((ev as { desc?: unknown }).desc ?? ""));
+            const role = String((ev as { role?: unknown }).role ?? "researcher") as Role;
+            const agents = s.agents.map((a) => ({ ...a }));
+            const approvals = s.approvals.map((r) => ({ ...r }));
+            const queue = [...s.queue];
+            const task: Task = { id, desc, role };
+            const events = assign(task, agents, board, s.events, approvals, queue);
+            return { live: true, agents, board, approvals, queue, events };
+          }
+          // Update kolom (done/todo) = kebenaran backend.
+          setCol(board, id, col || "done");
+          return { live: true, board };
         }
         return {};
       });
@@ -447,16 +478,18 @@ export const useStore = create<RoomState>((set, get) => {
           const queue = [...s.queue];
           let events = s.events;
 
-          // ── manager auto-scheduler ──
-          spawnT -= dt;
-          if (spawnT <= 0) {
-            spawnT = rand(4.5, 8);
-            const active = agents.filter(
-              (a) => a.role !== "manager" && a.state !== "idle",
-            ).length;
-            if (active < 4 && Math.random() < 0.85) {
-              const t: Task = { ...choice(TASKS), id: ++taskSeq };
-              events = assign(t, agents, board, events, approvals, queue);
+          // ── manager auto-scheduler (mock) — mati begitu backend nyata live ──
+          if (!s.live) {
+            spawnT -= dt;
+            if (spawnT <= 0) {
+              spawnT = rand(4.5, 8);
+              const active = agents.filter(
+                (a) => a.role !== "manager" && a.state !== "idle",
+              ).length;
+              if (active < 4 && Math.random() < 0.85) {
+                const t: Task = { ...choice(TASKS), id: ++taskSeq };
+                events = assign(t, agents, board, events, approvals, queue);
+              }
             }
           }
 

--- a/web/src/state/store.ts
+++ b/web/src/state/store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { approvePlan, rejectPlan, sendCommand } from "../net/api";
+import { approvePlan, rejectPlan, runTask } from "../net/api";
 import type {
   Agent,
   Approval,
@@ -307,8 +307,20 @@ export const useStore = create<RoomState>((set, get) => {
       else if (/(cek|audit|analisa|riset|profil|disk|log)/i.test(txt))
         role = "researcher";
 
-      // Kirim ke backend nyata (best-effort). Event balik lewat /room/stream.
-      void sendCommand({ text: txt });
+      // Kirim ke Manajer IT nyata (TaskRunner): PM pecah tugas → dispatch
+      // per-role ke pasukan. Progres live via /room/stream; hasil akhir → feed.
+      void runTask(txt).then((res) => {
+        if (!res) return;
+        set((s) => ({
+          events: feedInto(
+            s.events,
+            res.ok
+              ? `✅ <b>${MANAGER}</b> selesai (${res.outcomes.length} langkah): ${escapeHtml(res.summary)}`
+              : `⚠️ <b>${MANAGER}</b> berhenti: ${escapeHtml(res.note)}`,
+            res.ok ? "done" : "error",
+          ),
+        }));
+      });
       const safe = escapeHtml(txt);
       set((s) => {
         const agents = s.agents.map((a) => ({ ...a }));

--- a/web/src/state/types.ts
+++ b/web/src/state/types.ts
@@ -23,7 +23,8 @@ export interface LogEntry {
 }
 
 export interface Task {
-  id: number;
+  // number = tugas simulasi lokal; string = task step dari backend.
+  id: number | string;
   desc: string;
   role: Role;
   risky?: boolean;
@@ -86,7 +87,8 @@ export interface RoomEvent {
 export type BoardCol = "todo" | "doing" | "review" | "done";
 
 export interface BoardCard {
-  id: number;
+  // number = kartu simulasi lokal; string = kartu dari backend (task step).
+  id: number | string;
   desc: string;
   role: Role;
   col: BoardCol;

--- a/web/src/ui/TopBar.tsx
+++ b/web/src/ui/TopBar.tsx
@@ -4,6 +4,7 @@ import { ProviderButton } from "./ProviderSettings";
 
 export function TopBar(): JSX.Element {
   const count = useStore((s) => s.agents.length);
+  const workers = useStore((s) => s.workers);
   const theme = useStore((s) => s.theme);
   const toggleTheme = useStore((s) => s.toggleTheme);
 
@@ -28,6 +29,20 @@ export function TopBar(): JSX.Element {
       <div className="flex items-center gap-1.5 whitespace-nowrap font-mono text-[12px] text-ink-soft">
         <span className="h-[7px] w-[7px] rounded-full bg-accent shadow-[0_0_8px_var(--accent)]" />
         {count} agen
+      </div>
+
+      <div
+        className="flex items-center gap-1.5 whitespace-nowrap font-mono text-[12px] text-ink-soft"
+        title="Pasukan (worker) yang terhubung ke backend"
+      >
+        <span
+          className={
+            workers > 0
+              ? "h-[7px] w-[7px] rounded-full bg-[#3ddc84] shadow-[0_0_8px_#3ddc84]"
+              : "h-[7px] w-[7px] rounded-full bg-ink-faint"
+          }
+        />
+        {workers} pasukan
       </div>
 
       <ProviderButton />


### PR DESCRIPTION
Menyambungkan **pasukan nyata**, menyalurkan perintah command bar ke mereka via TaskRunner, dan membuat **gather-room jadi cermin 1:1 aktivitas backend**. Melengkapi alur "kirim perintah → pasukan kerja → terlihat di ruang" (Part of #82).

## 1. Konektivitas worker (#2)
- **web/nginx.conf** — `location /ws/` (Upgrade/Connection) → worker connect ke `/ws/worker` via origin publik.
- **scripts/test_worker.py** — worker uji minimal, **auto-reconnect** (tahan restart proxy/bot).

## 2. Command bar → TaskRunner (#1)
- **NullGitHubAdapter** — TaskRunner jalan tanpa GitHub (portable/mock); jejak issue lokal.
- **RoomTaskObserver** — mirror lifecycle task → RoomBus (feed + avatar), tetap isi papan `/tasks`.
- **build_task_runner** — fallback NullGitHub + observer room.
- **nginx** — proxy `/tasks/`; **frontend** — command bar → `runTask` (`POST /tasks/run`).

## 3. Gather-room = cermin backend nyata (#3)
- **room** — RoomTaskObserver emit `task.card` (doing→done per langkah); `/room/state` & `/room/stream` sertakan **jumlah worker nyata**.
- **worker_ws** — publish `worker.online`/`worker.offline` ke RoomBus saat register/disconnect.
- **frontend** — `applyServerEvent` handle `task.card` (**papan kanban dari backend**), `worker.*` + `room.snapshot` (indikator **'N pasukan'**); mode **live** mematikan spawner mock begitu backend mengendalikan ruangan.
- **TopBar** — indikator pasukan online (hijau bila ada worker). **types** — id kartu/task dukung string (step backend).

## Verifikasi E2E (stack containerized, mock provider, via nginx :8092)
- Worker connect `/ws/worker` → registered; `/room/state` **workers=1**.
- `POST /tasks/run` → PM pecah 2 langkah → dispatch role infra → worker eksekusi → **ok=true, closed=true**.
- `/room/stream`: `agent.status` + **`task.card doing→done`** + `activity` + presence — semua mengalir.
- **Screenshot browser** (playwright): papan SELESAI berisi langkah task asli, avatar Dewi 'Bekerja', '1 pasukan', feed alur nyata.

## Cek
`ruff` ✅ · `mypy` (145 file) ✅ · pytest **701 passed** (checkout bersih; 3 gagal lokal hanya karena `.env` dev).

Part of #82