### PR TITLE
fix(ci): perkuat git-sync deploy agar tahan posisi branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,12 @@ jobs:
           fi
           ssh -T git@github-work || true
           git fetch origin main
-          git merge --ff-only FETCH_HEAD
+          # Robust: deploy dir kadang tertinggal di branch lain (mis. saat dev),
+          # yang bikin `merge --ff-only FETCH_HEAD` gagal. Pastikan di main dulu,
+          # baru fast-forward ke origin/main. Gagal keras kalau divergen (bukan
+          # silent) — tak pakai reset --hard agar tak menghapus kerja lokal.
+          git checkout main 2>/dev/null || git checkout -B main origin/main
+          git merge --ff-only origin/main
           make deploy
 
   # ── 3. Verifikasi semua container running ───────────────────────────────────


### PR DESCRIPTION
## Masalah
Deploy #90 gagal: `fatal: Not possible to fast-forward, aborting` — deploy dir (kebetulan = direktori dev) sedang di branch lain saat `git merge --ff-only FETCH_HEAD`, jadi mencoba merge main ke branch feature.

## Perbaikan
Pastikan **checkout main dulu**, baru `git merge --ff-only origin/main`. Gagal keras kalau divergen (bukan silent), dan **tanpa `reset --hard`** supaya tak menghapus kerja lokal.

## Catatan (rekomendasi lanjutan, tidak di PR ini)
Akar kerapuhan: `DEPLOY_DIR` = direktori kerja dev. Idealnya deploy pakai **clone terpisah** (basename `ai-agent` agar project compose sama) supaya dev & deploy benar-benar terisolasi — bisa dikerjakan terpisah bila diinginkan.

Part of #82