### PR TITLE
feat(web): alur masuk di pengaturan (akun) — perbaiki missing bearer token

### DIFF
--- a/app/interfaces/auth.py
+++ b/app/interfaces/auth.py
@@ -184,6 +184,14 @@ def _login_page() -> str:
 
 # ── Routes ────────────────────────────────────────────────────────────────────
 
+@router.get("/config")
+async def auth_config() -> JSONResponse:
+    """Publik: kemampuan login yang tersedia — web memutuskan tombol mana yang ditampilkan."""
+    return JSONResponse(
+        {"google_oauth": bool(settings.google_client_id and settings.google_client_secret)}
+    )
+
+
 @router.get("/login", response_class=HTMLResponse)
 async def login_page() -> HTMLResponse:
     """Landing page — tampilkan tombol 'Login dengan Google' atau error jika tidak dikonfigurasi."""

--- a/tests/interfaces/test_auth_security.py
+++ b/tests/interfaces/test_auth_security.py
@@ -46,3 +46,18 @@ def test_email_allowlist_enforced_when_set(monkeypatch: pytest.MonkeyPatch) -> N
     assert auth._email_allowed("ali@hamasmart.com") is True
     assert auth._email_allowed("Ali@Hamasmart.com") is True  # case-insensitive
     assert auth._email_allowed("evil@example.com") is False
+
+
+def test_auth_config_reports_google_oauth_availability(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    app.include_router(auth.router)
+    client = TestClient(app)
+
+    monkeypatch.setattr(auth, "settings", _with(google_client_id="", google_client_secret=""))
+    assert client.get("/auth/config").json() == {"google_oauth": False}
+
+    monkeypatch.setattr(auth, "settings", _with(google_client_id="id", google_client_secret="sec"))
+    assert client.get("/auth/config").json() == {"google_oauth": True}

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "octopus-gather-room",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "Ruang Octopus — gather-room frontend for the AI IT-Manager (mock data, Phase 3 P0-P1)",
   "scripts": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -40,6 +40,11 @@ export default function App(): JSX.Element {
     // Token bisa berubah (login ulang) → selalu sinkron ke SW saat app dibuka
     // supaya tombol Setujui/Tolak di notifikasi pakai token yang valid.
     void syncTokenToSw();
+    // Belum ada token → fitur live (persetujuan, pasukan, stream) 401.
+    // Arahkan langsung ke Pengaturan → Akun supaya user tahu harus masuk.
+    void useStore.getState().refreshAuth().then(() => {
+      if (useStore.getState().auth.status === "anon") useStore.getState().openSettings();
+    });
     return () => stream.stop();
   }, []);
 

--- a/web/src/changelog.ts
+++ b/web/src/changelog.ts
@@ -12,6 +12,15 @@ export interface ReleaseNote {
 
 export const CHANGELOG: ReleaseNote[] = [
   {
+    version: "0.4.1",
+    date: "2026-08-29",
+    notes: [
+      "Pengaturan → Akun: masuk dengan token akses atau Google (bila server mengaktifkannya), lihat status sesi, keluar.",
+      "Bila belum masuk, Pengaturan terbuka otomatis dan ikon ⚙ berbadge kuning — memperbaiki error \"Missing Bearer token\" saat menyimpan pasukan.",
+      "Stream ruangan tersambung otomatis setelah masuk tanpa memuat ulang.",
+    ],
+  },
+  {
     version: "0.4.0",
     date: "2026-08-29",
     notes: [

--- a/web/src/net/api.ts
+++ b/web/src/net/api.ts
@@ -34,6 +34,88 @@ export function getToken(): string {
   }
 }
 
+export function setToken(t: string): void {
+  const store = ls();
+  if (!store) return;
+  if (t) store.setItem(TOKEN_KEY, t);
+  else store.removeItem(TOKEN_KEY);
+}
+export function clearToken(): void {
+  setToken("");
+}
+
+// ── Auth (sesi web) ──────────────────────────────────────────────────────────
+export interface AuthConfig {
+  google_oauth: boolean;
+}
+export async function fetchAuthConfig(): Promise<AuthConfig> {
+  try {
+    const resp = await fetch(`${API_BASE}/auth/config`);
+    if (!resp.ok) return { google_oauth: false };
+    return (await resp.json()) as AuthConfig;
+  } catch {
+    return { google_oauth: false };
+  }
+}
+
+export interface MeInfo {
+  user_id: string;
+  email: string;
+  display_name: string;
+}
+/** Identitas sesi saat ini. null = token kosong/tidak valid. Token admin
+ *  (ADMIN_TOKEN) bukan sesi user → /auth/me 401, kita kembalikan label admin. */
+export async function fetchMe(): Promise<MeInfo | "admin" | null> {
+  const t = getToken();
+  if (!t) return null;
+  try {
+    const resp = await fetch(`${API_BASE}/auth/me`, { headers: authHeaders() });
+    if (resp.ok) return (await resp.json()) as MeInfo;
+    // /auth/me hanya kenal sesi user; cek apakah token ini admin lewat endpoint ber-auth ringan.
+    const probe = await fetch(`${API_BASE}/room/state`, { headers: authHeaders() });
+    return probe.ok ? "admin" : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Mulai login Google (alur pairing yang sama dengan TUI): dapat kode, buka
+ *  halaman login, lalu poll sampai sesi terbentuk. */
+export async function startGoogleLogin(): Promise<{ code: string; loginUrl: string } | null> {
+  try {
+    const resp = await fetch(`${API_BASE}/auth/tui/start`, { method: "POST" });
+    if (!resp.ok) return null;
+    const body = (await resp.json()) as { code: string };
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    return { code: body.code, loginUrl: `${origin}/auth/tui-login?code=${encodeURIComponent(body.code)}` };
+  } catch {
+    return null;
+  }
+}
+export async function pollGoogleLogin(code: string): Promise<"pending" | "expired" | { token: string }> {
+  try {
+    const resp = await fetch(`${API_BASE}/auth/tui/poll`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    if (resp.status === 202) return "pending";
+    if (!resp.ok) return "expired";
+    const body = (await resp.json()) as { session_token?: string };
+    return body.session_token ? { token: body.session_token } : "pending";
+  } catch {
+    return "pending";
+  }
+}
+export async function logoutSession(): Promise<void> {
+  try {
+    await fetch(`${API_BASE}/auth/tui/logout`, { method: "POST", headers: authHeaders() });
+  } catch {
+    /* best-effort */
+  }
+  clearToken();
+}
+
 // ── Provider (otak) + API key BYOK ────────────────────────────────────────────
 export function getProvider(): string {
   return ls()?.getItem(PROVIDER_KEY) ?? "mock";

--- a/web/src/net/roomStream.ts
+++ b/web/src/net/roomStream.ts
@@ -21,12 +21,17 @@ export function startRoomStream(): RoomStream {
 }
 
 async function connectLive(signal: AbortSignal): Promise<void> {
-  const token = getToken();
-  const headers: Record<string, string> = token
-    ? { Authorization: `Bearer ${token}` }
-    : {};
-
   while (!signal.aborted) {
+    // Token dibaca ulang tiap percobaan: setelah user login lewat Pengaturan
+    // → Akun, stream langsung tersambung tanpa reload halaman.
+    const token = getToken();
+    const headers: Record<string, string> = token
+      ? { Authorization: `Bearer ${token}` }
+      : {};
+    if (!token) {
+      await new Promise((r) => setTimeout(r, 2000));
+      continue;
+    }
     try {
       const resp = await fetch("/room/stream", { headers, signal });
       if (!resp.ok || !resp.body) throw new Error(`room/stream HTTP ${resp.status}`);

--- a/web/src/state/store.ts
+++ b/web/src/state/store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { approvePlan, rejectPlan, runTask } from "../net/api";
+import { approvePlan, fetchMe, getToken, rejectPlan, runTask } from "../net/api";
 import { CURRENT_VERSION, fetchLatestVersion, type VersionInfo } from "../net/version";
 import type {
   Agent,
@@ -264,8 +264,15 @@ interface RoomState {
   /** true begitu backend nyata mengendalikan ruangan → matikan spawner mock */
   live: boolean;
   update: UpdateState;
+  /** Status sesi: unknown (belum dicek) · anon (tak ada/invalid token) · admin · user. */
+  auth: { status: "unknown" | "anon" | "admin" | "user"; email: string | null };
+  settingsOpen: boolean;
 
   // actions
+  /** Cek token di localStorage ke backend; dipanggil saat mount & setelah login/logout. */
+  refreshAuth: () => Promise<void>;
+  openSettings: () => void;
+  closeSettings: () => void;
   select: (id: string | null) => void;
   submitCommand: (text: string) => void;
   applyServerEvent: (ev: Record<string, unknown>) => void;
@@ -431,6 +438,21 @@ export const useStore = create<RoomState>((set, get) => {
     workers: 0,
     live: false,
     update: { available: false, latest: null, checking: false },
+    auth: { status: "unknown", email: null },
+    settingsOpen: false,
+
+    refreshAuth: async () => {
+      if (!getToken()) {
+        set({ auth: { status: "anon", email: null } });
+        return;
+      }
+      const me = await fetchMe();
+      if (me === null) set({ auth: { status: "anon", email: null } });
+      else if (me === "admin") set({ auth: { status: "admin", email: null } });
+      else set({ auth: { status: "user", email: me.email } });
+    },
+    openSettings: () => set({ settingsOpen: true }),
+    closeSettings: () => set({ settingsOpen: false }),
 
     select: (id) => set({ selectedId: id }),
 

--- a/web/src/ui/settings/SettingsButton.tsx
+++ b/web/src/ui/settings/SettingsButton.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useStore } from "../../state/store";
 import { SettingsDialog } from "./SettingsDialog";
 
@@ -12,14 +11,17 @@ export interface SettingsButtonProps {
  *  pembaruan menunggu. Menggantikan ProviderButton/NotifyButton/UpdateButton
  *  (TopBar) dan menu "⋯ Lainnya" (mobile). */
 export function SettingsButton({ onNavigateToPasukan }: SettingsButtonProps): JSX.Element {
-  const [open, setOpen] = useState(false);
+  const open = useStore((s) => s.settingsOpen);
+  const openSettings = useStore((s) => s.openSettings);
+  const closeSettings = useStore((s) => s.closeSettings);
   const updateAvailable = useStore((s) => s.update.available);
+  const anon = useStore((s) => s.auth.status === "anon");
 
   return (
     <>
       <button
         type="button"
-        onClick={() => setOpen(true)}
+        onClick={openSettings}
         title="Pengaturan"
         aria-label="Pengaturan"
         className="relative grid h-10 w-10 flex-none place-items-center rounded-lg border border-line text-ink-soft transition hover:border-accent hover:text-ink"
@@ -28,14 +30,18 @@ export function SettingsButton({ onNavigateToPasukan }: SettingsButtonProps): JS
           <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
           <circle cx="12" cy="12" r="3" />
         </svg>
-        {updateAvailable && (
-          <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-accent shadow-[0_0_6px_var(--accent)]" />
+        {(updateAvailable || anon) && (
+          <span
+            className={`absolute right-1 top-1 h-2 w-2 rounded-full ${
+              anon ? "bg-st-approval shadow-[0_0_6px_var(--st-approval)]" : "bg-accent shadow-[0_0_6px_var(--accent)]"
+            }`}
+          />
         )}
       </button>
 
       {open && (
         <SettingsDialog
-          onClose={() => setOpen(false)}
+          onClose={closeSettings}
           onNavigateToPasukan={onNavigateToPasukan}
         />
       )}

--- a/web/src/ui/settings/SettingsPanel.tsx
+++ b/web/src/ui/settings/SettingsPanel.tsx
@@ -1,7 +1,15 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { usePushToggle } from "../../hooks/usePushToggle";
 import { useIsMobile } from "../../hooks/useIsMobile";
-import { sendTestPush } from "../../net/api";
+import {
+  fetchAuthConfig,
+  logoutSession,
+  pollGoogleLogin,
+  sendTestPush,
+  setToken,
+  startGoogleLogin,
+} from "../../net/api";
+import { syncTokenToSw } from "../../net/push";
 import { CURRENT_VERSION } from "../../net/version";
 import { CHANGELOG } from "../../changelog";
 import { useStore } from "../../state/store";
@@ -124,6 +132,63 @@ export function SettingsPanel({ onClose, onNavigateToPasukan }: SettingsPanelPro
   const checkForUpdate = useStore((s) => s.checkForUpdate);
   const applyUpdate = useStore((s) => s.applyUpdate);
 
+  const auth = useStore((s) => s.auth);
+  const refreshAuth = useStore((s) => s.refreshAuth);
+  const [googleAvail, setGoogleAvail] = useState(false);
+  const [tokenOpen, setTokenOpen] = useState(false);
+  const [tokenInput, setTokenInput] = useState("");
+  const [loginMsg, setLoginMsg] = useState<string | null>(null);
+  const [loginBusy, setLoginBusy] = useState(false);
+  const pollTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    void fetchAuthConfig().then((c) => setGoogleAvail(c.google_oauth));
+    return () => {
+      if (pollTimer.current) window.clearInterval(pollTimer.current);
+    };
+  }, []);
+
+  const finishLogin = async (token: string): Promise<void> => {
+    setToken(token.trim());
+    await syncTokenToSw();
+    await refreshAuth();
+    const st = useStore.getState().auth.status;
+    setLoginMsg(st === "anon" ? "Token tidak valid" : "Berhasil masuk");
+    if (st !== "anon") {
+      setTokenOpen(false);
+      setTokenInput("");
+    }
+  };
+
+  const loginGoogle = async (): Promise<void> => {
+    setLoginBusy(true);
+    setLoginMsg("Membuka halaman login Google…");
+    const start = await startGoogleLogin();
+    if (!start) {
+      setLoginBusy(false);
+      setLoginMsg("Login Google belum tersedia di server ini");
+      return;
+    }
+    window.open(start.loginUrl, "_blank", "noopener");
+    setLoginMsg("Selesaikan login di tab yang terbuka — menunggu…");
+    pollTimer.current = window.setInterval(() => {
+      void pollGoogleLogin(start.code).then((r) => {
+        if (r === "pending") return;
+        if (pollTimer.current) window.clearInterval(pollTimer.current);
+        pollTimer.current = null;
+        setLoginBusy(false);
+        if (r === "expired") setLoginMsg("Kode login kedaluwarsa, coba lagi");
+        else void finishLogin(r.token);
+      });
+    }, 2000);
+  };
+
+  const logout = async (): Promise<void> => {
+    await logoutSession();
+    await refreshAuth();
+    setLoginMsg(null);
+  };
+
   const [providerOpen, setProviderOpen] = useState(false);
   const [agentEditorOpen, setAgentEditorOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -161,6 +226,82 @@ export function SettingsPanel({ onClose, onNavigateToPasukan }: SettingsPanelPro
 
   return (
     <div className="flex flex-col">
+      <SectionTitle>Akun</SectionTitle>
+      <Group>
+        <Row
+          label={
+            auth.status === "user"
+              ? `Masuk sebagai ${auth.email ?? "pengguna"}`
+              : auth.status === "admin"
+                ? "Masuk dengan token admin"
+                : auth.status === "unknown"
+                  ? "Memeriksa sesi…"
+                  : "Belum masuk"
+          }
+          hint={
+            auth.status === "anon"
+              ? "Persetujuan, pasukan, dan stream ruangan butuh sesi masuk"
+              : loginMsg ?? undefined
+          }
+          trailing={
+            auth.status === "anon" ? (
+              <span className="h-2.5 w-2.5 flex-none rounded-full bg-st-approval" />
+            ) : auth.status === "unknown" ? undefined : (
+              <span className="h-2.5 w-2.5 flex-none rounded-full bg-st-done" />
+            )
+          }
+        />
+        {auth.status === "anon" && googleAvail && (
+          <Row
+            label={loginBusy ? "Menunggu login Google…" : "Masuk dengan Google"}
+            hint={loginMsg ?? undefined}
+            onClick={loginBusy ? undefined : () => void loginGoogle()}
+            trailing={<Chevron />}
+          />
+        )}
+        {auth.status === "anon" && (
+          <>
+            <Row
+              label="Masuk dengan token akses"
+              hint={tokenOpen ? undefined : "Tempel ADMIN_TOKEN / token sesi dari TUI (/login)"}
+              onClick={() => setTokenOpen((v) => !v)}
+              trailing={<Chevron />}
+            />
+            {tokenOpen && (
+              <form
+                className="flex items-center gap-2 px-3 py-2.5"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  if (tokenInput.trim()) void finishLogin(tokenInput);
+                }}
+              >
+                <input
+                  type="password"
+                  value={tokenInput}
+                  onChange={(e) => setTokenInput(e.target.value)}
+                  placeholder="Token akses"
+                  autoComplete="off"
+                  aria-label="Token akses"
+                  className="h-11 min-w-0 flex-1 rounded-lg border border-line bg-surface px-3 text-[16px] text-ink outline-none focus-visible:border-accent"
+                />
+                <button
+                  type="submit"
+                  className="h-11 flex-none rounded-lg bg-accent px-4 text-[13.5px] font-semibold text-accent-ink"
+                >
+                  Masuk
+                </button>
+              </form>
+            )}
+            {loginMsg && !googleAvail && (
+              <div className="px-3 pb-2 text-[11.5px] text-ink-faint">{loginMsg}</div>
+            )}
+          </>
+        )}
+        {(auth.status === "user" || auth.status === "admin") && (
+          <Row label="Keluar" onClick={() => void logout()} trailing={<Chevron />} />
+        )}
+      </Group>
+
       <SectionTitle>Notifikasi</SectionTitle>
       <Group>
         <Row


### PR DESCRIPTION
## What
Login flow for the web PWA, surfaced in **Pengaturan → Akun**. Fixes the user-reported `Missing Bearer token` error when saving an agent.

## Why
The web had no way to obtain a session: the token only arrived via `?token=` in the URL. Regular users therefore hit 401 on every authenticated call — the room stream failed silently and roster CRUD showed the error.

## How
- **Backend**: public `GET /auth/config` → `{google_oauth: bool}` (+ test) so the web knows whether to offer Google login.
- **Web**:
  - `net/api.ts`: `setToken/clearToken`, `fetchMe` (session or admin token), `startGoogleLogin/pollGoogleLogin` (reuses the TUI pairing flow: `/auth/tui/start`, `/auth/tui-login?code=`, `/auth/tui/poll`), `logoutSession`
  - store: `auth` slice + `refreshAuth`, `settingsOpen/openSettings/closeSettings`
  - `SettingsPanel`: new **Akun** section (status, Google login when available, paste access token, logout)
  - `App.tsx`: on mount, if no valid token → open Settings; `SettingsButton` shows an amber dot while signed out
  - `roomStream.ts`: re-reads the token each attempt → connects right after login
- web v0.4.1 + changelog

## How to test
1. Clear `localStorage.octopus_token`, reload → Settings opens on **Akun: Belum masuk**.
2. Paste the `ADMIN_TOKEN` → "Masuk dengan token admin", stream connects, Pasukan → edit → Simpan works.
3. With `GOOGLE_CLIENT_ID/SECRET` + `APP_URL` set on the server, "Masuk dengan Google" opens the login tab and the app picks up the session after consent.
4. `make check` green; `cd web && npm run build` green.