### PR TITLE
feat(web): shell mobile lebih responsif & terasa native

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "octopus-gather-room",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Ruang Octopus — gather-room frontend for the AI IT-Manager (mock data, Phase 3 P0-P1)",
   "scripts": {

--- a/web/src/changelog.ts
+++ b/web/src/changelog.ts
@@ -12,6 +12,15 @@ export interface ReleaseNote {
 
 export const CHANGELOG: ReleaseNote[] = [
   {
+    version: "0.3.1",
+    date: "2026-08-29",
+    notes: [
+      "Tampilan mobile kini dipakai juga di tablet portrait dan HP landscape (rail tab di kiri, tombol tulis perintah di header).",
+      "Teks & tombol lebih besar dan nyaman disentuh; input tidak lagi memicu zoom otomatis di iOS.",
+      "Header menghormati area status bar (notch), transisi tab & sheet lebih halus.",
+    ],
+  },
+  {
     version: "0.3.0",
     date: "2026-08-29",
     notes: [

--- a/web/src/hooks/useIsMobile.ts
+++ b/web/src/hooks/useIsMobile.ts
@@ -1,8 +1,32 @@
 import { useEffect, useState } from "react";
 
-// Sinkron dengan breakpoint Tailwind "md" (768px) — App.tsx pakai batas yang
-// sama untuk memutuskan MobileShell vs tata letak desktop.
-const QUERY = "(max-width: 767px)";
+// Shell mobile untuk semua layar sentuh "kecil": HP portrait/landscape dan
+// tablet portrait (< 1024px), atau layar pendek (HP landscape) — tata letak
+// desktop (grid TopBar/aside) baru layak di ≥ 1024px dengan tinggi cukup.
+const QUERY = "(max-width: 1023px), (max-height: 520px)";
+export const SHORT_QUERY = "(max-height: 520px) and (orientation: landscape)";
+
+function useMedia(query: string): boolean {
+  const [on, setOn] = useState<boolean>(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+    return window.matchMedia(query).matches;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mql = window.matchMedia(query);
+    const onChange = (): void => setOn(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+  return on;
+}
+
+/** Layar pendek landscape (HP dimiringkan): tab bar jadi rail kiri, command bar
+ *  dipindah ke sheet supaya kanvas dapat tinggi maksimal. */
+export function useShortViewport(): boolean {
+  return useMedia(SHORT_QUERY);
+}
 
 function matches(): boolean {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -34,7 +34,7 @@ button {
   user-select: none;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 1023px) {
   .scroll-thin {
     scrollbar-width: none;
   }
@@ -59,5 +59,38 @@ button {
 @media (prefers-reduced-motion: reduce) {
   * {
     scroll-behavior: auto;
+  }
+}
+
+/* ── Mobile shell: transisi konten tab + tekan tombol terasa "native" ─────── */
+@keyframes tab-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: none; }
+}
+.tab-in {
+  animation: tab-in 180ms ease-out;
+}
+@keyframes sheet-in {
+  from { transform: translateY(24px); opacity: 0.6; }
+  to { transform: none; opacity: 1; }
+}
+.sheet-in {
+  animation: sheet-in 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+@media (max-width: 1023px) {
+  button:active {
+    transform: scale(0.97);
+  }
+  /* iOS zoom-in otomatis saat fokus input < 16px — hindari */
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .tab-in,
+  .sheet-in {
+    animation: none;
   }
 }

--- a/web/src/ui/ActivityFeed.tsx
+++ b/web/src/ui/ActivityFeed.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef } from "react";
 import { useStore } from "../state/store";
 import { cssVar } from "../room/engine/scene";
 
-export function ActivityFeed(): JSX.Element {
+/** `large`: tipografi mobile (14px) supaya nyaman dibaca di layar sentuh. */
+export function ActivityFeed({ large }: { large?: boolean } = {}): JSX.Element {
   const events = useStore((s) => s.events);
   const endRef = useRef<HTMLDivElement>(null);
 
@@ -13,14 +14,14 @@ export function ActivityFeed(): JSX.Element {
   return (
     <ul className="m-0 flex list-none flex-col gap-2 p-0">
       {events.map((f) => (
-        <li key={f.id} className="flex gap-2 text-[12.5px] leading-snug">
+        <li key={f.id} className={`flex gap-2 leading-snug ${large ? "text-[14px]" : "text-[12.5px]"}`}>
           <span
             className="mt-[5px] h-[7px] w-[7px] flex-none rounded-full"
             style={{ background: cssVar(f.color) }}
           />
           <span className="text-ink">
             <span dangerouslySetInnerHTML={{ __html: f.msg }} />{" "}
-            <time className="font-mono text-[10.5px] text-ink-faint">{f.t}</time>
+            <time className={`font-mono text-ink-faint ${large ? "text-[11.5px]" : "text-[10.5px]"}`}>{f.t}</time>
           </span>
         </li>
       ))}

--- a/web/src/ui/ApprovalCard.tsx
+++ b/web/src/ui/ApprovalCard.tsx
@@ -18,13 +18,14 @@ export interface ApprovalCardProps {
  *  lewat useIsMobile) dan ApprovalSheet — satu tempat untuk styling & markup. */
 export function ApprovalCard({ title, desc, onApprove, onReject, tall }: ApprovalCardProps): JSX.Element {
   const btnH = tall ? "min-h-[48px]" : "py-1.5";
-  const yesCls = `flex-1 rounded-lg border border-transparent bg-st-approval text-center text-[12.5px] font-semibold text-[#201400] ${btnH}`;
-  const noCls = `flex-1 rounded-lg border border-line bg-transparent text-center text-[12.5px] font-semibold text-ink transition hover:border-st-error ${btnH}`;
+  const txt = tall ? "text-[15px]" : "text-[12.5px]";
+  const yesCls = `flex-1 rounded-xl border border-transparent bg-st-approval text-center font-semibold text-[#201400] ${txt} ${btnH}`;
+  const noCls = `flex-1 rounded-xl border border-line bg-transparent text-center font-semibold text-ink transition hover:border-st-error ${txt} ${btnH}`;
 
   return (
     <div className="rounded-[11px] border p-3" style={CARD_STYLE}>
-      <div className="text-[13px] font-semibold text-ink">{title}</div>
-      <div className="my-1 mb-2.5 whitespace-pre-line text-[12.5px] text-ink-soft">{desc}</div>
+      <div className={`font-semibold text-ink ${tall ? "text-[15px]" : "text-[13px]"}`}>{title}</div>
+      <div className={`my-1 mb-2.5 whitespace-pre-line text-ink-soft ${tall ? "text-[14px]" : "text-[12.5px]"}`}>{desc}</div>
       <div className="flex gap-2">
         <button type="button" onClick={onApprove} className={yesCls}>
           Setujui

--- a/web/src/ui/mobile/BottomSheet.tsx
+++ b/web/src/ui/mobile/BottomSheet.tsx
@@ -16,7 +16,7 @@ export function BottomSheet({ onClose, title, children }: BottomSheetProps): JSX
       onClick={onClose}
     >
       <div
-        className="max-h-[85vh] w-full max-w-lg overflow-hidden rounded-t-2xl border-t border-line bg-panel shadow-xl"
+        className="sheet-in max-h-[85dvh] w-full max-w-lg overflow-hidden rounded-t-2xl border-t border-line bg-panel shadow-xl"
         style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
         onClick={(e) => e.stopPropagation()}
       >
@@ -24,11 +24,11 @@ export function BottomSheet({ onClose, title, children }: BottomSheetProps): JSX
           <span className="h-1 w-10 rounded-full bg-line" />
         </div>
         {title && (
-          <div className="px-4 pb-1 pt-1 font-display text-[15px] font-bold text-ink">
+          <div className="px-4 pb-1 pt-1 font-display text-[16px] font-bold text-ink">
             {title}
           </div>
         )}
-        <div className="scroll-thin max-h-[75vh] overflow-y-auto px-4 pb-4 pt-2">
+        <div className="scroll-thin max-h-[75dvh] overflow-y-auto px-4 pb-4 pt-2">
           {children}
         </div>
       </div>

--- a/web/src/ui/mobile/MobileCommandBar.tsx
+++ b/web/src/ui/mobile/MobileCommandBar.tsx
@@ -4,7 +4,7 @@ import { sendCommand } from "../../net/api";
 
 /** Command bar bawah ala chat: input rounded 44px + tombol kirim bulat.
  *  Submit lewat submitCommand yang sama dengan CommandBar desktop. */
-export function MobileCommandBar(): JSX.Element {
+export function MobileCommandBar({ autoFocus }: { autoFocus?: boolean } = {}): JSX.Element {
   const [value, setValue] = useState("");
   const submitCommand = useStore((s) => s.submitCommand);
 
@@ -25,16 +25,18 @@ export function MobileCommandBar(): JSX.Element {
     >
       <input
         type="text"
+        autoFocus={autoFocus}
+        enterKeyHint="send"
         value={value}
         onChange={(e) => setValue(e.target.value)}
         placeholder="Perintahkan Manajer…"
         aria-label="Perintah untuk Manajer"
-        className="h-11 min-w-0 flex-1 rounded-full border border-line bg-surface-2 px-4 text-[14px] text-ink outline-none placeholder:text-ink-faint focus-visible:border-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+        className="h-12 min-w-0 flex-1 rounded-full border border-line bg-surface-2 px-4 text-[16px] text-ink outline-none placeholder:text-ink-faint focus-visible:border-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
       />
       <button
         type="submit"
         aria-label="Kirim perintah"
-        className="grid h-11 w-11 flex-none place-items-center rounded-full border border-transparent bg-accent text-accent-ink transition active:brightness-95"
+        className="grid h-12 w-12 flex-none place-items-center rounded-full border border-transparent bg-accent text-accent-ink transition active:brightness-95"
       >
         <svg
           width="20"

--- a/web/src/ui/mobile/MobileHeader.tsx
+++ b/web/src/ui/mobile/MobileHeader.tsx
@@ -5,22 +5,30 @@ import { MoreMenu } from "./MoreMenu";
 
 /** Header ringkas mobile: logo + judul + status satu baris, lonceng notifikasi
  *  + menu "⋯ Lainnya" (bottom sheet) di kanan. TopBar desktop tak disentuh. */
-export function MobileHeader(): JSX.Element {
+export interface MobileHeaderProps {
+  /** Mode layar pendek: tampilkan tombol tulis perintah (command bar disembunyikan). */
+  onCompose?: () => void;
+}
+
+export function MobileHeader({ onCompose }: MobileHeaderProps = {}): JSX.Element {
   const workers = useStore((s) => s.workers);
   const count = useStore((s) => s.agents.length);
   const [moreOpen, setMoreOpen] = useState(false);
 
   return (
-    <header className="flex flex-none items-center gap-2.5 border-b border-line bg-surface px-3 py-2">
+    <header
+      className="flex flex-none items-center gap-2.5 border-b border-line bg-surface px-3 pb-2"
+      style={{ paddingTop: "calc(8px + env(safe-area-inset-top))" }}
+    >
       <div className="grid h-8 w-8 flex-none place-items-center rounded-lg bg-gradient-to-br from-accent to-[#6b5bd6] text-[16px] shadow-[0_0_0_1px_rgba(56,225,198,.4)_inset]">
         🐙
       </div>
 
       <div className="min-w-0 flex-1">
-        <h1 className="m-0 truncate font-display text-[14px] font-bold leading-tight text-ink">
+        <h1 className="m-0 truncate font-display text-[16px] font-bold leading-tight text-ink">
           Ruang Octopus
         </h1>
-        <div className="flex items-center gap-1.5 truncate font-mono text-[10.5px] text-ink-soft">
+        <div className="flex items-center gap-1.5 truncate font-mono text-[11.5px] text-ink-soft">
           <span
             className={
               workers > 0
@@ -32,6 +40,20 @@ export function MobileHeader(): JSX.Element {
         </div>
       </div>
 
+      {onCompose && (
+        <button
+          type="button"
+          onClick={onCompose}
+          aria-label="Tulis perintah"
+          className="grid h-10 w-10 flex-none place-items-center rounded-lg bg-accent text-accent-ink"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4 20h4l10.5-10.5a2.1 2.1 0 0 0-3-3L5 17z" />
+            <path d="m13.5 6.5 3 3" />
+          </svg>
+        </button>
+      )}
+
       <NotifyButton />
 
       <button
@@ -39,7 +61,7 @@ export function MobileHeader(): JSX.Element {
         onClick={() => setMoreOpen(true)}
         title="Lainnya"
         aria-label="Menu lainnya"
-        className="grid h-9 w-9 flex-none place-items-center rounded-lg border border-line text-[18px] leading-none text-ink-soft"
+        className="grid h-10 w-10 flex-none place-items-center rounded-lg border border-line text-[18px] leading-none text-ink-soft"
       >
         ⋯
       </button>

--- a/web/src/ui/mobile/MobileShell.tsx
+++ b/web/src/ui/mobile/MobileShell.tsx
@@ -8,6 +8,8 @@ import { MobileHeader } from "./MobileHeader";
 import { PasukanTab } from "./PasukanTab";
 import { RuanganTab } from "./RuanganTab";
 import { TabBar, type TabKey } from "./TabBar";
+import { BottomSheet } from "./BottomSheet";
+import { useShortViewport } from "../../hooks/useIsMobile";
 
 const TAB_STORAGE_KEY = "octopus-mobile-tab";
 const TAB_KEYS: TabKey[] = ["ruangan", "persetujuan", "aktivitas", "pasukan"];
@@ -36,6 +38,8 @@ function saveTab(tab: TabKey): void {
 export function MobileShell(): JSX.Element {
   const [tab, setTab] = useState<TabKey>(loadTab);
   const [approvalSheetOpen, setApprovalSheetOpen] = useState(false);
+  const [composeOpen, setComposeOpen] = useState(false);
+  const short = useShortViewport();
   const serverApprovals = useStore((s) => s.serverApprovals);
   const approvals = useStore((s) => s.approvals);
   const approvalCount = serverApprovals.length + approvals.length;
@@ -56,29 +60,51 @@ export function MobileShell(): JSX.Element {
     saveTab(t);
   };
 
+  const content = (
+    <main key={tab} className="tab-in min-h-0 flex-1 overflow-hidden">
+      {tab === "ruangan" && <RuanganTab />}
+      {tab === "persetujuan" && (
+        <div className="scroll-thin h-full overflow-y-auto px-3 py-3">
+          <ApprovalQueue />
+        </div>
+      )}
+      {tab === "aktivitas" && (
+        <div className="scroll-thin h-full overflow-y-auto px-3 py-3">
+          <ActivityFeed large />
+        </div>
+      )}
+      {tab === "pasukan" && <PasukanTab />}
+    </main>
+  );
+
+  const tabBar = (
+    <TabBar active={tab} onChange={changeTab} approvalCount={approvalCount} vertical={short} />
+  );
+
   return (
-    <div className="flex h-[100dvh] flex-col overflow-hidden bg-bg">
-      <MobileHeader />
+    <div className="flex h-[100dvh] w-full flex-col overflow-hidden bg-bg">
+      <MobileHeader onCompose={short ? () => setComposeOpen(true) : undefined} />
 
-      <main className="min-h-0 flex-1 overflow-hidden">
-        {tab === "ruangan" && <RuanganTab />}
-        {tab === "persetujuan" && (
-          <div className="scroll-thin h-full overflow-y-auto px-3 py-3">
-            <ApprovalQueue />
-          </div>
-        )}
-        {tab === "aktivitas" && (
-          <div className="scroll-thin h-full overflow-y-auto px-3 py-3">
-            <ActivityFeed />
-          </div>
-        )}
-        {tab === "pasukan" && <PasukanTab />}
-      </main>
+      {short ? (
+        <div className="flex min-h-0 flex-1">
+          {tabBar}
+          <div className="flex min-h-0 flex-1 flex-col">{content}</div>
+        </div>
+      ) : (
+        <>
+          {content}
+          <MobileCommandBar />
+          {tabBar}
+        </>
+      )}
 
-      <MobileCommandBar />
-      <TabBar active={tab} onChange={changeTab} approvalCount={approvalCount} />
+      {composeOpen && (
+        <BottomSheet onClose={() => setComposeOpen(false)} title="Perintahkan Manajer">
+          <MobileCommandBar autoFocus />
+        </BottomSheet>
+      )}
 
-      {approvalSheetOpen && (
+      {approvalSheetOpen && approvalCount > 0 && (
         <ApprovalSheet onClose={() => setApprovalSheetOpen(false)} />
       )}
     </div>

--- a/web/src/ui/mobile/PasukanTab.tsx
+++ b/web/src/ui/mobile/PasukanTab.tsx
@@ -22,13 +22,13 @@ export function PasukanTab(): JSX.Element {
     <div className="scroll-thin h-full overflow-y-auto px-3 py-3">
       <div className="mb-3 grid grid-cols-2 gap-2.5">
         <div className="rounded-xl border border-line bg-surface-2 p-3">
-          <div className="text-[10.5px] uppercase tracking-wide text-ink-faint">
+          <div className="text-[11px] uppercase tracking-wide text-ink-faint">
             Worker online
           </div>
           <div className="mt-1 font-display text-[20px] font-bold text-ink">{workers}</div>
         </div>
         <div className="rounded-xl border border-line bg-surface-2 p-3">
-          <div className="text-[10.5px] uppercase tracking-wide text-ink-faint">LLM aktif</div>
+          <div className="text-[11px] uppercase tracking-wide text-ink-faint">LLM aktif</div>
           <div className="mt-1 truncate font-display text-[16px] font-bold text-ink">
             {getProvider()}
           </div>
@@ -52,25 +52,25 @@ export function PasukanTab(): JSX.Element {
                   className="flex min-w-0 flex-1 items-center gap-3 py-2 text-left"
                 >
                   <span
-                    className="grid h-9 w-9 flex-none place-items-center rounded-full text-[15px]"
+                    className="grid h-10 w-10 flex-none place-items-center rounded-full text-[16px]"
                     style={{ background: mix(ROLE[a.role].color, "#ffffff", 0.16) }}
                   >
                     {ROLE[a.role].icon}
                   </span>
                   <span className="min-w-0 flex-1">
-                    <span className="block truncate text-[13.5px] font-semibold text-ink">
+                    <span className="block truncate text-[15px] font-semibold text-ink">
                       {a.name}{" "}
                       <span className="font-normal text-ink-faint">
                         · {ROLE[a.role].label}
                       </span>
                     </span>
-                    <span className="block truncate text-[11.5px] text-ink-soft">
+                    <span className="block truncate text-[12.5px] text-ink-soft">
                       {a.task ? a.task.desc : "—"}
                     </span>
                   </span>
                 </button>
                 <span
-                  className="flex-none font-mono text-[10.5px]"
+                  className="flex-none font-mono text-[11px]"
                   style={{ color: cssVar(st.c) }}
                 >
                   {st.txt}
@@ -79,7 +79,7 @@ export function PasukanTab(): JSX.Element {
                   type="button"
                   onClick={() => setEditing({ id: a.id, name: a.name, role: a.role })}
                   aria-label={`Kelola ${a.name}`}
-                  className="grid h-9 w-9 flex-none place-items-center rounded-lg text-[16px] text-ink-faint"
+                  className="grid h-11 w-11 flex-none place-items-center rounded-lg text-[18px] text-ink-faint"
                 >
                   ⋯
                 </button>
@@ -96,7 +96,7 @@ export function PasukanTab(): JSX.Element {
         <button
           type="button"
           onClick={() => setEditing("new")}
-          className="mt-1 min-h-[48px] rounded-xl border border-dashed border-line text-[13px] font-semibold text-ink-soft"
+          className="mt-1 min-h-[52px] rounded-xl border border-dashed border-line text-[14.5px] font-semibold text-ink-soft"
         >
           + Tambah agen
         </button>

--- a/web/src/ui/mobile/TabBar.tsx
+++ b/web/src/ui/mobile/TabBar.tsx
@@ -8,8 +8,8 @@ const TABS: { key: TabKey; label: string }[] = [
 ];
 
 const ICON_PROPS = {
-  width: 20,
-  height: 20,
+  width: 22,
+  height: 22,
   viewBox: "0 0 24 24",
   fill: "none",
   stroke: "currentColor",
@@ -58,14 +58,25 @@ export interface TabBarProps {
   active: TabKey;
   onChange: (tab: TabKey) => void;
   approvalCount: number;
+  /** Rail vertikal di kiri (layar pendek/landscape) — ikon saja. */
+  vertical?: boolean;
 }
 
 /** Tab bar sticky di dasar layar (4 tab) + badge angka di Persetujuan. */
-export function TabBar({ active, onChange, approvalCount }: TabBarProps): JSX.Element {
+export function TabBar({ active, onChange, approvalCount, vertical }: TabBarProps): JSX.Element {
   return (
     <nav
-      className="grid flex-none grid-cols-4 border-t border-line bg-surface"
-      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+      aria-label="Navigasi utama"
+      className={
+        vertical
+          ? "flex w-[64px] flex-none flex-col items-stretch justify-center gap-1 border-r border-line bg-surface px-1"
+          : "grid flex-none grid-cols-4 border-t border-line bg-surface"
+      }
+      style={
+        vertical
+          ? { paddingLeft: "env(safe-area-inset-left)" }
+          : { paddingBottom: "env(safe-area-inset-bottom)" }
+      }
     >
       {TABS.map((t) => {
         const isActive = t.key === active;
@@ -76,12 +87,12 @@ export function TabBar({ active, onChange, approvalCount }: TabBarProps): JSX.El
             onClick={() => onChange(t.key)}
             aria-label={t.label}
             aria-current={isActive ? "page" : undefined}
-            className={`relative flex min-h-[52px] flex-col items-center justify-center gap-0.5 text-[10.5px] font-semibold transition ${
-              isActive ? "text-accent" : "text-ink-faint"
-            }`}
+            className={`relative flex flex-col items-center justify-center gap-1 rounded-xl text-[11.5px] font-semibold transition ${
+              vertical ? "min-h-[56px]" : "min-h-[58px]"
+            } ${isActive ? "text-accent" : "text-ink-faint"}`}
           >
             <TabIcon tab={t.key} />
-            {t.label}
+            {!vertical && t.label}
             {t.key === "persetujuan" && approvalCount > 0 && (
               <span className="absolute right-[22%] top-1.5 grid h-[16px] min-w-[16px] place-items-center rounded-full bg-st-error px-1 text-[9.5px] font-bold leading-none text-white">
                 {approvalCount}


### PR DESCRIPTION
## What
Responsiveness pass on the mobile PWA shell (web v0.3.1). Design unchanged; behavior adapts to more screen classes and feels closer to a native app.

## Why
Tablet-portrait and landscape phones still received the cramped desktop layout; type/hit targets were small; iOS zoomed on input focus; the header ignored the notch area.

## How
| File | Change |
|---|---|
| `web/src/hooks/useIsMobile.ts` | shell breakpoint `(max-width: 1023px), (max-height: 520px)`; new `useShortViewport()` |
| `web/src/ui/mobile/MobileShell.tsx` | short/landscape layout: vertical tab rail + compose sheet; `tab-in` transition |
| `web/src/ui/mobile/TabBar.tsx` | `vertical` rail mode, 58px tabs, 22px icons |
| `web/src/ui/mobile/MobileHeader.tsx` | safe-area-top padding, compose button, larger title/status |
| `web/src/ui/mobile/MobileCommandBar.tsx` | 48px input at 16px (no iOS auto-zoom), `enterKeyHint="send"`, `autoFocus` in sheet |
| `web/src/ui/mobile/BottomSheet.tsx`, `PasukanTab.tsx`, `ApprovalCard.tsx`, `ActivityFeed.tsx` | dvh, `sheet-in` animation, larger type on mobile |
| `web/src/index.css` | 1023px media rules, press feedback, 16px inputs, keyframes |
| `web/package.json`, `web/src/changelog.ts` | 0.3.1 + notes |

## How to test
1. `cd web && npm ci && npm run build`.
2. DevTools 360×740, 390×844, 768×1024 (portrait tablet) → mobile shell; 844×390 → rail on the left + pencil button opens the command sheet; ≥1024 wide with height > 520 → desktop.
3. On iOS standalone: header sits below the status bar; focusing the command input does not zoom.
