### PR TITLE
fix(web): shell mobile isi viewport iOS penuh + kanvas HP tidak over-zoom

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "octopus-gather-room",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "Ruang Octopus — gather-room frontend for the AI IT-Manager (mock data, Phase 3 P0-P1)",
   "scripts": {

--- a/web/src/changelog.ts
+++ b/web/src/changelog.ts
@@ -12,6 +12,14 @@ export interface ReleaseNote {
 
 export const CHANGELOG: ReleaseNote[] = [
   {
+    version: "0.3.2",
+    date: "2026-08-29",
+    notes: [
+      "Perbaikan iPhone: tab bar kini menempel di dasar layar (tidak ada celah kosong di atas home indicator).",
+      "Kanvas ruangan di HP tidak lagi terlalu zoom; petunjuk yang menutupi kartu manajer disembunyikan.",
+    ],
+  },
+  {
     version: "0.3.1",
     date: "2026-08-29",
     notes: [

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -94,3 +94,10 @@ button {
     animation: none;
   }
 }
+
+/* iOS standalone: area di luar shell (bila ada) menyatu dgn bar bawah */
+@media (max-width: 1023px) {
+  body {
+    background: var(--surface);
+  }
+}

--- a/web/src/room/RoomCanvas.tsx
+++ b/web/src/room/RoomCanvas.tsx
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 import { useRoomEngine } from "./useRoomEngine";
 
-export function RoomCanvas(): JSX.Element {
+export function RoomCanvas({ hideHint }: { hideHint?: boolean } = {}): JSX.Element {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   useRoomEngine(canvasRef);
 
@@ -12,9 +12,11 @@ export function RoomCanvas(): JSX.Element {
         className="block h-full w-full touch-none"
         aria-label="Ruang Octopus — office virtual agen AI"
       />
+      {!hideHint && (
       <div className="pointer-events-none absolute bottom-3 left-3.5 rounded-md border border-line bg-[var(--c-namebg)] px-2.5 py-1.5 text-[11.5px] text-ink-faint backdrop-blur">
         Klik/ketuk avatar untuk detail · tugas berisiko butuh persetujuanmu
       </div>
+      )}
     </div>
   );
 }

--- a/web/src/room/engine/render.ts
+++ b/web/src/room/engine/render.ts
@@ -64,11 +64,11 @@ export function computeCamera(cssW: number, cssH: number): Camera {
   // → pakai mode cover: skala ke tinggi kontainer, lebar boleh meluap dan
   // di-pan horizontal (lihat useRoomEngine). Awal: pusat world di tengah layar.
   if (cssH > cssW * (WORLD_H / WORLD_W) * 1.35) {
-    const scale = (cssH - pad * 2) / WORLD_H;
+    const scale = Math.min((cssH - pad * 2) / WORLD_H, (cssW * 2.0) / WORLD_W);
     return {
       scale,
       offX: clampOffX((cssW - WORLD_W * scale) / 2, cssW, scale),
-      offY: pad,
+      offY: Math.max(pad, (cssH - WORLD_H * scale) / 2),
     };
   }
   const scale = Math.min(

--- a/web/src/ui/mobile/MobileShell.tsx
+++ b/web/src/ui/mobile/MobileShell.tsx
@@ -82,7 +82,7 @@ export function MobileShell(): JSX.Element {
   );
 
   return (
-    <div className="flex h-[100dvh] w-full flex-col overflow-hidden bg-bg">
+    <div className="fixed inset-0 flex flex-col overflow-hidden bg-bg" style={{ height: "100dvh", minHeight: "-webkit-fill-available" }}>
       <MobileHeader onCompose={short ? () => setComposeOpen(true) : undefined} />
 
       {short ? (

--- a/web/src/ui/mobile/RuanganTab.tsx
+++ b/web/src/ui/mobile/RuanganTab.tsx
@@ -12,9 +12,9 @@ export function RuanganTab(): JSX.Element {
 
   return (
     <div className="relative h-full w-full">
-      <RoomCanvas />
+      <RoomCanvas hideHint />
       {manager && (
-        <div className="pointer-events-none absolute inset-x-3 bottom-14 rounded-xl border border-line bg-[var(--c-namebg)] px-3 py-2.5 backdrop-blur">
+        <div className="pointer-events-none absolute inset-x-3 bottom-3 rounded-xl border border-line bg-[var(--c-namebg)] px-3 py-2.5 backdrop-blur">
           <div className="flex items-center gap-2.5">
             <span
               className="grid h-7 w-7 flex-none place-items-center rounded-full text-[14px]"

--- a/web/src/ui/mobile/TabBar.tsx
+++ b/web/src/ui/mobile/TabBar.tsx
@@ -75,7 +75,7 @@ export function TabBar({ active, onChange, approvalCount, vertical }: TabBarProp
       style={
         vertical
           ? { paddingLeft: "env(safe-area-inset-left)" }
-          : { paddingBottom: "env(safe-area-inset-bottom)" }
+          : { paddingBottom: "max(env(safe-area-inset-bottom), 8px)" }
       }
     >
       {TABS.map((t) => {


### PR DESCRIPTION
## What
Fixes reported on a real iPhone (screenshot from user): grey gap above the home indicator below the tab bar; room canvas over-zoomed; canvas hint overlapping the manager card.

## How
- `MobileShell`: `position: fixed; inset: 0` (+ `100dvh` / `-webkit-fill-available` fallbacks) so the shell fills the real standalone viewport
- `TabBar`: `padding-bottom: max(env(safe-area-inset-bottom), 8px)`; mobile `body` background = surface
- `render.ts::computeCamera`: portrait cover capped at 2× viewport width, vertically centered
- `RoomCanvas` `hideHint` prop (used on mobile), manager card moved to bottom
- web v0.3.2 + changelog

## How to test
`cd web && npm run build`; DevTools iPhone 11 (414×896) → tab bar flush at bottom; on device standalone → no grey gap.