### PR TITLE
feat(web): mobile app shell + kelola pasukan (roster CRUD)

### DIFF
--- a/app/adapters/redis_client.py
+++ b/app/adapters/redis_client.py
@@ -167,6 +167,11 @@ def k_push_subs(user_id: str) -> str:
     return f"push:subs:{user_id}"
 
 
+def k_roster(user_id: str) -> str:
+    """Hash roster pasukan per user (field=agent_id, value=JSON)."""
+    return f"room:roster:{user_id}"
+
+
 # ── Generic helpers ──────────────────────────────────────────────────────────
 
 async def healthcheck() -> dict[str, Any]:

--- a/app/adapters/roster_redis.py
+++ b/app/adapters/roster_redis.py
@@ -1,0 +1,74 @@
+"""Roster adapter — CRUD nama/peran agen di Redis hash, satu hash per user.
+
+``RedisRosterStore.list`` mengembalikan ``DEFAULT_ROSTER`` selama hash belum
+pernah ditulis (user belum pernah mengubah roster-nya). Begitu ada mutasi
+pertama (``upsert``/``delete``), hash di-seed dengan seluruh ``DEFAULT_ROSTER``
+lebih dulu — supaya rename/hapus satu agen tidak diam-diam membuang 6 agen
+default lain yang belum pernah disentuh user.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Protocol, cast
+
+from app.adapters.redis_client import get_client, k_roster
+from app.ports.roster import DEFAULT_ROSTER, RosterAgent
+
+logger = logging.getLogger(__name__)
+
+
+class _RedisLike(Protocol):
+    async def hset(self, name: str, key: str, value: str) -> Any: ...
+    async def hgetall(self, name: str) -> dict[str, str]: ...
+    async def hdel(self, name: str, *keys: str) -> Any: ...
+
+
+def _encode(agent: RosterAgent) -> str:
+    return json.dumps({"id": agent.id, "name": agent.name, "role": agent.role})
+
+
+def _decode(raw: str) -> RosterAgent | None:
+    try:
+        d = json.loads(raw)
+        return RosterAgent(id=d["id"], name=d["name"], role=d["role"])
+    except (ValueError, KeyError, TypeError):
+        logger.warning("roster entry korup, dilewati")
+        return None
+
+
+class RedisRosterStore:
+    """``RosterPort`` konkret — hash Redis (field=agent_id, value=JSON)."""
+
+    def __init__(self, redis_client: _RedisLike | None = None) -> None:
+        self._client = redis_client
+
+    def _redis(self) -> _RedisLike:
+        if self._client is not None:
+            return self._client
+        return cast("_RedisLike", get_client())
+
+    async def list(self, user_id: str) -> list[RosterAgent]:
+        raw = await self._redis().hgetall(k_roster(user_id))
+        if not raw:
+            return list(DEFAULT_ROSTER)
+        agents = [_decode(v) for v in raw.values()]
+        return [a for a in agents if a is not None]
+
+    async def _seed_if_empty(self, user_id: str) -> None:
+        existing = await self._redis().hgetall(k_roster(user_id))
+        if existing:
+            return
+        redis = self._redis()
+        for agent in DEFAULT_ROSTER:
+            await redis.hset(k_roster(user_id), agent.id, _encode(agent))
+
+    async def upsert(self, user_id: str, agent: RosterAgent) -> None:
+        await self._seed_if_empty(user_id)
+        await self._redis().hset(k_roster(user_id), agent.id, _encode(agent))
+
+    async def delete(self, user_id: str, agent_id: str) -> bool:
+        await self._seed_if_empty(user_id)
+        n = await self._redis().hdel(k_roster(user_id), agent_id)
+        return bool(n)

--- a/app/composition.py
+++ b/app/composition.py
@@ -41,6 +41,7 @@ from app.orchestrator.workflow import WorkflowOrchestrator
 from app.ports.embedder import Embedder
 from app.ports.knowledge_store import KnowledgeStore
 from app.ports.push import PushPort
+from app.ports.roster import RosterPort
 
 
 @lru_cache(maxsize=1)
@@ -183,6 +184,15 @@ def build_push() -> PushPort:
         vapid_private_key=settings.vapid_private_key,
         vapid_subject=settings.vapid_subject,
     )
+
+
+@lru_cache(maxsize=1)
+def build_roster() -> RosterPort:
+    """Compose ``RosterPort`` — satu instance Redis store dibagi ke semua caller
+    (interfaces/roster.py, snapshot /room/state & /room/stream)."""
+    from app.adapters.roster_redis import RedisRosterStore
+
+    return RedisRosterStore()
 
 
 def build_workflow_orchestrator() -> WorkflowOrchestrator:

--- a/app/interfaces/gateway.py
+++ b/app/interfaces/gateway.py
@@ -13,6 +13,7 @@ from app.interfaces.dashboard import router as dashboard_router
 from app.interfaces.health import router as health_router
 from app.interfaces.push import router as push_router
 from app.interfaces.room import router as room_router
+from app.interfaces.roster import router as roster_router
 from app.interfaces.skills import router as skills_router
 from app.interfaces.tasks import router as tasks_router
 from app.interfaces.worker_ws import router as worker_ws_router
@@ -51,6 +52,7 @@ app.include_router(auth_router)
 app.include_router(admin_router)
 app.include_router(chat_router)
 app.include_router(room_router)
+app.include_router(roster_router)
 app.include_router(push_router)
 app.include_router(context_router)
 app.include_router(skills_router)

--- a/app/interfaces/room.py
+++ b/app/interfaces/room.py
@@ -20,22 +20,13 @@ from typing import Any
 from fastapi import APIRouter, Header
 from fastapi.responses import JSONResponse, StreamingResponse
 
+from app.composition import build_roster
 from app.interfaces.chat import _resolve_caller
 from app.ports.push import NullPush, PushMessage, PushPort
+from app.ports.roster import DEFAULT_ROSTER
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/room", tags=["room"])
-
-# Cast tetap ruangan (selaras mockup). Presence worker real menyusul.
-_ROSTER: tuple[dict[str, str], ...] = (
-    {"id": "octo", "name": "Octo", "role": "manager"},
-    {"id": "nadia", "name": "Nadia", "role": "coder"},
-    {"id": "bima", "name": "Bima", "role": "coder"},
-    {"id": "sari", "name": "Sari", "role": "tester"},
-    {"id": "rangga", "name": "Rangga", "role": "reviewer"},
-    {"id": "dewi", "name": "Dewi", "role": "deployer"},
-    {"id": "yusuf", "name": "Yusuf", "role": "researcher"},
-)
 
 
 class RoomBus:
@@ -193,10 +184,14 @@ class RoomTaskObserver:
             logger.debug("push task_finished dilewati: tidak ada event loop aktif")
 
 
-def _snapshot(workers: int = 0) -> dict[str, Any]:
+def _default_agent_dicts() -> list[dict[str, str]]:
+    return [{"id": a.id, "name": a.name, "role": a.role} for a in DEFAULT_ROSTER]
+
+
+def _snapshot(agents: list[dict[str, str]], workers: int = 0) -> dict[str, Any]:
     return {
         "type": "room.snapshot",
-        "agents": [dict(a, status="idle") for a in _ROSTER],
+        "agents": [dict(a, status="idle") for a in agents],
         "tasks": [],
         "approvals": [],
         "workers": workers,
@@ -220,6 +215,28 @@ async def _worker_count_for(user_id: str, mode: str) -> int:
         return 0
 
 
+async def _agents_snapshot_for(user_id: str, mode: str) -> list[dict[str, str]]:
+    """Ambil roster (nama/peran hasil CRUD user) untuk room caller.
+
+    Admin → resolve ke user demo (room tunggal), sama seperti
+    ``_worker_count_for``. Gagal di titik mana pun (resolve/Redis) → fallback
+    ke roster default supaya ruangan tetap tampil.
+    """
+    target = user_id
+    if mode == "admin":
+        from app.interfaces.chat import _resolve_admin_target
+
+        try:
+            target = _resolve_admin_target("demo@local")
+        except Exception:
+            return _default_agent_dicts()
+    try:
+        agents = await build_roster().list(target)
+        return [{"id": a.id, "name": a.name, "role": a.role} for a in agents]
+    except Exception:
+        return _default_agent_dicts()
+
+
 def _sse(event: dict[str, Any]) -> str:
     etype = event.get("type", "message")
     return f"event: {etype}\ndata: {json.dumps(event, ensure_ascii=False)}\n\n"
@@ -229,13 +246,14 @@ def _sse(event: dict[str, Any]) -> str:
 async def room_state(authorization: str | None = Header(default=None)) -> JSONResponse:
     user_id, mode = _resolve_caller(authorization)  # gate: 401 kalau token invalid
     workers = await _worker_count_for(user_id, mode)
-    return JSONResponse(_snapshot(workers))
+    agents = await _agents_snapshot_for(user_id, mode)
+    return JSONResponse(_snapshot(agents, workers))
 
 
-async def _room_stream(workers: int = 0) -> AsyncIterator[str]:
+async def _room_stream(agents: list[dict[str, str]], workers: int = 0) -> AsyncIterator[str]:
     q = _bus.subscribe()
     try:
-        yield _sse(_snapshot(workers))
+        yield _sse(_snapshot(agents, workers))
         while True:
             try:
                 event = await asyncio.wait_for(q.get(), timeout=15.0)
@@ -252,4 +270,5 @@ async def room_stream(
 ) -> StreamingResponse:
     user_id, mode = _resolve_caller(authorization)
     workers = await _worker_count_for(user_id, mode)
-    return StreamingResponse(_room_stream(workers), media_type="text/event-stream")
+    agents = await _agents_snapshot_for(user_id, mode)
+    return StreamingResponse(_room_stream(agents, workers), media_type="text/event-stream")

--- a/app/interfaces/roster.py
+++ b/app/interfaces/roster.py
@@ -1,0 +1,114 @@
+"""HTTP endpoint untuk roster pasukan — CRUD nama/peran agen gather-room.
+
+Auth memakai model yang sama seperti ``/chat`` dan ``/push``: Bearer session
+token, atau ``ADMIN_TOKEN`` + ``as_email`` (admin kelola roster user lain).
+
+Setiap mutasi (PUT/DELETE) mem-publish ``roster.updated`` ke ``RoomBus``
+supaya klien lain yang sedang membuka ``/room/stream`` ikut refresh tanpa
+polling.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Header, HTTPException, status
+from pydantic import BaseModel
+
+from app.composition import build_roster
+from app.interfaces.chat import _resolve_user_and_conv
+from app.ports.roster import ROSTER_ROLES, RosterAgent
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/room/roster", tags=["roster"])
+
+# Sama seperti id agen default (huruf kecil, angka, dash) — dipakai juga untuk
+# id hasil slugifikasi nama di frontend.
+_ID_RE = re.compile(r"^[a-z0-9-]{1,32}$")
+
+
+def _agent_dict(agent: RosterAgent) -> dict[str, str]:
+    return {"id": agent.id, "name": agent.name, "role": agent.role}
+
+
+def _publish_roster_updated(agents: list[RosterAgent]) -> None:
+    """Best-effort — kegagalan publish tak boleh menggagalkan mutasi CRUD."""
+    try:
+        from app.interfaces.room import publish_room_event
+
+        publish_room_event("roster.updated", agents=[_agent_dict(a) for a in agents])
+    except Exception:
+        logger.debug("roster publish gagal", exc_info=True)
+
+
+class RosterUpsertRequest(BaseModel):
+    name: str
+    role: str
+    as_email: str | None = None
+
+
+@router.get("")
+async def roster_list(
+    authorization: str | None = Header(default=None),
+    as_email: str | None = None,
+) -> list[dict[str, str]]:
+    user_id, _conv_id = _resolve_user_and_conv(authorization, as_email)
+    agents = await build_roster().list(user_id)
+    return [_agent_dict(a) for a in agents]
+
+
+@router.put("/{agent_id}")
+async def roster_upsert(
+    agent_id: str,
+    req: Annotated[RosterUpsertRequest, Body(...)],
+    authorization: str | None = Header(default=None),
+) -> dict[str, str]:
+    user_id, _conv_id = _resolve_user_and_conv(authorization, req.as_email)
+
+    if not _ID_RE.match(agent_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="id agen tidak valid (a-z, 0-9, dash; maks 32 karakter)",
+        )
+    name = req.name.strip()
+    if not (1 <= len(name) <= 24):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="nama harus 1-24 karakter",
+        )
+    if req.role not in ROSTER_ROLES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"peran tidak dikenal: {req.role}",
+        )
+
+    store = build_roster()
+    agent = RosterAgent(id=agent_id, name=name, role=req.role)
+    await store.upsert(user_id, agent)
+    _publish_roster_updated(await store.list(user_id))
+    return _agent_dict(agent)
+
+
+@router.delete("/{agent_id}")
+async def roster_delete(
+    agent_id: str,
+    authorization: str | None = Header(default=None),
+    as_email: str | None = None,
+) -> dict[str, bool]:
+    user_id, _conv_id = _resolve_user_and_conv(authorization, as_email)
+
+    store = build_roster()
+    agents = await store.list(user_id)
+    target = next((a for a in agents if a.id == agent_id), None)
+    if target is not None and target.role == "manager":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="manajer tidak bisa dihapus — harus ada tepat satu manajer",
+        )
+
+    ok = await store.delete(user_id, agent_id)
+    if ok:
+        _publish_roster_updated(await store.list(user_id))
+    return {"ok": ok}

--- a/app/ports/roster.py
+++ b/app/ports/roster.py
@@ -1,0 +1,49 @@
+"""Port untuk roster pasukan (CRUD nama/peran agen) — mengendalikan siapa yang
+tampil di gather-room, terpisah dari presence worker (``worker_registry``).
+
+Konsep sama seperti port lain (push, github_issues): domain/interfaces
+tergantung pada Protocol ini, bukan implementasi konkret (``RedisRosterStore``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+# Peran yang boleh dipakai roster — selaras dengan Role di frontend (types.ts).
+ROSTER_ROLES = frozenset(
+    {"manager", "coder", "tester", "reviewer", "deployer", "researcher"}
+)
+
+
+@dataclass(frozen=True)
+class RosterAgent:
+    """Satu baris roster: identitas agen yang tampil di gather-room."""
+
+    id: str
+    name: str
+    role: str
+
+
+# Cast tetap ruangan (selaras mockup) — dipindah dari app/interfaces/room.py
+# supaya jadi satu sumber kebenaran yang dipakai baik fallback maupun seed
+# awal RedisRosterStore.
+DEFAULT_ROSTER: tuple[RosterAgent, ...] = (
+    RosterAgent(id="octo", name="Octo", role="manager"),
+    RosterAgent(id="nadia", name="Nadia", role="coder"),
+    RosterAgent(id="bima", name="Bima", role="coder"),
+    RosterAgent(id="sari", name="Sari", role="tester"),
+    RosterAgent(id="rangga", name="Rangga", role="reviewer"),
+    RosterAgent(id="dewi", name="Dewi", role="deployer"),
+    RosterAgent(id="yusuf", name="Yusuf", role="researcher"),
+)
+
+
+class RosterPort(Protocol):
+    async def list(self, user_id: str) -> list[RosterAgent]: ...
+
+    async def upsert(self, user_id: str, agent: RosterAgent) -> None: ...
+
+    async def delete(self, user_id: str, agent_id: str) -> bool:
+        """Return True kalau agent memang ada & terhapus."""
+        ...

--- a/tests/adapters/test_roster_redis.py
+++ b/tests/adapters/test_roster_redis.py
@@ -1,0 +1,85 @@
+"""Unit tests -- RedisRosterStore (in-memory fake Redis hash, no jaringan nyata)."""
+
+from __future__ import annotations
+
+from app.adapters.roster_redis import RedisRosterStore
+from app.ports.roster import DEFAULT_ROSTER, RosterAgent
+
+
+class FakeRedisHash:
+    """Stand-in minimal untuk redis async client -- cukup hset/hgetall/hdel."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, dict[str, str]] = {}
+
+    async def hset(self, name: str, key: str, value: str) -> int:
+        self._data.setdefault(name, {})[key] = value
+        return 1
+
+    async def hgetall(self, name: str) -> dict[str, str]:
+        return dict(self._data.get(name, {}))
+
+    async def hdel(self, name: str, *keys: str) -> int:
+        bucket = self._data.get(name, {})
+        n = 0
+        for k in keys:
+            if k in bucket:
+                del bucket[k]
+                n += 1
+        return n
+
+
+def _store() -> tuple[RedisRosterStore, FakeRedisHash]:
+    redis = FakeRedisHash()
+    return RedisRosterStore(redis), redis
+
+
+async def test_list_returns_default_roster_when_empty() -> None:
+    store, _redis = _store()
+    agents = await store.list("user-1")
+    assert agents == list(DEFAULT_ROSTER)
+
+
+async def test_upsert_then_list_seeds_defaults_and_applies_change() -> None:
+    store, _redis = _store()
+    await store.upsert("user-1", RosterAgent(id="octo", name="Kapten", role="manager"))
+
+    agents = await store.list("user-1")
+    by_id = {a.id: a for a in agents}
+    assert len(agents) == len(DEFAULT_ROSTER)
+    assert by_id["octo"].name == "Kapten"
+    # agen lain tetap ada (bukan cuma "octo") -- seed default terjadi di upsert pertama.
+    assert by_id["nadia"].name == "Nadia"
+
+
+async def test_upsert_adds_new_agent() -> None:
+    store, _redis = _store()
+    await store.upsert("user-1", RosterAgent(id="baru", name="Agen Baru", role="coder"))
+
+    agents = await store.list("user-1")
+    by_id = {a.id: a for a in agents}
+    assert len(agents) == len(DEFAULT_ROSTER) + 1
+    assert by_id["baru"].role == "coder"
+
+
+async def test_delete_removes_agent() -> None:
+    store, _redis = _store()
+    await store.upsert("user-1", RosterAgent(id="nadia", name="Nadia Baru", role="coder"))
+
+    ok = await store.delete("user-1", "nadia")
+    assert ok is True
+    agents = await store.list("user-1")
+    assert "nadia" not in {a.id for a in agents}
+
+
+async def test_delete_unknown_agent_returns_false() -> None:
+    store, _redis = _store()
+    assert await store.delete("user-1", "nobody") is False
+
+
+async def test_roster_scoped_per_user() -> None:
+    store, _redis = _store()
+    await store.upsert("user-1", RosterAgent(id="octo", name="Kapten", role="manager"))
+
+    agents_u2 = await store.list("user-2")
+    assert agents_u2 == list(DEFAULT_ROSTER)

--- a/tests/interfaces/test_push_endpoints.py
+++ b/tests/interfaces/test_push_endpoints.py
@@ -93,7 +93,11 @@ def test_subscribe_requires_auth() -> None:
 
 def test_vapid_key_503_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(push_iface, "_resolve_caller", lambda _a: (USER, "user"))
-    monkeypatch.setattr(push_iface, "settings", load_settings())  # blank vapid keys
+    monkeypatch.setattr(
+        push_iface,
+        "settings",
+        dataclasses.replace(load_settings(), vapid_public_key="", vapid_private_key=""),
+    )  # blank vapid keys
     app = FastAPI()
     app.include_router(push_iface.router)
     client = TestClient(app)
@@ -104,7 +108,11 @@ def test_vapid_key_503_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> Non
 
 def test_subscribe_503_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(push_iface, "_resolve_user_and_conv", lambda _a, _e: (USER, USER))
-    monkeypatch.setattr(push_iface, "settings", load_settings())
+    monkeypatch.setattr(
+        push_iface,
+        "settings",
+        dataclasses.replace(load_settings(), vapid_public_key="", vapid_private_key=""),
+    )
     app = FastAPI()
     app.include_router(push_iface.router)
     client = TestClient(app)

--- a/tests/interfaces/test_room.py
+++ b/tests/interfaces/test_room.py
@@ -14,11 +14,23 @@ from app.config import load_settings
 from app.interfaces.room import RoomBus, _bus, publish_room_event, router
 
 
+class _FakeRoster:
+    """Roster fake deterministik -- lepas dari Redis/DB nyata di test env."""
+
+    async def list(self, user_id: str) -> list[object]:
+        from app.ports.roster import DEFAULT_ROSTER
+
+        return list(DEFAULT_ROSTER)
+
+
 @pytest.fixture
 def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setattr(
         chat_mod, "settings", dataclasses.replace(load_settings(), admin_token="test-admin")
     )
+    import app.interfaces.room as room_mod
+
+    monkeypatch.setattr(room_mod, "build_roster", lambda: _FakeRoster())
     app = FastAPI()
     app.include_router(router)
     return TestClient(app)

--- a/tests/interfaces/test_roster_endpoints.py
+++ b/tests/interfaces/test_roster_endpoints.py
@@ -1,0 +1,201 @@
+"""HTTP tests for /room/roster/* -- list/upsert/delete + roster.updated publish.
+
+Auth resolution (_resolve_user_and_conv) sudah punya coverage sendiri di
+tests/interfaces/test_chat*.py; di sini kita monkeypatch supaya fokus ke
+kontrak router roster: 401 tanpa auth, validasi 400, larangan hapus manajer,
+PUT membuat/mengubah, DELETE menghapus, dan publish roster.updated ke RoomBus.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.interfaces import roster as roster_iface
+from app.ports.roster import DEFAULT_ROSTER, RosterAgent
+
+USER = "user-1"
+
+
+class FakeRoster:
+    def __init__(self) -> None:
+        self._agents: dict[str, RosterAgent] = {a.id: a for a in DEFAULT_ROSTER}
+
+    async def list(self, user_id: str) -> list[RosterAgent]:
+        return list(self._agents.values())
+
+    async def upsert(self, user_id: str, agent: RosterAgent) -> None:
+        self._agents[agent.id] = agent
+
+    async def delete(self, user_id: str, agent_id: str) -> bool:
+        return self._agents.pop(agent_id, None) is not None
+
+
+@pytest.fixture
+def fake() -> FakeRoster:
+    return FakeRoster()
+
+
+@pytest.fixture
+def client(fake: FakeRoster, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setattr(roster_iface, "build_roster", lambda: fake)
+    monkeypatch.setattr(roster_iface, "_resolve_user_and_conv", lambda _a, _e: (USER, USER))
+    app = FastAPI()
+    app.include_router(roster_iface.router)
+    yield TestClient(app)
+
+
+# -- auth ----------------------------------------------------------------------
+
+
+def test_list_requires_auth() -> None:
+    app = FastAPI()
+    app.include_router(roster_iface.router)
+    resp = TestClient(app).get("/room/roster")
+    assert resp.status_code == 401
+
+
+def test_put_requires_auth() -> None:
+    app = FastAPI()
+    app.include_router(roster_iface.router)
+    resp = TestClient(app).put("/room/roster/nadia", json={"name": "X", "role": "coder"})
+    assert resp.status_code == 401
+
+
+def test_delete_requires_auth() -> None:
+    app = FastAPI()
+    app.include_router(roster_iface.router)
+    resp = TestClient(app).delete("/room/roster/nadia")
+    assert resp.status_code == 401
+
+
+# -- list ------------------------------------------------------------------------
+
+
+def test_list_returns_default_roster(client: TestClient) -> None:
+    resp = client.get("/room/roster", headers={"Authorization": "Bearer x"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == len(DEFAULT_ROSTER)
+    assert {a["id"] for a in body} == {a.id for a in DEFAULT_ROSTER}
+
+
+# -- validation --------------------------------------------------------------------
+
+
+def test_put_rejects_invalid_id(client: TestClient) -> None:
+    resp = client.put(
+        "/room/roster/Invalid_ID!",
+        json={"name": "X", "role": "coder"},
+        headers={"Authorization": "Bearer x"},
+    )
+    assert resp.status_code == 400
+
+
+def test_put_rejects_empty_name(client: TestClient) -> None:
+    resp = client.put(
+        "/room/roster/nadia",
+        json={"name": "   ", "role": "coder"},
+        headers={"Authorization": "Bearer x"},
+    )
+    assert resp.status_code == 400
+
+
+def test_put_rejects_name_too_long(client: TestClient) -> None:
+    resp = client.put(
+        "/room/roster/nadia",
+        json={"name": "x" * 25, "role": "coder"},
+        headers={"Authorization": "Bearer x"},
+    )
+    assert resp.status_code == 400
+
+
+def test_put_rejects_unknown_role(client: TestClient) -> None:
+    resp = client.put(
+        "/room/roster/nadia",
+        json={"name": "Nadia", "role": "ceo"},
+        headers={"Authorization": "Bearer x"},
+    )
+    assert resp.status_code == 400
+
+
+# -- CRUD happy paths -----------------------------------------------------------
+
+
+def test_put_creates_new_agent(client: TestClient, fake: FakeRoster) -> None:
+    resp = client.put(
+        "/room/roster/baru",
+        json={"name": "Agen Baru", "role": "tester"},
+        headers={"Authorization": "Bearer x"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"id": "baru", "name": "Agen Baru", "role": "tester"}
+    assert fake._agents["baru"].role == "tester"
+
+
+def test_put_updates_existing_agent(client: TestClient, fake: FakeRoster) -> None:
+    resp = client.put(
+        "/room/roster/nadia",
+        json={"name": "Nadia B.", "role": "reviewer"},
+        headers={"Authorization": "Bearer x"},
+    )
+    assert resp.status_code == 200
+    assert fake._agents["nadia"].name == "Nadia B."
+    assert fake._agents["nadia"].role == "reviewer"
+
+
+def test_delete_removes_agent(client: TestClient, fake: FakeRoster) -> None:
+    resp = client.delete("/room/roster/nadia", headers={"Authorization": "Bearer x"})
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert "nadia" not in fake._agents
+
+
+def test_delete_unknown_agent_returns_false(client: TestClient) -> None:
+    resp = client.delete("/room/roster/nobody", headers={"Authorization": "Bearer x"})
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": False}
+
+
+def test_cannot_delete_manager(client: TestClient, fake: FakeRoster) -> None:
+    resp = client.delete("/room/roster/octo", headers={"Authorization": "Bearer x"})
+    assert resp.status_code == 400
+    assert "octo" in fake._agents
+
+
+# -- roster.updated publish ------------------------------------------------------
+
+
+def test_put_publishes_roster_updated(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    published: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        roster_iface,
+        "_publish_roster_updated",
+        lambda agents: published.append({"agents": [a.id for a in agents]}),
+    )
+    resp = client.put(
+        "/room/roster/baru",
+        json={"name": "Baru", "role": "coder"},
+        headers={"Authorization": "Bearer x"},
+    )
+    assert resp.status_code == 200
+    assert len(published) == 1
+    assert "baru" in published[0]["agents"]
+
+
+def test_delete_publishes_roster_updated(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    published: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        roster_iface,
+        "_publish_roster_updated",
+        lambda agents: published.append({"agents": [a.id for a in agents]}),
+    )
+    resp = client.delete("/room/roster/nadia", headers={"Authorization": "Bearer x"})
+    assert resp.status_code == 200
+    assert len(published) == 1
+    assert "nadia" not in published[0]["agents"]

--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#0d9e88" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta
       name="description"
       content="Ruang Octopus — office virtual tempat Manajer AI mengoordinasi pasukan agen."

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "octopus-gather-room",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Ruang Octopus — gather-room frontend for the AI IT-Manager (mock data, Phase 3 P0-P1)",
   "scripts": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,8 @@ import { ActivityFeed } from "./ui/ActivityFeed";
 import { startRoomStream } from "./net/roomStream";
 import { setBadge, syncTokenToSw } from "./net/push";
 import { useStore } from "./state/store";
+import { useIsMobile } from "./hooks/useIsMobile";
+import { MobileShell } from "./ui/mobile/MobileShell";
 
 function Section({
   title,
@@ -31,6 +33,8 @@ function Section({
 }
 
 export default function App(): JSX.Element {
+  const isMobile = useIsMobile();
+
   useEffect(() => {
     const stream = startRoomStream();
     // Token bisa berubah (login ulang) → selalu sinkron ke SW saat app dibuka
@@ -54,6 +58,10 @@ export default function App(): JSX.Element {
       }
     });
   }, []);
+
+  if (isMobile) {
+    return <MobileShell />;
+  }
 
   return (
     <div className="flex min-h-[100dvh] flex-col md:grid md:h-[100dvh] md:min-h-0 md:grid-cols-[1fr_minmax(300px,348px)] md:grid-rows-[auto_1fr] md:overflow-hidden">

--- a/web/src/changelog.ts
+++ b/web/src/changelog.ts
@@ -12,6 +12,16 @@ export interface ReleaseNote {
 
 export const CHANGELOG: ReleaseNote[] = [
   {
+    version: "0.3.0",
+    date: "2026-08-29",
+    notes: [
+      "Tampilan mobile ala aplikasi: tab bar bawah (Ruangan · Persetujuan · Aktivitas · Pasukan) + command bar bawah bergaya chat.",
+      "Sheet persetujuan otomatis muncul saat Manajer minta persetujuan baru sambil kamu di HP.",
+      "Menu ⋯ \"Lainnya\" merapikan provider BYOK, versi/update, dan ganti tema di satu tempat.",
+      "Kelola pasukan: ganti nama & peran agen, tambah agen baru, atau hapus — langsung dari tab Pasukan (mobile) atau tombol \"Kelola\" di Roster (desktop). Manajer tak bisa dihapus.",
+    ],
+  },
+  {
     version: "0.2.0",
     date: "2026-08-28",
     notes: [

--- a/web/src/hooks/useIsMobile.ts
+++ b/web/src/hooks/useIsMobile.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+// Sinkron dengan breakpoint Tailwind "md" (768px) — App.tsx pakai batas yang
+// sama untuk memutuskan MobileShell vs tata letak desktop.
+const QUERY = "(max-width: 767px)";
+
+function matches(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia(QUERY).matches;
+}
+
+/** SSR-safe: mengembalikan false di render pertama server, lalu sinkron ke
+ *  lebar viewport nyata via matchMedia begitu mount di klien. */
+export function useIsMobile(): boolean {
+  const [mobile, setMobile] = useState<boolean>(matches);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const mql = window.matchMedia(QUERY);
+    const onChange = (): void => setMobile(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return mobile;
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -8,12 +8,39 @@ body,
   height: 100%;
 }
 
+html,
+body {
+  overscroll-behavior: none; /* cegah "pull to refresh" / bounce ala native app */
+}
+
 body {
   margin: 0;
   background: var(--bg);
   color: var(--ink);
   font-family: "IBM Plex Sans", system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
+}
+
+button {
+  touch-action: manipulation; /* hilangkan delay 300ms & double-tap-zoom di tombol */
+}
+
+/* Chrome UI (bukan teks konten seperti feed/log) tak perlu bisa di-select —
+   mengurangi selection tak sengaja saat scroll/tap di layar sentuh. */
+header,
+nav,
+button {
+  user-select: none;
+}
+
+@media (max-width: 767px) {
+  .scroll-thin {
+    scrollbar-width: none;
+  }
+  .scroll-thin::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 /* thin scrollbars for panels */

--- a/web/src/net/api.ts
+++ b/web/src/net/api.ts
@@ -149,3 +149,74 @@ export async function approvePlan(planId: string): Promise<boolean> {
 export async function rejectPlan(planId: string): Promise<boolean> {
   return _decide("/chat/reject", planId);
 }
+
+// ── Roster pasukan (CRUD nama/peran agen) ─────────────────────────────────────
+
+export interface RosterAgentDto {
+  id: string;
+  name: string;
+  role: string;
+}
+
+export interface RosterMutationResult {
+  ok: boolean;
+  /** Pesan error server (400 validasi, dll) — cuma diisi kalau ok=false. */
+  detail?: string;
+}
+
+async function _detailOf(resp: Response): Promise<string | undefined> {
+  try {
+    const body = (await resp.json()) as { detail?: string };
+    return body.detail;
+  } catch {
+    return undefined;
+  }
+}
+
+/** GET roster lengkap milik user (fallback roster default kalau baru pertama kali). */
+export async function fetchRoster(): Promise<RosterAgentDto[] | null> {
+  try {
+    const resp = await fetch(`${API_BASE}/room/roster?as_email=demo@local`, {
+      headers: authHeaders(),
+    });
+    if (!resp.ok) return null;
+    return (await resp.json()) as RosterAgentDto[];
+  } catch {
+    return null;
+  }
+}
+
+/** PUT — buat agen baru (id belum ada) atau ubah nama/peran agen yang ada. */
+export async function saveAgent(
+  id: string,
+  data: { name: string; role: string },
+): Promise<RosterMutationResult> {
+  try {
+    const resp = await fetch(`${API_BASE}/room/roster/${encodeURIComponent(id)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body: JSON.stringify({ ...data, as_email: "demo@local" }),
+    });
+    if (!resp.ok) return { ok: false, detail: await _detailOf(resp) };
+    return { ok: true };
+  } catch {
+    return { ok: false, detail: "gagal terhubung ke server" };
+  }
+}
+
+/** DELETE agen — backend menolak (400) kalau agennya manajer. */
+export async function deleteAgent(id: string): Promise<RosterMutationResult> {
+  try {
+    const resp = await fetch(
+      `${API_BASE}/room/roster/${encodeURIComponent(id)}?as_email=demo@local`,
+      { method: "DELETE", headers: authHeaders() },
+    );
+    if (!resp.ok) return { ok: false, detail: await _detailOf(resp) };
+    const body = (await resp.json()) as { ok?: boolean };
+    return body.ok === true
+      ? { ok: true }
+      : { ok: false, detail: "agen tidak ditemukan" };
+  } catch {
+    return { ok: false, detail: "gagal terhubung ke server" };
+  }
+}

--- a/web/src/room/engine/render.ts
+++ b/web/src/room/engine/render.ts
@@ -60,6 +60,17 @@ export function readPalette(): Palette {
 
 export function computeCamera(cssW: number, cssH: number): Camera {
   const pad = 24;
+  // Portrait (HP): world 1280×800 di-"contain" akan jadi strip kecil di tengah
+  // → pakai mode cover: skala ke tinggi kontainer, lebar boleh meluap dan
+  // di-pan horizontal (lihat useRoomEngine). Awal: pusat world di tengah layar.
+  if (cssH > cssW * (WORLD_H / WORLD_W) * 1.35) {
+    const scale = (cssH - pad * 2) / WORLD_H;
+    return {
+      scale,
+      offX: clampOffX((cssW - WORLD_W * scale) / 2, cssW, scale),
+      offY: pad,
+    };
+  }
   const scale = Math.min(
     (cssW - pad * 2) / WORLD_W,
     (cssH - pad * 2) / WORLD_H,
@@ -69,6 +80,15 @@ export function computeCamera(cssW: number, cssH: number): Camera {
     offX: (cssW - WORLD_W * scale) / 2,
     offY: (cssH - WORLD_H * scale) / 2,
   };
+}
+
+/** Batasi pan horizontal supaya tepi world tak lepas dari layar (mode cover). */
+export function clampOffX(offX: number, cssW: number, scale: number): number {
+  const pad = 24;
+  const minX = cssW - WORLD_W * scale - pad;
+  const maxX = pad;
+  if (minX > maxX) return (cssW - WORLD_W * scale) / 2; // world lebih sempit: tengah
+  return Math.min(maxX, Math.max(minX, offX));
 }
 
 export function rrect(

--- a/web/src/room/useRoomEngine.ts
+++ b/web/src/room/useRoomEngine.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import type { RefObject } from "react";
 import { useStore } from "../state/store";
 import {
-  computeCamera,
+  clampOffX, computeCamera,
   drawPings,
   drawWorld,
   readPalette,
@@ -60,7 +60,24 @@ export function useRoomEngine(canvasRef: RefObject<HTMLCanvasElement>): void {
     if (canvas.parentElement) ro.observe(canvas.parentElement);
     resize();
 
+    // Tap = pilih agen; drag horizontal = pan kamera (mode cover di HP).
+    let drag: { id: number; startX: number; startOffX: number; moved: boolean } | null = null;
     const onPointerDown = (e: PointerEvent): void => {
+      drag = { id: e.pointerId, startX: e.clientX, startOffX: cam.offX, moved: false };
+      canvas.setPointerCapture(e.pointerId);
+    };
+    const onPointerMove = (e: PointerEvent): void => {
+      if (!drag || drag.id !== e.pointerId) return;
+      const dx = e.clientX - drag.startX;
+      if (!drag.moved && Math.abs(dx) < 6) return;
+      drag.moved = true;
+      cam = { ...cam, offX: clampOffX(drag.startOffX + dx, cssW, cam.scale) };
+    };
+    const onPointerUp = (e: PointerEvent): void => {
+      if (!drag || drag.id !== e.pointerId) return;
+      const wasTap = !drag.moved;
+      drag = null;
+      if (!wasTap) return;
       const rect = canvas.getBoundingClientRect();
       const { x, y } = screenToWorld(
         cam,
@@ -71,6 +88,9 @@ export function useRoomEngine(canvasRef: RefObject<HTMLCanvasElement>): void {
       if (id) useStore.getState().select(id);
     };
     canvas.addEventListener("pointerdown", onPointerDown);
+    canvas.addEventListener("pointermove", onPointerMove);
+    canvas.addEventListener("pointerup", onPointerUp);
+    canvas.addEventListener("pointercancel", onPointerUp);
 
     const frame = (t: number): void => {
       const dt = Math.min((t - last) / 1000, 0.05);
@@ -123,6 +143,9 @@ export function useRoomEngine(canvasRef: RefObject<HTMLCanvasElement>): void {
       cancelAnimationFrame(raf);
       ro.disconnect();
       canvas.removeEventListener("pointerdown", onPointerDown);
+      canvas.removeEventListener("pointermove", onPointerMove);
+      canvas.removeEventListener("pointerup", onPointerUp);
+      canvas.removeEventListener("pointercancel", onPointerUp);
     };
   }, [canvasRef]);
 }

--- a/web/src/state/store.ts
+++ b/web/src/state/store.ts
@@ -17,11 +17,20 @@ import {
   center,
   MEET,
   REVIEW,
+  ROLE,
   SERVER,
   WORLD_H,
   WORLD_W,
   zoneBy,
 } from "../room/engine/scene";
+
+/** Roster entry hasil CRUD backend (/room/roster, event roster.updated /
+ *  room.snapshot) — cuma identitas, bukan runtime state (posisi/tugas/log). */
+export interface RosterEntry {
+  id: string;
+  name: string;
+  role: Role;
+}
 
 // ── small helpers ──
 const rand = (a: number, b: number): number => a + Math.random() * (b - a);
@@ -57,6 +66,7 @@ const TASKS: Omit<Task, "id">[] = [
 
 // ── initial roster ──
 function mk(
+  id: string,
   name: string,
   role: Role,
   x: number,
@@ -64,7 +74,7 @@ function mk(
   state: Agent["state"] = "idle",
 ): Agent {
   return {
-    id: name.toLowerCase(),
+    id,
     name,
     role,
     state,
@@ -83,22 +93,97 @@ function mk(
   };
 }
 
+// Zona kantor per peran — dipakai baik untuk penempatan awal maupun agen baru
+// hasil CRUD roster (lihat homeFor).
+const ZONE_FOR_ROLE: Record<Role, string> = {
+  manager: "Kantor Manajer",
+  coder: "Dev Bay",
+  tester: "QA Corner",
+  reviewer: "Ruang Review",
+  deployer: "Deploy Station",
+  researcher: "Riset",
+};
+
+/** Slot tempat tinggal (home) agen ke-`index` (0-based, di antara agen
+ *  seperan lain) di dalam zona kantor perannya — grid 3 kolom, spasi merata
+ *  supaya banyak agen seperan tak bertumpuk di satu titik. */
+function homeFor(role: Role, index: number): { x: number; y: number } {
+  const zone = zoneBy(ZONE_FOR_ROLE[role]);
+  if (role === "manager") {
+    const c = center(zone);
+    return { x: c.x, y: c.y + 8 };
+  }
+  const cols = 3;
+  const col = index % cols;
+  const row = Math.floor(index / cols);
+  const pad = 70;
+  const stepX = cols > 1 ? (zone.w - pad * 2) / (cols - 1) : 0;
+  return {
+    x: clamp(zone.x + pad + col * stepX, zone.x + 24, zone.x + zone.w - 24),
+    y: clamp(zone.y + pad + row * 90, zone.y + 24, zone.y + zone.h - 24),
+  };
+}
+
+const VALID_ROLES = new Set<string>(Object.keys(ROLE));
+
+/** Validasi payload agents dari event server (boundary tak terpercaya) —
+ *  entri dengan id kosong atau peran tak dikenal dibuang, bukan bikin crash. */
+function parseRosterEntries(raw: unknown): RosterEntry[] {
+  if (!Array.isArray(raw)) return [];
+  const out: RosterEntry[] = [];
+  for (const item of raw) {
+    if (typeof item !== "object" || item === null) continue;
+    const id = String((item as { id?: unknown }).id ?? "").trim();
+    const name = String((item as { name?: unknown }).name ?? "").trim();
+    const role = String((item as { role?: unknown }).role ?? "");
+    if (!id || !name || !VALID_ROLES.has(role)) continue;
+    out.push({ id, name, role: role as Role });
+  }
+  return out;
+}
+
+/** selectedId tetap valid setelah reconcile — null-kan kalau agennya dibuang. */
+function keepSelected(selectedId: string | null, agents: Agent[]): string | null {
+  if (selectedId === null) return null;
+  return agents.some((a) => a.id === selectedId) ? selectedId : null;
+}
+
 function initialAgents(): Agent[] {
-  const devBay = zoneBy("Dev Bay");
-  const qa = zoneBy("QA Corner");
-  const rev = zoneBy("Ruang Review");
-  const deploy = zoneBy("Deploy Station");
-  const research = zoneBy("Riset");
-  const mgr = center(zoneBy("Kantor Manajer"));
-  return [
-    mk("Octo", "manager", mgr.x, mgr.y + 8, "patrol"),
-    mk("Nadia", "coder", devBay.x + 80, devBay.y + 95),
-    mk("Bima", "coder", devBay.x + 210, devBay.y + 150),
-    mk("Sari", "tester", qa.x + 90, qa.y + 110),
-    mk("Rangga", "reviewer", rev.x + 95, rev.y + 95),
-    mk("Dewi", "deployer", deploy.x + 118, deploy.y + 110),
-    mk("Yusuf", "researcher", research.x + 105, research.y + 90),
-  ];
+  return reconcileAgents([], [
+    { id: "octo", name: "Octo", role: "manager" },
+    { id: "nadia", name: "Nadia", role: "coder" },
+    { id: "bima", name: "Bima", role: "coder" },
+    { id: "sari", name: "Sari", role: "tester" },
+    { id: "rangga", name: "Rangga", role: "reviewer" },
+    { id: "dewi", name: "Dewi", role: "deployer" },
+    { id: "yusuf", name: "Yusuf", role: "researcher" },
+  ]).map((a) => (a.role === "manager" ? { ...a, state: "patrol" } : a));
+}
+
+/** Reconcile roster server (CRUD /room/roster, event roster.updated /
+ *  room.snapshot) ke agents runtime: agen yang sudah ada mempertahankan
+ *  posisi/tugas/log-nya (cuma nama/peran yang disinkronkan), agen baru
+ *  ditempatkan via homeFor, agen yang sudah tak ada di roster dibuang. */
+function reconcileAgents(current: Agent[], roster: RosterEntry[]): Agent[] {
+  const byId = new Map(current.map((a) => [a.id, a]));
+  const roleCounts = new Map<Role, number>();
+  const next: Agent[] = [];
+  for (const r of roster) {
+    const idx = roleCounts.get(r.role) ?? 0;
+    roleCounts.set(r.role, idx + 1);
+    const existing = byId.get(r.id);
+    if (existing) {
+      next.push(
+        existing.name === r.name && existing.role === r.role
+          ? existing
+          : { ...existing, name: r.name, role: r.role },
+      );
+    } else {
+      const home = homeFor(r.role, idx);
+      next.push(mk(r.id, r.name, r.role, home.x, home.y));
+    }
+  }
+  return next;
 }
 
 function initialTheme(): Theme {
@@ -129,6 +214,9 @@ interface RoomState {
   select: (id: string | null) => void;
   submitCommand: (text: string) => void;
   applyServerEvent: (ev: Record<string, unknown>) => void;
+  /** Sinkronkan agents dengan roster server (CRUD /room/roster / event
+   *  roster.updated / room.snapshot) — lihat reconcileAgents. */
+  applyRoster: (roster: RosterEntry[]) => void;
   approve: (id: number) => void;
   reject: (id: number) => void;
   approveServer: (planId: string) => void;
@@ -365,7 +453,20 @@ export const useStore = create<RoomState>((set, get) => {
         }
         if (type === "room.snapshot") {
           const w = Number((ev as { workers?: unknown }).workers ?? 0);
-          return { workers: Number.isFinite(w) ? w : 0, live: w > 0 || s.live };
+          const roster = parseRosterEntries((ev as { agents?: unknown }).agents);
+          const agents = roster.length ? reconcileAgents(s.agents, roster) : s.agents;
+          return {
+            workers: Number.isFinite(w) ? w : 0,
+            live: w > 0 || s.live,
+            agents,
+            selectedId: keepSelected(s.selectedId, agents),
+          };
+        }
+        if (type === "roster.updated") {
+          const roster = parseRosterEntries((ev as { agents?: unknown }).agents);
+          if (!roster.length) return {};
+          const agents = reconcileAgents(s.agents, roster);
+          return { agents, selectedId: keepSelected(s.selectedId, agents) };
         }
         if (type === "worker.online") {
           return {
@@ -401,6 +502,13 @@ export const useStore = create<RoomState>((set, get) => {
           return { live: true, board };
         }
         return {};
+      });
+    },
+
+    applyRoster: (roster) => {
+      set((s) => {
+        const agents = reconcileAgents(s.agents, roster);
+        return { agents, selectedId: keepSelected(s.selectedId, agents) };
       });
     },
 

--- a/web/src/ui/AgentEditor.tsx
+++ b/web/src/ui/AgentEditor.tsx
@@ -1,0 +1,206 @@
+import { useState } from "react";
+import { useIsMobile } from "../hooks/useIsMobile";
+import { deleteAgent, fetchRoster, saveAgent } from "../net/api";
+import { ROLE } from "../room/engine/scene";
+import { useStore } from "../state/store";
+import type { Role } from "../state/types";
+import { BottomSheet } from "./mobile/BottomSheet";
+
+const ROLE_OPTIONS: Role[] = [
+  "manager",
+  "coder",
+  "tester",
+  "reviewer",
+  "deployer",
+  "researcher",
+];
+
+function slugify(name: string, taken: Set<string>): string {
+  const base =
+    name
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "agen";
+  if (!taken.has(base)) return base;
+  let i = 2;
+  while (taken.has(`${base}-${i}`)) i += 1;
+  return `${base}-${i}`;
+}
+
+export interface AgentEditorProps {
+  /** null = mode tambah agen baru. */
+  agent: { id: string; name: string; role: Role } | null;
+  onClose: () => void;
+}
+
+/** Editor CRUD roster satu-satunya — muncul sebagai bottom sheet di mobile
+ *  (Pasukan tab) dan modal di desktop (tombol "Kelola" di Roster). Optimistic
+ *  update ke store dulu, lalu refetch & tampilkan error kalau server menolak. */
+export function AgentEditor({ agent, onClose }: AgentEditorProps): JSX.Element {
+  const isMobile = useIsMobile();
+  const agents = useStore((s) => s.agents);
+  const applyRoster = useStore((s) => s.applyRoster);
+  const [name, setName] = useState(agent?.name ?? "");
+  const [role, setRole] = useState<Role>(agent?.role ?? "coder");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const isManager = agent?.role === "manager";
+
+  const rosterList = (): { id: string; name: string; role: Role }[] =>
+    agents.map((a) => ({ id: a.id, name: a.name, role: a.role }));
+
+  const revertToServer = async (): Promise<void> => {
+    const fresh = await fetchRoster();
+    if (fresh) applyRoster(fresh as { id: string; name: string; role: Role }[]);
+  };
+
+  const handleSave = async (): Promise<void> => {
+    const trimmed = name.trim();
+    if (!trimmed || trimmed.length > 24) {
+      setError("Nama harus 1–24 karakter");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+
+    const id = agent?.id ?? slugify(trimmed, new Set(agents.map((a) => a.id)));
+    const list = rosterList();
+    const idx = list.findIndex((a) => a.id === id);
+    if (idx >= 0) list[idx] = { id, name: trimmed, role };
+    else list.push({ id, name: trimmed, role });
+    applyRoster(list); // optimistic
+
+    const res = await saveAgent(id, { name: trimmed, role });
+    setBusy(false);
+    if (!res.ok) {
+      setError(res.detail ?? "Gagal menyimpan");
+      await revertToServer();
+      return;
+    }
+    onClose();
+  };
+
+  const handleDelete = async (): Promise<void> => {
+    if (!agent || isManager) return;
+    setBusy(true);
+    setError(null);
+
+    const list = rosterList().filter((a) => a.id !== agent.id);
+    applyRoster(list); // optimistic
+
+    const res = await deleteAgent(agent.id);
+    setBusy(false);
+    if (!res.ok) {
+      setError(res.detail ?? "Gagal menghapus");
+      await revertToServer();
+      return;
+    }
+    onClose();
+  };
+
+  const content = (
+    <div className="flex flex-col gap-3">
+      <div>
+        <label className="block font-mono text-[11px] uppercase tracking-wide text-ink-faint">
+          Nama
+        </label>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={24}
+          placeholder="Nama agen"
+          className="mt-1 w-full rounded-lg border border-line bg-surface-2 px-3 py-2.5 text-[14px] text-ink outline-none focus-visible:border-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+        />
+      </div>
+
+      <div>
+        <label className="block font-mono text-[11px] uppercase tracking-wide text-ink-faint">
+          Peran
+        </label>
+        <div className="mt-1.5 grid grid-cols-3 gap-1.5">
+          {ROLE_OPTIONS.map((r) => {
+            const active = r === role;
+            return (
+              <button
+                key={r}
+                type="button"
+                onClick={() => setRole(r)}
+                className="min-h-[40px] rounded-lg border px-2 text-[12px] font-semibold transition"
+                style={{
+                  borderColor: active ? ROLE[r].color : "var(--line)",
+                  color: active ? ROLE[r].color : "var(--ink-soft)",
+                  background: active
+                    ? `color-mix(in oklab, ${ROLE[r].color} 14%, var(--panel))`
+                    : "transparent",
+                }}
+              >
+                {ROLE[r].icon} {ROLE[r].label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {error && <p className="text-[12px] text-st-error">{error}</p>}
+
+      <div className="mt-1 flex gap-2">
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={busy}
+          className="min-h-[44px] flex-1 rounded-lg bg-accent text-[13px] font-semibold text-accent-ink transition disabled:opacity-60"
+        >
+          Simpan
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleDelete()}
+          disabled={busy || !agent || isManager}
+          title={isManager ? "Manajer tidak bisa dihapus" : undefined}
+          className="min-h-[44px] flex-1 rounded-lg border border-line text-[13px] font-semibold text-ink transition disabled:opacity-40"
+        >
+          Hapus
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="min-h-[44px] flex-1 rounded-lg border border-line text-[13px] font-semibold text-ink-soft"
+        >
+          Batal
+        </button>
+      </div>
+      {isManager && (
+        <p className="-mt-1.5 text-[11px] text-ink-faint">
+          Manajer tidak bisa dihapus — harus ada tepat satu manajer.
+        </p>
+      )}
+    </div>
+  );
+
+  const title = agent ? "Ubah agen" : "Tambah agen";
+
+  if (isMobile) {
+    return (
+      <BottomSheet onClose={onClose} title={title}>
+        {content}
+      </BottomSheet>
+    );
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 grid place-items-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-sm rounded-2xl border border-line bg-surface p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="m-0 mb-3 font-display text-[16px] font-bold text-ink">{title}</h2>
+        {content}
+      </div>
+    </div>
+  );
+}

--- a/web/src/ui/ApprovalCard.tsx
+++ b/web/src/ui/ApprovalCard.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+
+const CARD_STYLE = {
+  borderColor: "color-mix(in oklab, var(--st-approval) 45%, var(--line))",
+  background: "color-mix(in oklab, var(--st-approval) 9%, var(--panel))",
+};
+
+export interface ApprovalCardProps {
+  title: ReactNode;
+  desc: ReactNode;
+  onApprove: () => void;
+  onReject: () => void;
+  /** Tombol minimal 48px — dipakai di mobile (ApprovalSheet / tab Persetujuan). */
+  tall?: boolean;
+}
+
+/** Kartu persetujuan dipakai bersama oleh ApprovalQueue (desktop & mobile,
+ *  lewat useIsMobile) dan ApprovalSheet — satu tempat untuk styling & markup. */
+export function ApprovalCard({ title, desc, onApprove, onReject, tall }: ApprovalCardProps): JSX.Element {
+  const btnH = tall ? "min-h-[48px]" : "py-1.5";
+  const yesCls = `flex-1 rounded-lg border border-transparent bg-st-approval text-center text-[12.5px] font-semibold text-[#201400] ${btnH}`;
+  const noCls = `flex-1 rounded-lg border border-line bg-transparent text-center text-[12.5px] font-semibold text-ink transition hover:border-st-error ${btnH}`;
+
+  return (
+    <div className="rounded-[11px] border p-3" style={CARD_STYLE}>
+      <div className="text-[13px] font-semibold text-ink">{title}</div>
+      <div className="my-1 mb-2.5 whitespace-pre-line text-[12.5px] text-ink-soft">{desc}</div>
+      <div className="flex gap-2">
+        <button type="button" onClick={onApprove} className={yesCls}>
+          Setujui
+        </button>
+        <button type="button" onClick={onReject} className={noCls}>
+          Tolak
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/ui/ApprovalQueue.tsx
+++ b/web/src/ui/ApprovalQueue.tsx
@@ -1,5 +1,7 @@
 import { ROLE } from "../room/engine/scene";
 import { useStore } from "../state/store";
+import { useIsMobile } from "../hooks/useIsMobile";
+import { ApprovalCard } from "./ApprovalCard";
 
 export function ApprovalQueue(): JSX.Element {
   const approvals = useStore((s) => s.approvals);
@@ -9,6 +11,8 @@ export function ApprovalQueue(): JSX.Element {
   const reject = useStore((s) => s.reject);
   const approveServer = useStore((s) => s.approveServer);
   const rejectServer = useStore((s) => s.rejectServer);
+  // Tab Persetujuan / ApprovalSheet mobile butuh target sentuh >=48px.
+  const tall = useIsMobile();
 
   if (!approvals.length && !serverApprovals.length) {
     return (
@@ -18,33 +22,18 @@ export function ApprovalQueue(): JSX.Element {
     );
   }
 
-  const cardStyle = {
-    borderColor: "color-mix(in oklab, var(--st-approval) 45%, var(--line))",
-    background: "color-mix(in oklab, var(--st-approval) 9%, var(--panel))",
-  };
-  const yesCls =
-    "flex-1 rounded-lg border border-transparent bg-st-approval py-1.5 text-center text-[12.5px] font-semibold text-[#201400]";
-  const noCls =
-    "flex-1 rounded-lg border border-line bg-transparent py-1.5 text-center text-[12.5px] font-semibold text-ink transition hover:border-st-error";
-
   return (
     <div className="flex flex-col gap-2.5">
       {/* Approval backend nyata (dari /room/stream) */}
       {serverApprovals.map((r) => (
-        <div key={r.planId} className="rounded-[11px] border p-3" style={cardStyle}>
-          <div className="text-[13px] font-semibold text-ink">🛰️ Backend</div>
-          <div className="my-1 mb-2.5 whitespace-pre-line text-[12.5px] text-ink-soft">
-            {r.desc}
-          </div>
-          <div className="flex gap-2">
-            <button onClick={() => approveServer(r.planId)} className={yesCls}>
-              Setujui
-            </button>
-            <button onClick={() => rejectServer(r.planId)} className={noCls}>
-              Tolak
-            </button>
-          </div>
-        </div>
+        <ApprovalCard
+          key={r.planId}
+          title="🛰️ Backend"
+          desc={r.desc}
+          tall={tall}
+          onApprove={() => approveServer(r.planId)}
+          onReject={() => rejectServer(r.planId)}
+        />
       ))}
 
       {/* Approval mock (ambience scheduler) */}
@@ -52,22 +41,18 @@ export function ApprovalQueue(): JSX.Element {
         const agent = agents.find((a) => a.id === r.agentId);
         const icon = agent ? ROLE[agent.role].icon : "⚙";
         return (
-          <div key={r.id} className="rounded-[11px] border p-3" style={cardStyle}>
-            <div className="text-[13px] font-semibold text-ink">
-              {icon} {agent?.name ?? "Agen"}
-            </div>
-            <div className="my-1 mb-2.5 text-[12.5px] text-ink-soft">
-              ingin menjalankan: <b className="text-ink">{r.task.desc}</b>
-            </div>
-            <div className="flex gap-2">
-              <button onClick={() => approve(r.id)} className={yesCls}>
-                Setujui
-              </button>
-              <button onClick={() => reject(r.id)} className={noCls}>
-                Tolak
-              </button>
-            </div>
-          </div>
+          <ApprovalCard
+            key={r.id}
+            title={`${icon} ${agent?.name ?? "Agen"}`}
+            desc={
+              <>
+                ingin menjalankan: <b className="text-ink">{r.task.desc}</b>
+              </>
+            }
+            tall={tall}
+            onApprove={() => approve(r.id)}
+            onReject={() => reject(r.id)}
+          />
         );
       })}
     </div>

--- a/web/src/ui/Roster.tsx
+++ b/web/src/ui/Roster.tsx
@@ -1,45 +1,72 @@
+import { useState } from "react";
 import { useStore } from "../state/store";
 import { ROLE, STATUS, cssVar } from "../room/engine/scene";
+import { AgentEditor } from "./AgentEditor";
 
 export function Roster(): JSX.Element {
   const agents = useStore((s) => s.agents);
   const selectedId = useStore((s) => s.selectedId);
   const select = useStore((s) => s.select);
+  const [editing, setEditing] = useState(false);
+  const selectedAgent = agents.find((a) => a.id === selectedId) ?? null;
 
   return (
-    <div className="flex flex-col gap-0.5">
-      {agents.map((a) => {
-        const st = STATUS[a.state] ?? STATUS.idle;
-        const active = a.id === selectedId;
-        return (
-          <button
-            key={a.id}
-            onClick={() => select(a.id)}
-            className={`flex items-center gap-2.5 rounded-lg border px-2 py-1.5 text-left transition ${
-              active
-                ? "border-line bg-surface-2"
-                : "border-transparent hover:bg-surface-2"
-            }`}
-          >
-            <span
-              className="h-2.5 w-2.5 flex-none rounded-full"
-              style={{ background: ROLE[a.role].color }}
-            />
-            <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-ink">
-              {a.name}{" "}
-              <span className="font-normal text-ink-faint">
-                · {ROLE[a.role].label}
-              </span>
-            </span>
-            <span
-              className="font-mono text-[10.5px]"
-              style={{ color: cssVar(st.c) }}
+    <div className="flex flex-col gap-2">
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => setEditing(true)}
+          className="rounded-md border border-line px-2 py-1 text-[11px] font-semibold text-ink-soft transition hover:border-accent hover:text-ink"
+        >
+          Kelola
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-0.5">
+        {agents.map((a) => {
+          const st = STATUS[a.state] ?? STATUS.idle;
+          const active = a.id === selectedId;
+          return (
+            <button
+              key={a.id}
+              onClick={() => select(a.id)}
+              className={`flex items-center gap-2.5 rounded-lg border px-2 py-1.5 text-left transition ${
+                active
+                  ? "border-line bg-surface-2"
+                  : "border-transparent hover:bg-surface-2"
+              }`}
             >
-              {st.txt}
-            </span>
-          </button>
-        );
-      })}
+              <span
+                className="h-2.5 w-2.5 flex-none rounded-full"
+                style={{ background: ROLE[a.role].color }}
+              />
+              <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-ink">
+                {a.name}{" "}
+                <span className="font-normal text-ink-faint">
+                  · {ROLE[a.role].label}
+                </span>
+              </span>
+              <span
+                className="font-mono text-[10.5px]"
+                style={{ color: cssVar(st.c) }}
+              >
+                {st.txt}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {editing && (
+        <AgentEditor
+          agent={
+            selectedAgent
+              ? { id: selectedAgent.id, name: selectedAgent.name, role: selectedAgent.role }
+              : null
+          }
+          onClose={() => setEditing(false)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/ui/mobile/ApprovalSheet.tsx
+++ b/web/src/ui/mobile/ApprovalSheet.tsx
@@ -1,0 +1,37 @@
+import { useStore } from "../../state/store";
+import { ApprovalQueue } from "../ApprovalQueue";
+import { BottomSheet } from "./BottomSheet";
+
+export interface ApprovalSheetProps {
+  onClose: () => void;
+}
+
+/** Sheet yang muncul otomatis saat ada approval.request baru (lihat
+ *  MobileShell) — isinya ApprovalQueue yang sama dengan tab Persetujuan,
+ *  cuma dibungkus judul + count pill + tombol Tutup. */
+export function ApprovalSheet({ onClose }: ApprovalSheetProps): JSX.Element {
+  const count = useStore((s) => s.serverApprovals.length + s.approvals.length);
+
+  return (
+    <BottomSheet
+      onClose={onClose}
+      title={
+        <div className="flex items-center gap-2">
+          <span>Perlu persetujuan</span>
+          <span className="grid h-5 min-w-[20px] place-items-center rounded-full bg-st-approval px-1.5 text-[11px] font-bold text-[#201400]">
+            {count}
+          </span>
+        </div>
+      }
+    >
+      <ApprovalQueue />
+      <button
+        type="button"
+        onClick={onClose}
+        className="mt-3 min-h-[48px] w-full rounded-lg border border-line text-[13px] font-semibold text-ink"
+      >
+        Tutup
+      </button>
+    </BottomSheet>
+  );
+}

--- a/web/src/ui/mobile/BottomSheet.tsx
+++ b/web/src/ui/mobile/BottomSheet.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+
+export interface BottomSheetProps {
+  onClose: () => void;
+  title?: ReactNode;
+  children: ReactNode;
+}
+
+/** Sheet generik dari bawah layar (dipakai MoreMenu, ApprovalSheet, AgentEditor
+ *  mobile) — backdrop gelap + drag handle + judul opsional, tutup lewat
+ *  backdrop atau tombol "Tutup" pemanggil sendiri di dalam `children`. */
+export function BottomSheet({ onClose, title, children }: BottomSheetProps): JSX.Element {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="max-h-[85vh] w-full max-w-lg overflow-hidden rounded-t-2xl border-t border-line bg-panel shadow-xl"
+        style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-center pb-1 pt-2.5">
+          <span className="h-1 w-10 rounded-full bg-line" />
+        </div>
+        {title && (
+          <div className="px-4 pb-1 pt-1 font-display text-[15px] font-bold text-ink">
+            {title}
+          </div>
+        )}
+        <div className="scroll-thin max-h-[75vh] overflow-y-auto px-4 pb-4 pt-2">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/ui/mobile/MobileCommandBar.tsx
+++ b/web/src/ui/mobile/MobileCommandBar.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { useStore } from "../../state/store";
+import { sendCommand } from "../../net/api";
+
+/** Command bar bawah ala chat: input rounded 44px + tombol kirim bulat.
+ *  Submit lewat submitCommand yang sama dengan CommandBar desktop. */
+export function MobileCommandBar(): JSX.Element {
+  const [value, setValue] = useState("");
+  const submitCommand = useStore((s) => s.submitCommand);
+
+  const onSubmit = (e: React.FormEvent): void => {
+    e.preventDefault();
+    const txt = value.trim();
+    if (!txt) return;
+    submitCommand(txt);
+    void sendCommand({ text: txt }); // stub, no-op in mock mode
+    setValue("");
+  };
+
+  return (
+    <form
+      className="flex flex-none items-center gap-2 border-t border-line bg-surface px-3 py-2"
+      onSubmit={onSubmit}
+      autoComplete="off"
+    >
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Perintahkan Manajer…"
+        aria-label="Perintah untuk Manajer"
+        className="h-11 min-w-0 flex-1 rounded-full border border-line bg-surface-2 px-4 text-[14px] text-ink outline-none placeholder:text-ink-faint focus-visible:border-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+      />
+      <button
+        type="submit"
+        aria-label="Kirim perintah"
+        className="grid h-11 w-11 flex-none place-items-center rounded-full border border-transparent bg-accent text-accent-ink transition active:brightness-95"
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="12" y1="19" x2="12" y2="5" />
+          <polyline points="5 12 12 5 19 12" />
+        </svg>
+      </button>
+    </form>
+  );
+}

--- a/web/src/ui/mobile/MobileHeader.tsx
+++ b/web/src/ui/mobile/MobileHeader.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { useStore } from "../../state/store";
+import { NotifyButton } from "../NotifyButton";
+import { MoreMenu } from "./MoreMenu";
+
+/** Header ringkas mobile: logo + judul + status satu baris, lonceng notifikasi
+ *  + menu "⋯ Lainnya" (bottom sheet) di kanan. TopBar desktop tak disentuh. */
+export function MobileHeader(): JSX.Element {
+  const workers = useStore((s) => s.workers);
+  const count = useStore((s) => s.agents.length);
+  const [moreOpen, setMoreOpen] = useState(false);
+
+  return (
+    <header className="flex flex-none items-center gap-2.5 border-b border-line bg-surface px-3 py-2">
+      <div className="grid h-8 w-8 flex-none place-items-center rounded-lg bg-gradient-to-br from-accent to-[#6b5bd6] text-[16px] shadow-[0_0_0_1px_rgba(56,225,198,.4)_inset]">
+        🐙
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <h1 className="m-0 truncate font-display text-[14px] font-bold leading-tight text-ink">
+          Ruang Octopus
+        </h1>
+        <div className="flex items-center gap-1.5 truncate font-mono text-[10.5px] text-ink-soft">
+          <span
+            className={
+              workers > 0
+                ? "h-[6px] w-[6px] flex-none rounded-full bg-[#3ddc84] shadow-[0_0_6px_#3ddc84]"
+                : "h-[6px] w-[6px] flex-none rounded-full bg-ink-faint"
+            }
+          />
+          {workers} pasukan online · {count} agen
+        </div>
+      </div>
+
+      <NotifyButton />
+
+      <button
+        type="button"
+        onClick={() => setMoreOpen(true)}
+        title="Lainnya"
+        aria-label="Menu lainnya"
+        className="grid h-9 w-9 flex-none place-items-center rounded-lg border border-line text-[18px] leading-none text-ink-soft"
+      >
+        ⋯
+      </button>
+
+      {moreOpen && <MoreMenu onClose={() => setMoreOpen(false)} />}
+    </header>
+  );
+}

--- a/web/src/ui/mobile/MobileShell.tsx
+++ b/web/src/ui/mobile/MobileShell.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from "react";
+import { useStore } from "../../state/store";
+import { ActivityFeed } from "../ActivityFeed";
+import { ApprovalQueue } from "../ApprovalQueue";
+import { ApprovalSheet } from "./ApprovalSheet";
+import { MobileCommandBar } from "./MobileCommandBar";
+import { MobileHeader } from "./MobileHeader";
+import { PasukanTab } from "./PasukanTab";
+import { RuanganTab } from "./RuanganTab";
+import { TabBar, type TabKey } from "./TabBar";
+
+const TAB_STORAGE_KEY = "octopus-mobile-tab";
+const TAB_KEYS: TabKey[] = ["ruangan", "persetujuan", "aktivitas", "pasukan"];
+
+function loadTab(): TabKey {
+  try {
+    const v = window.localStorage.getItem(TAB_STORAGE_KEY);
+    if (v && (TAB_KEYS as string[]).includes(v)) return v as TabKey;
+  } catch {
+    /* localStorage tak tersedia (mode privat, dll) — abaikan */
+  }
+  return "ruangan";
+}
+
+function saveTab(tab: TabKey): void {
+  try {
+    window.localStorage.setItem(TAB_STORAGE_KEY, tab);
+  } catch {
+    /* abaikan */
+  }
+}
+
+/** Shell aplikasi mobile (viewport < md) — header ringkas, konten tab penuh
+ *  tinggi, command bar + tab bar sticky di bawah. Dipilih App.tsx via
+ *  useIsMobile; layout desktop (grid TopBar/RoomCanvas/aside) tak disentuh. */
+export function MobileShell(): JSX.Element {
+  const [tab, setTab] = useState<TabKey>(loadTab);
+  const [approvalSheetOpen, setApprovalSheetOpen] = useState(false);
+  const serverApprovals = useStore((s) => s.serverApprovals);
+  const approvals = useStore((s) => s.approvals);
+  const approvalCount = serverApprovals.length + approvals.length;
+
+  // Buka sheet persetujuan otomatis begitu approval.request baru masuk,
+  // di tab manapun user sedang berada.
+  const prevServerLen = useRef(serverApprovals.length);
+  useEffect(() => {
+    if (serverApprovals.length > prevServerLen.current) {
+      setApprovalSheetOpen(true);
+      navigator.vibrate?.(30);
+    }
+    prevServerLen.current = serverApprovals.length;
+  }, [serverApprovals.length]);
+
+  const changeTab = (t: TabKey): void => {
+    setTab(t);
+    saveTab(t);
+  };
+
+  return (
+    <div className="flex h-[100dvh] flex-col overflow-hidden bg-bg">
+      <MobileHeader />
+
+      <main className="min-h-0 flex-1 overflow-hidden">
+        {tab === "ruangan" && <RuanganTab />}
+        {tab === "persetujuan" && (
+          <div className="scroll-thin h-full overflow-y-auto px-3 py-3">
+            <ApprovalQueue />
+          </div>
+        )}
+        {tab === "aktivitas" && (
+          <div className="scroll-thin h-full overflow-y-auto px-3 py-3">
+            <ActivityFeed />
+          </div>
+        )}
+        {tab === "pasukan" && <PasukanTab />}
+      </main>
+
+      <MobileCommandBar />
+      <TabBar active={tab} onChange={changeTab} approvalCount={approvalCount} />
+
+      {approvalSheetOpen && (
+        <ApprovalSheet onClose={() => setApprovalSheetOpen(false)} />
+      )}
+    </div>
+  );
+}

--- a/web/src/ui/mobile/MoreMenu.tsx
+++ b/web/src/ui/mobile/MoreMenu.tsx
@@ -1,0 +1,32 @@
+import { useStore } from "../../state/store";
+import { ProviderButton } from "../ProviderSettings";
+import { UpdateButton } from "../UpdateButton";
+import { BottomSheet } from "./BottomSheet";
+
+export interface MoreMenuProps {
+  onClose: () => void;
+}
+
+/** Menu "⋯ Lainnya" mobile — isi TopBar desktop yang tak muat di header
+ *  ringkas: provider BYOK, versi/update, ganti tema. */
+export function MoreMenu({ onClose }: MoreMenuProps): JSX.Element {
+  const theme = useStore((s) => s.theme);
+  const toggleTheme = useStore((s) => s.toggleTheme);
+
+  return (
+    <BottomSheet onClose={onClose} title="Lainnya">
+      <div className="flex flex-col gap-2">
+        <ProviderButton />
+        <UpdateButton />
+        <button
+          type="button"
+          onClick={toggleTheme}
+          className="flex min-h-[44px] items-center justify-between rounded-lg border border-line px-3 py-2 text-[13px] font-semibold text-ink"
+        >
+          Tema
+          <span>{theme === "dark" ? "☀ Terang" : "◐ Gelap"}</span>
+        </button>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/web/src/ui/mobile/PasukanTab.tsx
+++ b/web/src/ui/mobile/PasukanTab.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { getProvider } from "../../net/api";
+import { mix } from "../../room/engine/render";
+import { ROLE, STATUS, cssVar } from "../../room/engine/scene";
+import { useStore } from "../../state/store";
+import type { Role } from "../../state/types";
+import { AgentEditor } from "../AgentEditor";
+import { InspectorPanel } from "../InspectorPanel";
+
+type Editing = "new" | { id: string; name: string; role: Role };
+
+/** Tab Pasukan mobile: ringkasan (worker online / LLM aktif) + roster CRUD —
+ *  tap baris untuk pilih agen (InspectorPanel di bawahnya), "⋯" untuk kelola. */
+export function PasukanTab(): JSX.Element {
+  const agents = useStore((s) => s.agents);
+  const workers = useStore((s) => s.workers);
+  const selectedId = useStore((s) => s.selectedId);
+  const select = useStore((s) => s.select);
+  const [editing, setEditing] = useState<Editing | null>(null);
+
+  return (
+    <div className="scroll-thin h-full overflow-y-auto px-3 py-3">
+      <div className="mb-3 grid grid-cols-2 gap-2.5">
+        <div className="rounded-xl border border-line bg-surface-2 p-3">
+          <div className="text-[10.5px] uppercase tracking-wide text-ink-faint">
+            Worker online
+          </div>
+          <div className="mt-1 font-display text-[20px] font-bold text-ink">{workers}</div>
+        </div>
+        <div className="rounded-xl border border-line bg-surface-2 p-3">
+          <div className="text-[10.5px] uppercase tracking-wide text-ink-faint">LLM aktif</div>
+          <div className="mt-1 truncate font-display text-[16px] font-bold text-ink">
+            {getProvider()}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        {agents.map((a) => {
+          const active = a.id === selectedId;
+          const st = STATUS[a.state] ?? STATUS.idle;
+          return (
+            <div key={a.id}>
+              <div
+                className={`flex min-h-[56px] items-center gap-2 rounded-xl border px-2.5 ${
+                  active ? "border-accent bg-surface-2" : "border-line bg-surface"
+                }`}
+              >
+                <button
+                  type="button"
+                  onClick={() => select(active ? null : a.id)}
+                  className="flex min-w-0 flex-1 items-center gap-3 py-2 text-left"
+                >
+                  <span
+                    className="grid h-9 w-9 flex-none place-items-center rounded-full text-[15px]"
+                    style={{ background: mix(ROLE[a.role].color, "#ffffff", 0.16) }}
+                  >
+                    {ROLE[a.role].icon}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[13.5px] font-semibold text-ink">
+                      {a.name}{" "}
+                      <span className="font-normal text-ink-faint">
+                        · {ROLE[a.role].label}
+                      </span>
+                    </span>
+                    <span className="block truncate text-[11.5px] text-ink-soft">
+                      {a.task ? a.task.desc : "—"}
+                    </span>
+                  </span>
+                </button>
+                <span
+                  className="flex-none font-mono text-[10.5px]"
+                  style={{ color: cssVar(st.c) }}
+                >
+                  {st.txt}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setEditing({ id: a.id, name: a.name, role: a.role })}
+                  aria-label={`Kelola ${a.name}`}
+                  className="grid h-9 w-9 flex-none place-items-center rounded-lg text-[16px] text-ink-faint"
+                >
+                  ⋯
+                </button>
+              </div>
+              {active && (
+                <div className="mb-1 mt-1.5 rounded-xl border border-line bg-panel p-3">
+                  <InspectorPanel />
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        <button
+          type="button"
+          onClick={() => setEditing("new")}
+          className="mt-1 min-h-[48px] rounded-xl border border-dashed border-line text-[13px] font-semibold text-ink-soft"
+        >
+          + Tambah agen
+        </button>
+      </div>
+
+      {editing && (
+        <AgentEditor
+          agent={editing === "new" ? null : editing}
+          onClose={() => setEditing(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/ui/mobile/RuanganTab.tsx
+++ b/web/src/ui/mobile/RuanganTab.tsx
@@ -1,0 +1,38 @@
+import { RoomCanvas } from "../../room/RoomCanvas";
+import { mix } from "../../room/engine/render";
+import { ROLE, STATUS } from "../../room/engine/scene";
+import { useStore } from "../../state/store";
+
+/** Tab Ruangan mobile: RoomCanvas penuh + kartu status manajer mengambang di
+ *  atas hint bawaan RoomCanvas (bottom-3) supaya tak tumpang tindih. */
+export function RuanganTab(): JSX.Element {
+  const manager = useStore((s) => s.agents.find((a) => a.role === "manager") ?? null);
+
+  const st = manager ? STATUS[manager.state] ?? STATUS.idle : null;
+
+  return (
+    <div className="relative h-full w-full">
+      <RoomCanvas />
+      {manager && (
+        <div className="pointer-events-none absolute inset-x-3 bottom-14 rounded-xl border border-line bg-[var(--c-namebg)] px-3 py-2.5 backdrop-blur">
+          <div className="flex items-center gap-2.5">
+            <span
+              className="grid h-7 w-7 flex-none place-items-center rounded-full text-[14px]"
+              style={{ background: mix(ROLE.manager.color, "#ffffff", 0.16) }}
+            >
+              {ROLE.manager.icon}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-[12.5px] font-semibold text-ink">
+                {manager.name} · {st?.txt}
+              </div>
+              <div className="truncate text-[11px] text-ink-soft">
+                {manager.task ? manager.task.desc : "Belum ada tugas"}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/ui/mobile/TabBar.tsx
+++ b/web/src/ui/mobile/TabBar.tsx
@@ -1,0 +1,95 @@
+export type TabKey = "ruangan" | "persetujuan" | "aktivitas" | "pasukan";
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: "ruangan", label: "Ruangan" },
+  { key: "persetujuan", label: "Persetujuan" },
+  { key: "aktivitas", label: "Aktivitas" },
+  { key: "pasukan", label: "Pasukan" },
+];
+
+const ICON_PROPS = {
+  width: 20,
+  height: 20,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.8,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+function TabIcon({ tab }: { tab: TabKey }): JSX.Element {
+  switch (tab) {
+    case "ruangan":
+      return (
+        <svg {...ICON_PROPS}>
+          <path d="M3 11.5 12 4l9 7.5" />
+          <path d="M5.5 10v9h13v-9" />
+        </svg>
+      );
+    case "persetujuan":
+      return (
+        <svg {...ICON_PROPS}>
+          <path d="M12 3.5 5 6v6c0 4.2 3 7 7 8.5 4-1.5 7-4.3 7-8.5V6z" />
+          <path d="m9.2 12.2 2 2 3.6-3.9" />
+        </svg>
+      );
+    case "aktivitas":
+      return (
+        <svg {...ICON_PROPS}>
+          <path d="M3 12h4l2-7 4 14 2-7h6" />
+        </svg>
+      );
+    case "pasukan":
+      return (
+        <svg {...ICON_PROPS}>
+          <circle cx="9" cy="8" r="3.2" />
+          <path d="M2.8 19c.6-3.4 3-5.2 6.2-5.2s5.6 1.8 6.2 5.2" />
+          <circle cx="17" cy="8.5" r="2.4" />
+          <path d="M15.8 13.9c2.4.2 4 1.9 4.5 5" />
+        </svg>
+      );
+    default:
+      return <svg {...ICON_PROPS} />;
+  }
+}
+
+export interface TabBarProps {
+  active: TabKey;
+  onChange: (tab: TabKey) => void;
+  approvalCount: number;
+}
+
+/** Tab bar sticky di dasar layar (4 tab) + badge angka di Persetujuan. */
+export function TabBar({ active, onChange, approvalCount }: TabBarProps): JSX.Element {
+  return (
+    <nav
+      className="grid flex-none grid-cols-4 border-t border-line bg-surface"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+    >
+      {TABS.map((t) => {
+        const isActive = t.key === active;
+        return (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => onChange(t.key)}
+            aria-label={t.label}
+            aria-current={isActive ? "page" : undefined}
+            className={`relative flex min-h-[52px] flex-col items-center justify-center gap-0.5 text-[10.5px] font-semibold transition ${
+              isActive ? "text-accent" : "text-ink-faint"
+            }`}
+          >
+            <TabIcon tab={t.key} />
+            {t.label}
+            {t.key === "persetujuan" && approvalCount > 0 && (
+              <span className="absolute right-[22%] top-1.5 grid h-[16px] min-w-[16px] place-items-center rounded-full bg-st-error px-1 text-[9.5px] font-bold leading-none text-white">
+                {approvalCount}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
## What
Native-app-style mobile shell for the Octopus PWA (< 768px) and roster CRUD ("kelola pasukan": rename / change role / add / delete agents). Desktop layout is unchanged.

## Why
On phones the desktop layout wrapped into a long scrolling page with approvals buried at the bottom. The approved design (Claude Design canvas) moves to a 4-tab shell with a thumb-reach command bar and an approval bottom-sheet. Users also wanted to rename their agents.

## How
**Mobile shell** (`web/src/ui/mobile/*`, `web/src/hooks/useIsMobile.ts`)
- Compact header (logo, pasukan/agen status, 🔔, ⋯ menu → provider, version/update, theme)
- Sticky chat-style command bar + tab bar: Ruangan · Persetujuan (badge) · Aktivitas · Pasukan, safe-area aware
- `ApprovalSheet` opens on incoming `approval.request`; shared `BottomSheet`, `ApprovalCard` extracted from `ApprovalQueue`
- Room canvas: portrait "cover" fit + drag-to-pan (`render.ts::computeCamera/clampOffX`, `useRoomEngine.ts`)
- Native polish in `index.css` / `index.html` (overscroll, tap highlight, 44px targets, hidden scrollbars, iOS status bar)

**Roster CRUD**
- `app/ports/roster.py` (`RosterPort`, `DEFAULT_ROSTER`, `ROSTER_ROLES`), `app/adapters/roster_redis.py` (`RedisRosterStore`, hash `room:roster:<user>`, default roster when empty, manager required & undeletable)
- `app/interfaces/roster.py`: `GET /room/roster`, `PUT /room/roster/{id}`, `DELETE /room/roster/{id}`; publishes `roster.updated`; `/room/state` + `/room/stream` snapshot now per-user roster
- Web: `AgentEditor` (sheet/modal), "Kelola" on desktop roster, ⋯ per row + "+ Tambah agen" on mobile; store reconciles agents from `room.snapshot` / `roster.updated` keeping runtime positions/state

**Version** web `0.3.0` + changelog entry (in-app update prompt will show it).

| File | Change |
|---|---|
| `web/src/ui/mobile/*`, `web/src/hooks/useIsMobile.ts` | new mobile shell |
| `web/src/ui/{AgentEditor,ApprovalCard}.tsx`, `ApprovalQueue.tsx`, `Roster.tsx` | CRUD UI + shared card |
| `web/src/state/store.ts`, `web/src/net/api.ts` | roster reconcile + API |
| `web/src/room/engine/render.ts`, `web/src/room/useRoomEngine.ts` | cover camera + pan |
| `app/ports/roster.py`, `app/adapters/roster_redis.py`, `app/interfaces/roster.py`, `room.py`, `gateway.py`, `composition.py`, `redis_client.py` | backend CRUD |
| `tests/adapters/test_roster_redis.py`, `tests/interfaces/test_roster_endpoints.py`, `test_room.py`, `test_push_endpoints.py` | tests (push 503 tests made `.env`-independent) |

## How to test
1. `make check` → ruff/mypy green, 738 passed (3 pre-existing `.env` failures locally only).
2. `cd web && npm ci && npm run build`.
3. Open the PWA on a phone (or DevTools 390×844): tabs, command bar, ⋯ menu; trigger a risky command → approval sheet slides up.
4. Pasukan → ⋯ on a row → rename/change role → Simpan → row updates and `GET /room/roster` reflects it; "+ Tambah agen" adds one; deleting the manager is refused.
