### PR TITLE
fix: koreksi default DEPLOY_DIR ke path VPS yang benar

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          DEPLOY_DIR="${DEPLOY_DIR:-/home/ali/project/codinginid/ai-agent}"
+          DEPLOY_DIR="${DEPLOY_DIR:-/home/ali/project/ai-agent}"
 
           if [ ! -d "$DEPLOY_DIR/.git" ]; then
             echo "::error::Deploy directory tidak ditemukan: $DEPLOY_DIR"


### PR DESCRIPTION
Default fallback `DEPLOY_DIR` menunjuk `/home/ali/project/codinginid/ai-agent` (tak ada) → tiap merge ke main gagal auto-deploy. Betulkan ke `/home/ali/project/ai-agent`.

Repo variable `DEPLOY_DIR` juga sudah diset sebagai override utama; ini defense-in-depth kalau variable hilang.

**Terverifikasi:** setelah set variable, deploy run [32928258159](https://github.com/CodinginID/ai-agent/actions/runs/32928258159) **sukses** (Validate ✓ · Deploy ✓ · Verify ✓), container healthy.

Part of #82