### PR TITLE
feat(web): tata letak ruangan khusus portrait (hp) sesuai desain

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "octopus-gather-room",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "description": "Ruang Octopus — gather-room frontend for the AI IT-Manager (mock data, Phase 3 P0-P1)",
   "scripts": {

--- a/web/src/changelog.ts
+++ b/web/src/changelog.ts
@@ -12,6 +12,13 @@ export interface ReleaseNote {
 
 export const CHANGELOG: ReleaseNote[] = [
   {
+    version: "0.4.2",
+    date: "2026-08-29",
+    notes: [
+      "Tampilan Ruangan di HP dirancang ulang mengikuti mockup: 5 zona dalam grid portrait (Meja Manajer, Ruang Review, Area Kerja, Server, Meeting), avatar kotak dengan ikon peran & cincin status, tanpa zoom/pan berlebihan.",
+    ],
+  },
+  {
     version: "0.4.1",
     date: "2026-08-29",
     notes: [

--- a/web/src/room/engine/agents.ts
+++ b/web/src/room/engine/agents.ts
@@ -1,4 +1,4 @@
-import { AGENT_SPEED, center, ROLE, STATUS, zoneBy } from "./scene";
+import { AGENT_SPEED, getLayout, ROLE, STATUS } from "./scene";
 import type { Agent } from "../../state/types";
 import { mix, rrect, type Palette } from "./render";
 
@@ -31,7 +31,23 @@ export function initRender(agents: Agent[]): Map<string, RenderAgent> {
   return m;
 }
 
-const MGR_HOME = center(zoneBy("Kantor Manajer"));
+/** Snap render positions to the store's logical positions — called by
+ *  useRoomEngine right after a layout switch so agents don't visibly glide
+ *  across the (now differently-sized) world. */
+export function resetRenderPositions(
+  render: Map<string, RenderAgent>,
+  agents: Agent[],
+): void {
+  for (const a of agents) {
+    const r = render.get(a.id);
+    if (!r) continue;
+    r.rx = a.posX;
+    r.ry = a.posY;
+    r.wtx = a.homeX;
+    r.wty = a.homeY;
+    r.wanderT = rand(1, 3);
+  }
+}
 
 export function stepAgents(
   render: Map<string, RenderAgent>,
@@ -60,8 +76,10 @@ export function stepAgents(
       r.wanderT -= dt;
       if (r.wanderT <= 0) {
         r.wanderT = rand(3, 6);
-        r.wtx = MGR_HOME.x + rand(-70, 70);
-        r.wty = MGR_HOME.y + rand(-30, 40);
+        // Portrait: zona kecil (tile 40px + pill) → jelajah manajer dipersempit.
+        const k = getLayout().kind === "portrait" ? 0.3 : 1;
+        r.wtx = a.homeX + rand(-70, 70) * k;
+        r.wty = a.homeY + rand(-30, 40) * k;
       }
       tx = r.wtx;
       ty = r.wty;
@@ -70,8 +88,9 @@ export function stepAgents(
       if (r.wanderT <= 0) {
         r.wanderT = rand(2.5, 6);
         if (Math.random() < 0.6) {
-          r.wtx = a.homeX + rand(-46, 46);
-          r.wty = a.homeY + rand(-38, 38);
+          const k = getLayout().kind === "portrait" ? 0.25 : 1;
+          r.wtx = a.homeX + rand(-46, 46) * k;
+          r.wty = a.homeY + rand(-38, 38) * k;
         }
       }
       tx = r.wtx;
@@ -95,6 +114,85 @@ export function stepAgents(
 }
 
 export function drawAgent(
+  ctx: CanvasRenderingContext2D,
+  pal: Palette,
+  a: Agent,
+  r: RenderAgent,
+  selectedId: string | null,
+  timeMs: number,
+  reduceMotion: boolean,
+): void {
+  if (getLayout().kind === "portrait") {
+    drawAgentTile(ctx, pal, a, r, selectedId);
+    return;
+  }
+  drawAgentCircle(ctx, pal, a, r, selectedId, timeMs, reduceMotion);
+}
+
+/** Portrait "Ruangan" tab avatar — a 40×40 rounded-square tile filled with
+ *  the role color, a status-colored ring, the role's emoji icon, and a name
+ *  pill underneath (matches the approved mockup). */
+function drawAgentTile(
+  ctx: CanvasRenderingContext2D,
+  pal: Palette,
+  a: Agent,
+  r: RenderAgent,
+  selectedId: string | null,
+): void {
+  const size = 40;
+  const half = size / 2;
+  const x = r.rx;
+  const y = r.ry;
+  const st = STATUS[a.state] ?? STATUS.idle;
+  const ringColor = pal[st.c];
+
+  // selection highlight (drawn first, sits outside everything else)
+  if (a.id === selectedId) {
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = pal.ping;
+    rrect(ctx, x - half - 5, y - half - 5, size + 10, size + 10, 15);
+    ctx.stroke();
+  }
+
+  // tile body + drop shadow
+  ctx.save();
+  ctx.shadowColor = "rgba(0,0,0,.38)";
+  ctx.shadowBlur = 14;
+  ctx.shadowOffsetY = 4;
+  ctx.fillStyle = ROLE[a.role].color;
+  rrect(ctx, x - half, y - half, size, size, 12);
+  ctx.fill();
+  ctx.restore();
+
+  // status ring — sits just outside the tile edge (mirrors the mockup's
+  // outward box-shadow ring) instead of overlapping the icon.
+  const ringPad = 1.5;
+  ctx.lineWidth = 3;
+  ctx.strokeStyle = ringColor;
+  rrect(ctx, x - half - ringPad, y - half - ringPad, size + ringPad * 2, size + ringPad * 2, 12 + ringPad);
+  ctx.stroke();
+
+  // role icon
+  ctx.font = '18px "Apple Color Emoji","Segoe UI Emoji","Noto Color Emoji",sans-serif';
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(ROLE[a.role].icon, x, y + 1);
+
+  // name pill
+  ctx.font = "500 10.5px 'IBM Plex Sans', sans-serif";
+  const pw = ctx.measureText(a.name).width + 14;
+  const py = y + half + 6;
+  ctx.fillStyle = pal.nameBg;
+  rrect(ctx, x - pw / 2, py, pw, 17, 99);
+  ctx.fill();
+  ctx.fillStyle = pal.name;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(a.name, x, py + 8.5);
+}
+
+/** Landscape (desktop) avatar — unchanged circle+eyes body. */
+function drawAgentCircle(
   ctx: CanvasRenderingContext2D,
   pal: Palette,
   a: Agent,

--- a/web/src/room/engine/render.ts
+++ b/web/src/room/engine/render.ts
@@ -1,4 +1,4 @@
-import { WORLD_H, WORLD_W, ZONES, type Zone } from "./scene";
+import { getLayout, isRackZone, type Zone } from "./scene";
 import type { BoardCard } from "../../state/types";
 import { drawBoard } from "./board";
 
@@ -59,36 +59,45 @@ export function readPalette(): Palette {
 }
 
 export function computeCamera(cssW: number, cssH: number): Camera {
-  const pad = 24;
-  // Portrait (HP): world 1280×800 di-"contain" akan jadi strip kecil di tengah
-  // → pakai mode cover: skala ke tinggi kontainer, lebar boleh meluap dan
-  // di-pan horizontal (lihat useRoomEngine). Awal: pusat world di tengah layar.
-  if (cssH > cssW * (WORLD_H / WORLD_W) * 1.35) {
-    const scale = Math.min((cssH - pad * 2) / WORLD_H, (cssW * 2.0) / WORLD_W);
-    return {
-      scale,
-      offX: clampOffX((cssW - WORLD_W * scale) / 2, cssW, scale),
-      offY: Math.max(pad, (cssH - WORLD_H * scale) / 2),
-    };
+  const layout = getLayout();
+  if (layout.kind === "portrait") {
+    // Fit width exactly (the mockup room is a fixed 390-wide grid); if the
+    // world is taller than the container, allow vertical drag-pan instead
+    // of shrinking to fit (see clampOffY + useRoomEngine's pointer drag).
+    const scale = cssW / layout.worldW;
+    return { scale, offX: 0, offY: 0 };
   }
+  const pad = 24;
   const scale = Math.min(
-    (cssW - pad * 2) / WORLD_W,
-    (cssH - pad * 2) / WORLD_H,
+    (cssW - pad * 2) / layout.worldW,
+    (cssH - pad * 2) / layout.worldH,
   );
   return {
     scale,
-    offX: (cssW - WORLD_W * scale) / 2,
-    offY: (cssH - WORLD_H * scale) / 2,
+    offX: (cssW - layout.worldW * scale) / 2,
+    offY: (cssH - layout.worldH * scale) / 2,
   };
 }
 
-/** Batasi pan horizontal supaya tepi world tak lepas dari layar (mode cover). */
+/** Batasi pan horizontal (landscape) supaya tepi world tak lepas dari layar. */
 export function clampOffX(offX: number, cssW: number, scale: number): number {
   const pad = 24;
-  const minX = cssW - WORLD_W * scale - pad;
+  const worldW = getLayout().worldW;
+  const minX = cssW - worldW * scale - pad;
   const maxX = pad;
-  if (minX > maxX) return (cssW - WORLD_W * scale) / 2; // world lebih sempit: tengah
+  if (minX > maxX) return (cssW - worldW * scale) / 2; // world lebih sempit: tengah
   return Math.min(maxX, Math.max(minX, offX));
+}
+
+/** Batasi pan vertikal (portrait) — 0 kalau world muat, else clamp supaya
+ *  tepi atas/bawah tak lepas dari layar. */
+export function clampOffY(offY: number, cssH: number, scale: number): number {
+  const worldH = getLayout().worldH;
+  const worldHpx = worldH * scale;
+  if (worldHpx <= cssH) return 0;
+  const minY = cssH - worldHpx;
+  const maxY = 0;
+  return Math.min(maxY, Math.max(minY, offY));
 }
 
 export function rrect(
@@ -99,6 +108,9 @@ export function rrect(
   h: number,
   r: number,
 ): void {
+  // arcTo dengan r > setengah sisi menghasilkan busur raksasa (bukan di-clamp
+  // seperti CSS border-radius) → fill/stroke "menyebar" ke luar bentuk.
+  r = Math.max(0, Math.min(r, w / 2, h / 2));
   ctx.beginPath();
   ctx.moveTo(x + r, y);
   ctx.arcTo(x + w, y, x + w, y + h, r);
@@ -151,37 +163,52 @@ export function drawWorld(
   board: BoardCard[],
   timeMs: number,
 ): void {
-  // floor + wall
-  ctx.fillStyle = pal.wall;
-  rrect(ctx, -16, -16, WORLD_W + 32, WORLD_H + 32, 26);
-  ctx.fill();
+  const layout = getLayout();
+  const portrait = layout.kind === "portrait";
+  const gridStep = portrait ? 32 : 40;
+
+  // floor (+ wall border band, landscape only — mockup has no such band)
+  if (!portrait) {
+    ctx.fillStyle = pal.wall;
+    rrect(ctx, -16, -16, layout.worldW + 32, layout.worldH + 32, 26);
+    ctx.fill();
+  }
   ctx.fillStyle = pal.floor;
-  rrect(ctx, 0, 0, WORLD_W, WORLD_H, 18);
-  ctx.fill();
+  if (portrait) {
+    ctx.fillRect(0, 0, layout.worldW, layout.worldH);
+  } else {
+    rrect(ctx, 0, 0, layout.worldW, layout.worldH, 18);
+    ctx.fill();
+  }
 
   // floor grid (clipped)
   ctx.strokeStyle = pal.floorLine;
   ctx.lineWidth = 1;
   ctx.save();
-  rrect(ctx, 0, 0, WORLD_W, WORLD_H, 18);
+  if (portrait) {
+    ctx.beginPath();
+    ctx.rect(0, 0, layout.worldW, layout.worldH);
+  } else {
+    rrect(ctx, 0, 0, layout.worldW, layout.worldH, 18);
+  }
   ctx.clip();
-  for (let x = 40; x < WORLD_W; x += 40) {
+  for (let x = gridStep; x < layout.worldW; x += gridStep) {
     ctx.beginPath();
     ctx.moveTo(x, 0);
-    ctx.lineTo(x, WORLD_H);
+    ctx.lineTo(x, layout.worldH);
     ctx.stroke();
   }
-  for (let y = 40; y < WORLD_H; y += 40) {
+  for (let y = gridStep; y < layout.worldH; y += gridStep) {
     ctx.beginPath();
     ctx.moveTo(0, y);
-    ctx.lineTo(WORLD_W, y);
+    ctx.lineTo(layout.worldW, y);
     ctx.stroke();
   }
   ctx.restore();
 
   // zones
-  for (const z of ZONES) {
-    const isServer = z.name === "Server Room";
+  for (const z of layout.zones) {
+    const isServer = isRackZone(z);
     ctx.fillStyle = isServer ? pal.server : pal.zone;
     ctx.strokeStyle = pal.zoneLine;
     ctx.lineWidth = 1.5;
@@ -190,13 +217,22 @@ export function drawWorld(
     ctx.stroke();
     if (isServer) drawServer(ctx, pal, z, timeMs);
     ctx.fillStyle = pal.zoneLabel;
-    ctx.font = "600 13px 'Chakra Petch', sans-serif";
-    ctx.textAlign = "left";
-    ctx.textBaseline = "top";
-    ctx.fillText(z.name.toUpperCase(), z.x + 12, z.y + 11);
+    if (portrait) {
+      ctx.font = "500 10px 'IBM Plex Mono', monospace";
+      ctx.textAlign = "left";
+      ctx.textBaseline = "top";
+      ctx.fillText(z.name.toUpperCase(), z.x + 10, z.y + 8);
+    } else {
+      ctx.font = "600 13px 'Chakra Petch', sans-serif";
+      ctx.textAlign = "left";
+      ctx.textBaseline = "top";
+      ctx.fillText(z.name.toUpperCase(), z.x + 12, z.y + 11);
+    }
   }
 
-  drawBoard(ctx, pal, board);
+  // kanban board: drawn inside a landscape zone — no room for it in the
+  // compact portrait grid (mockup has no board either).
+  if (!portrait) drawBoard(ctx, pal, board);
 }
 
 export function drawPings(

--- a/web/src/room/engine/scene.ts
+++ b/web/src/room/engine/scene.ts
@@ -1,8 +1,5 @@
 import type { AgentState, BoardCol, Role } from "../../state/types";
 
-export const WORLD_W = 1280;
-export const WORLD_H = 800;
-
 /** constant walking speed shared by the mock scheduler and the renderer,
  *  so logical arrival (store) and visual arrival (canvas) stay in sync */
 export const AGENT_SPEED = 150;
@@ -15,7 +12,23 @@ export interface Zone {
   h: number;
 }
 
-export const ZONES: Zone[] = [
+export type LayoutKind = "landscape" | "portrait";
+
+interface SceneLayout {
+  kind: LayoutKind;
+  worldW: number;
+  worldH: number;
+  zones: Zone[];
+  /** role -> home zone name, for this layout */
+  roleZone: Record<Role, string>;
+  meetZone: string;
+  reviewZone: string;
+  serverZone: string;
+}
+
+// ── landscape (desktop) world — unchanged from the original single-layout
+// scene, kept byte-for-byte so desktop visuals never move. ──
+const LANDSCAPE_ZONES: Zone[] = [
   { name: "Kantor Manajer", x: 500, y: 34, w: 280, h: 150 },
   { name: "Riset", x: 34, y: 34, w: 210, h: 150 },
   { name: "Dev Bay", x: 34, y: 214, w: 300, h: 250 },
@@ -26,8 +39,66 @@ export const ZONES: Zone[] = [
   { name: "Server Room", x: 1010, y: 464, w: 236, h: 302 },
 ];
 
+const LANDSCAPE: SceneLayout = {
+  kind: "landscape",
+  worldW: 1280,
+  worldH: 800,
+  zones: LANDSCAPE_ZONES,
+  roleZone: {
+    manager: "Kantor Manajer",
+    coder: "Dev Bay",
+    tester: "QA Corner",
+    reviewer: "Ruang Review",
+    deployer: "Deploy Station",
+    researcher: "Riset",
+  },
+  meetZone: "Meja Rapat",
+  reviewZone: "Ruang Review",
+  serverZone: "Server Room",
+};
+
+// ── portrait (mobile "Ruangan" tab) world — 390×560 CSS-px room, matching
+// the approved mockup grid (2 columns, 16px margins, ~18px gutters). ──
+const PORTRAIT_ZONES: Zone[] = [
+  { name: "Meja Manajer", x: 16, y: 18, w: 170, h: 150 },
+  { name: "Ruang Review", x: 204, y: 18, w: 170, h: 150 },
+  { name: "Area Kerja", x: 16, y: 190, w: 358, h: 190 },
+  { name: "Server", x: 16, y: 402, w: 170, h: 130 },
+  { name: "Meeting", x: 204, y: 402, w: 170, h: 130 },
+];
+
+const PORTRAIT: SceneLayout = {
+  kind: "portrait",
+  worldW: 390,
+  worldH: 560,
+  zones: PORTRAIT_ZONES,
+  roleZone: {
+    manager: "Meja Manajer",
+    coder: "Area Kerja",
+    tester: "Area Kerja",
+    reviewer: "Ruang Review",
+    deployer: "Server",
+    researcher: "Area Kerja",
+  },
+  meetZone: "Meeting",
+  reviewZone: "Ruang Review",
+  serverZone: "Server",
+};
+
+let active: SceneLayout = LANDSCAPE;
+
+/** Switch the scene the engine/store operate on. No-op safe to call every
+ *  render — callers should still guard redundant calls themselves. */
+export function setSceneLayout(kind: LayoutKind): void {
+  active = kind === "portrait" ? PORTRAIT : LANDSCAPE;
+}
+
+export function getLayout(): { kind: LayoutKind; worldW: number; worldH: number; zones: Zone[] } {
+  return active;
+}
+
 export const zoneBy = (name: string): Zone => {
-  const z = ZONES.find((zo) => zo.name === name);
+  const z = active.zones.find((zo) => zo.name === name);
   if (!z) throw new Error(`unknown zone: ${name}`);
   return z;
 };
@@ -37,9 +108,17 @@ export const center = (z: Zone): { x: number; y: number } => ({
   y: z.y + z.h / 2,
 });
 
-export const MEET = center(zoneBy("Meja Rapat"));
-export const SERVER = center(zoneBy("Server Room"));
-export const REVIEW = center(zoneBy("Ruang Review"));
+/** Home zone for a role in the *active* layout. */
+export const homeZoneFor = (role: Role): Zone => zoneBy(active.roleZone[role]);
+
+export const meetPoint = (): { x: number; y: number } => center(zoneBy(active.meetZone));
+export const reviewPoint = (): { x: number; y: number } => center(zoneBy(active.reviewZone));
+export const serverPoint = (): { x: number; y: number } => center(zoneBy(active.serverZone));
+
+/** true for the one zone that gets the animated server-rack drawing —
+ *  landscape only; the portrait "Server" card stays a plain zone (mockup). */
+export const isRackZone = (z: Zone): boolean =>
+  active.kind === "landscape" && z.name === active.serverZone;
 
 export interface RoleDef {
   label: string;

--- a/web/src/room/useRoomEngine.ts
+++ b/web/src/room/useRoomEngine.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import type { RefObject } from "react";
 import { useStore } from "../state/store";
 import {
-  clampOffX, computeCamera,
+  clampOffX, clampOffY, computeCamera,
   drawPings,
   drawWorld,
   readPalette,
@@ -13,10 +13,12 @@ import {
 import {
   drawAgent,
   initRender,
+  resetRenderPositions,
   stepAgents,
   type RenderAgent,
 } from "./engine/agents";
 import { pickAgent, screenToWorld } from "./engine/input";
+import { getLayout, type LayoutKind } from "./engine/scene";
 import type { Theme } from "../state/types";
 
 export function useRoomEngine(canvasRef: RefObject<HTMLCanvasElement>): void {
@@ -41,6 +43,7 @@ export function useRoomEngine(canvasRef: RefObject<HTMLCanvasElement>): void {
     let pal: Palette = readPalette();
     let lastTheme: Theme = useStore.getState().theme;
     let lastEventCount = useStore.getState().events.length;
+    let lastLayoutKind: LayoutKind = getLayout().kind;
     let raf = 0;
     let last = performance.now();
 
@@ -60,14 +63,36 @@ export function useRoomEngine(canvasRef: RefObject<HTMLCanvasElement>): void {
     if (canvas.parentElement) ro.observe(canvas.parentElement);
     resize();
 
-    // Tap = pilih agen; drag horizontal = pan kamera (mode cover di HP).
-    let drag: { id: number; startX: number; startOffX: number; moved: boolean } | null = null;
+    // Tap = pilih agen; drag = pan kamera (horizontal di landscape, vertikal
+    // di portrait — arah pan mengikuti sumbu yang bisa meluap di tiap layout).
+    let drag: {
+      id: number;
+      startX: number;
+      startY: number;
+      startOffX: number;
+      startOffY: number;
+      moved: boolean;
+    } | null = null;
     const onPointerDown = (e: PointerEvent): void => {
-      drag = { id: e.pointerId, startX: e.clientX, startOffX: cam.offX, moved: false };
+      drag = {
+        id: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        startOffX: cam.offX,
+        startOffY: cam.offY,
+        moved: false,
+      };
       canvas.setPointerCapture(e.pointerId);
     };
     const onPointerMove = (e: PointerEvent): void => {
       if (!drag || drag.id !== e.pointerId) return;
+      if (getLayout().kind === "portrait") {
+        const dy = e.clientY - drag.startY;
+        if (!drag.moved && Math.abs(dy) < 6) return;
+        drag.moved = true;
+        cam = { ...cam, offY: clampOffY(drag.startOffY + dy, cssH, cam.scale) };
+        return;
+      }
       const dx = e.clientX - drag.startX;
       if (!drag.moved && Math.abs(dx) < 6) return;
       drag.moved = true;
@@ -100,6 +125,15 @@ export function useRoomEngine(canvasRef: RefObject<HTMLCanvasElement>): void {
       if (snap.theme !== lastTheme) {
         lastTheme = snap.theme;
         pal = readPalette();
+      }
+
+      // layout switched (mobile "Ruangan" tab entering/leaving portrait) —
+      // re-fit the camera and snap avatars to their new logical spot instead
+      // of animating a glide across the (now differently-sized) world.
+      if (getLayout().kind !== lastLayoutKind) {
+        lastLayoutKind = getLayout().kind;
+        cam = computeCamera(cssW, cssH);
+        resetRenderPositions(render, snap.agents);
       }
 
       // emit a coordination ping at the manager whenever activity fires

--- a/web/src/state/store.ts
+++ b/web/src/state/store.ts
@@ -16,13 +16,14 @@ import type {
 import {
   AGENT_SPEED,
   center,
-  MEET,
-  REVIEW,
+  getLayout,
+  homeZoneFor,
+  meetPoint,
+  reviewPoint,
   ROLE,
-  SERVER,
-  WORLD_H,
-  WORLD_W,
-  zoneBy,
+  serverPoint,
+  setSceneLayout,
+  type LayoutKind,
 } from "../room/engine/scene";
 
 /** Roster entry hasil CRUD backend (/room/roster, event roster.updated /
@@ -94,22 +95,15 @@ function mk(
   };
 }
 
-// Zona kantor per peran — dipakai baik untuk penempatan awal maupun agen baru
-// hasil CRUD roster (lihat homeFor).
-const ZONE_FOR_ROLE: Record<Role, string> = {
-  manager: "Kantor Manajer",
-  coder: "Dev Bay",
-  tester: "QA Corner",
-  reviewer: "Ruang Review",
-  deployer: "Deploy Station",
-  researcher: "Riset",
-};
-
-/** Slot tempat tinggal (home) agen ke-`index` (0-based, di antara agen
- *  seperan lain) di dalam zona kantor perannya — grid 3 kolom, spasi merata
- *  supaya banyak agen seperan tak bertumpuk di satu titik. */
+/** Slot tempat tinggal (home) agen ke-`index` (0-based, di antara agen lain
+ *  yang berbagi zona home yang sama pada layout aktif — lihat homeZoneFor)
+ *  di dalam zona kantor perannya. Landscape: grid 3 kolom disebar merata di
+ *  lebar zona (perilaku asli, tak berubah — satu zona = satu peran).
+ *  Portrait: grid 3-kolom berpitch tetap ~56px supaya beberapa peran yang
+ *  berbagi satu zona (mis. Area Kerja) tak bertumpuk, dan baris pertama
+ *  disisakan ruang di bawah label zona. */
 function homeFor(role: Role, index: number): { x: number; y: number } {
-  const zone = zoneBy(ZONE_FOR_ROLE[role]);
+  const zone = homeZoneFor(role);
   if (role === "manager") {
     const c = center(zone);
     return { x: c.x, y: c.y + 8 };
@@ -117,12 +111,45 @@ function homeFor(role: Role, index: number): { x: number; y: number } {
   const cols = 3;
   const col = index % cols;
   const row = Math.floor(index / cols);
+  if (getLayout().kind === "portrait") {
+    // Tile 40px + pill nama ≈ 64px tinggi → pitch vertikal 74 supaya baris
+    // kedua tidak menimpa pill baris pertama; horizontal 100 (3 kolom / 358).
+    const pitchX = Math.min(100, (zone.w - 60) / Math.max(1, cols - 1));
+    const pitchY = 74;
+    const labelH = 30;
+    const gridW = (cols - 1) * pitchX;
+    const startX = zone.x + zone.w / 2 - gridW / 2;
+    return {
+      x: clamp(startX + col * pitchX, zone.x + 30, zone.x + zone.w - 30),
+      y: clamp(zone.y + labelH + 26 + row * pitchY, zone.y + labelH + 20, zone.y + zone.h - 44),
+    };
+  }
   const pad = 70;
   const stepX = cols > 1 ? (zone.w - pad * 2) / (cols - 1) : 0;
   return {
     x: clamp(zone.x + pad + col * stepX, zone.x + 24, zone.x + zone.w - 24),
     y: clamp(zone.y + pad + row * 90, zone.y + 24, zone.y + zone.h - 24),
   };
+}
+
+/** Tempat logis agen yang sedang "away" dari home-nya, diturunkan dari
+ *  state — dipakai applyLayout untuk retarget ke titik yang setara secara
+ *  logis di layout baru (mis. agen "await" tetap di titik rapat, bukan
+ *  balik ke home). */
+function logicalPlaceFor(state: Agent["state"]): "home" | "meet" | "review" | "server" {
+  switch (state) {
+    case "to_meet":
+    case "await":
+      return "meet";
+    case "to_srv":
+    case "working":
+      return "server";
+    case "to_rev":
+    case "review":
+      return "review";
+    default:
+      return "home";
+  }
 }
 
 const VALID_ROLES = new Set<string>(Object.keys(ROLE));
@@ -167,11 +194,15 @@ function initialAgents(): Agent[] {
  *  ditempatkan via homeFor, agen yang sudah tak ada di roster dibuang. */
 function reconcileAgents(current: Agent[], roster: RosterEntry[]): Agent[] {
   const byId = new Map(current.map((a) => [a.id, a]));
-  const roleCounts = new Map<Role, number>();
+  // dihitung per-zona-home (bukan per-peran) supaya peran yang berbagi satu
+  // zona di layout portrait (coder/tester/researcher → Area Kerja) tetap
+  // dapat slot grid yang berbeda-beda, bukan saling menumpuk di slot 0.
+  const zoneCounts = new Map<string, number>();
   const next: Agent[] = [];
   for (const r of roster) {
-    const idx = roleCounts.get(r.role) ?? 0;
-    roleCounts.set(r.role, idx + 1);
+    const zoneName = homeZoneFor(r.role).name;
+    const idx = zoneCounts.get(zoneName) ?? 0;
+    zoneCounts.set(zoneName, idx + 1);
     const existing = byId.get(r.id);
     if (existing) {
       next.push(
@@ -279,6 +310,10 @@ interface RoomState {
   /** Sinkronkan agents dengan roster server (CRUD /room/roster / event
    *  roster.updated / room.snapshot) — lihat reconcileAgents. */
   applyRoster: (roster: RosterEntry[]) => void;
+  /** Ganti scene aktif (landscape/portrait) dan re-home semua agen ke zona
+   *  yang sepadan di layout baru — dipanggil RuanganTab mobile saat tab
+   *  Ruangan berorientasi portrait; desktop tidak pernah memanggil ini. */
+  applyLayout: (kind: LayoutKind) => void;
   approve: (id: number) => void;
   reject: (id: number) => void;
   approveServer: (planId: string) => void;
@@ -318,8 +353,9 @@ export const useStore = create<RoomState>((set, get) => {
   };
 
   const moveTo = (a: Agent, x: number, y: number): void => {
-    a.targetX = clamp(x, 24, WORLD_W - 24);
-    a.targetY = clamp(y, 24, WORLD_H - 24);
+    const layout = getLayout();
+    a.targetX = clamp(x, 24, layout.worldW - 24);
+    a.targetY = clamp(y, 24, layout.worldH - 24);
     a.travel = Math.max(
       dist(a.posX, a.posY, a.targetX, a.targetY) / AGENT_SPEED,
       0.35,
@@ -378,10 +414,15 @@ export const useStore = create<RoomState>((set, get) => {
     logInto(a, `Ditugaskan: ${task.desc}`);
     if (task.risky) {
       a.state = "to_meet";
-      moveTo(a, MEET.x + rand(-34, 34), MEET.y + rand(-18, 18));
+      const meet = meetPoint();
+      // Portrait: zona 170×130 → sebar horizontal saja supaya pill nama tak bertumpuk.
+      if (getLayout().kind === "portrait") moveTo(a, meet.x + rand(-44, 44), meet.y + 6);
+      else moveTo(a, meet.x + rand(-34, 34), meet.y + rand(-18, 18));
     } else {
       a.state = "to_srv";
-      moveTo(a, SERVER.x + rand(-40, 40), SERVER.y + rand(-30, 30));
+      const server = serverPoint();
+      if (getLayout().kind === "portrait") moveTo(a, server.x + rand(-44, 44), server.y + 6);
+      else moveTo(a, server.x + rand(-40, 40), server.y + rand(-30, 30));
     }
     void approvals;
     return ev;
@@ -616,6 +657,40 @@ export const useStore = create<RoomState>((set, get) => {
       });
     },
 
+    applyLayout: (kind) => {
+      if (getLayout().kind === kind) return; // guard: no-op on redundant re-application
+      setSceneLayout(kind);
+      set((s) => {
+        const zoneCounts = new Map<string, number>();
+        const agents = s.agents.map((a) => {
+          const zoneName = homeZoneFor(a.role).name;
+          const idx = zoneCounts.get(zoneName) ?? 0;
+          zoneCounts.set(zoneName, idx + 1);
+          const home = homeFor(a.role, idx);
+          const place = logicalPlaceFor(a.state);
+          const pt =
+            place === "meet"
+              ? meetPoint()
+              : place === "review"
+                ? reviewPoint()
+                : place === "server"
+                  ? serverPoint()
+                  : home;
+          return {
+            ...a,
+            homeX: home.x,
+            homeY: home.y,
+            posX: pt.x,
+            posY: pt.y,
+            targetX: pt.x,
+            targetY: pt.y,
+            travel: 0,
+          };
+        });
+        return { agents };
+      });
+    },
+
     approve: (id) => {
       set((s) => {
         const i = s.approvals.findIndex((r) => r.id === id);
@@ -632,7 +707,8 @@ export const useStore = create<RoomState>((set, get) => {
         if (a) {
           logInto(a, "Disetujui — lanjut eksekusi");
           a.state = "to_srv";
-          moveTo(a, SERVER.x + rand(-40, 40), SERVER.y + rand(-30, 30));
+          const server = serverPoint();
+          moveTo(a, server.x + rand(-40, 40), server.y + rand(-30, 30));
         }
         return { approvals, agents, events };
       });
@@ -781,7 +857,8 @@ export const useStore = create<RoomState>((set, get) => {
                   if (a.task?.review) {
                     setCol(board, a.task.id, "review");
                     a.state = "to_rev";
-                    moveTo(a, REVIEW.x + rand(-40, 40), REVIEW.y + rand(-24, 24));
+                    const review = reviewPoint();
+                    moveTo(a, review.x + rand(-40, 40), review.y + rand(-24, 24));
                   } else {
                     if (a.task) setCol(board, a.task.id, "done");
                     returnHome(a);

--- a/web/src/ui/mobile/RuanganTab.tsx
+++ b/web/src/ui/mobile/RuanganTab.tsx
@@ -1,17 +1,47 @@
+import { useEffect, useRef } from "react";
 import { RoomCanvas } from "../../room/RoomCanvas";
 import { mix } from "../../room/engine/render";
 import { ROLE, STATUS } from "../../room/engine/scene";
 import { useStore } from "../../state/store";
 
 /** Tab Ruangan mobile: RoomCanvas penuh + kartu status manajer mengambang di
- *  atas hint bawaan RoomCanvas (bottom-3) supaya tak tumpang tindih. */
+ *  atas hint bawaan RoomCanvas (bottom-3) supaya tak tumpang tindih.
+ *
+ *  Scene aktif (landscape/portrait) mengikuti orientasi kontainer tab ini —
+ *  bukan sekadar "selalu portrait di mobile" — supaya HP landscape / tablet
+ *  (yang juga lewat MobileShell) tetap memakai world landscape yang sudah
+ *  pas untuk layar lebar. Desktop (App.tsx, RoomCanvas langsung) tak pernah
+ *  memanggil applyLayout sama sekali. */
 export function RuanganTab(): JSX.Element {
   const manager = useStore((s) => s.agents.find((a) => a.role === "manager") ?? null);
 
   const st = manager ? STATUS[manager.state] ?? STATUS.idle : null;
+  const wrapRef = useRef<HTMLDivElement>(null);
+  // true begitu kontainer ini pernah beralih ke portrait — cuma revert ke
+  // landscape saat unmount kalau kita yang tadi mengubahnya.
+  const switchedToPortrait = useRef(false);
+
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const apply = (): void => {
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return;
+      const portrait = rect.height > rect.width;
+      switchedToPortrait.current = portrait;
+      useStore.getState().applyLayout(portrait ? "portrait" : "landscape");
+    };
+    apply();
+    const ro = new ResizeObserver(apply);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      if (switchedToPortrait.current) useStore.getState().applyLayout("landscape");
+    };
+  }, []);
 
   return (
-    <div className="relative h-full w-full">
+    <div ref={wrapRef} className="relative h-full w-full">
       <RoomCanvas hideHint />
       {manager && (
         <div className="pointer-events-none absolute inset-x-3 bottom-3 rounded-xl border border-line bg-[var(--c-namebg)] px-3 py-2.5 backdrop-blur">


### PR DESCRIPTION
## What
Dedicated portrait room layout for phones so the **Ruangan** tab matches the approved mockup, instead of the desktop 1280×800 world scaled and panned.

## How
- `scene.ts`: two layouts (`LANDSCAPE` unchanged for desktop; `PORTRAIT` with 5 zones — Meja Manajer, Ruang Review, Area Kerja, Server, Meeting) behind `getLayout()/setSceneLayout()`; zone lookups, meet/review/server points resolve from the active layout
- `RuanganTab` picks the layout from its container aspect ratio; store `applyLayout()` re-homes agents (and keeps away-agents at the equivalent point)
- Portrait rendering: contain camera (no pan), rounded zone cards + mono labels, 40px role-colored avatar tiles with icon, status ring and name pill; kanban board hidden
- `rrect` clamps the radius — canvas `arcTo` with r > side/2 produced huge arcs (diagonal-cut tiles, light "beams")
- Portrait spacing 100×74 grid, smaller idle wander so tiles don't overlap
- web v0.4.2 + changelog

## How to test
`cd web && npm run build`; preview at 390×844 / 430×932 → 5 zones fully visible, tiles inside zones, no clipping, no drag needed; 1400×900 desktop unchanged.