### PR TITLE
fix(web): sinkron roster via /room/state — nama pasukan tak kembali default

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "octopus-gather-room",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "Ruang Octopus — gather-room frontend for the AI IT-Manager (mock data, Phase 3 P0-P1)",
   "scripts": {

--- a/web/src/changelog.ts
+++ b/web/src/changelog.ts
@@ -12,6 +12,14 @@ export interface ReleaseNote {
 
 export const CHANGELOG: ReleaseNote[] = [
   {
+    version: "0.4.3",
+    date: "2026-08-30",
+    notes: [
+      "Nama/peran pasukan yang sudah disimpan kini selalu tampil (sebelumnya kembali ke default bila stream ruangan tertahan proxy).",
+      "Snapshot ruangan diambil via JSON saat mulai, setelah masuk, dan tiap 20 detik sebagai cadangan.",
+    ],
+  },
+  {
     version: "0.4.2",
     date: "2026-08-29",
     notes: [

--- a/web/src/net/roomStream.ts
+++ b/web/src/net/roomStream.ts
@@ -8,16 +8,45 @@ export interface RoomStream {
   stop: () => void;
 }
 
+const STATE_POLL_MS = 20_000;
+
 export function startRoomStream(): RoomStream {
   const stopScheduler = useStore.getState().startScheduler();
   const ctrl = new AbortController();
   void connectLive(ctrl.signal);
+  // Cadangan snapshot via JSON: beberapa proxy (mis. Cloudflare quick tunnel)
+  // menahan body SSE sehingga room.snapshot tak pernah sampai → roster/worker
+  // di UI tetap default. /room/state = data yang sama, lewat request biasa.
+  void fetchRoomState(ctrl.signal);
+  const poll = window.setInterval(() => {
+    if (document.visibilityState === "visible") void fetchRoomState(ctrl.signal);
+  }, STATE_POLL_MS);
   return {
     stop: () => {
       stopScheduler();
+      window.clearInterval(poll);
       ctrl.abort();
     },
   };
+}
+
+/** Ambil snapshot ruangan sekali (idempoten — applyServerEvent me-reconcile). */
+export async function fetchRoomState(signal?: AbortSignal): Promise<boolean> {
+  const token = getToken();
+  if (!token) return false;
+  try {
+    const resp = await fetch("/room/state", {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+      signal,
+    });
+    if (!resp.ok) return false;
+    const ev = (await resp.json()) as Record<string, unknown>;
+    useStore.getState().applyServerEvent(ev);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function connectLive(signal: AbortSignal): Promise<void> {

--- a/web/src/ui/settings/SettingsPanel.tsx
+++ b/web/src/ui/settings/SettingsPanel.tsx
@@ -10,6 +10,7 @@ import {
   startGoogleLogin,
 } from "../../net/api";
 import { syncTokenToSw } from "../../net/push";
+import { fetchRoomState } from "../../net/roomStream";
 import { CURRENT_VERSION } from "../../net/version";
 import { CHANGELOG } from "../../changelog";
 import { useStore } from "../../state/store";
@@ -153,6 +154,7 @@ export function SettingsPanel({ onClose, onNavigateToPasukan }: SettingsPanelPro
     await syncTokenToSw();
     await refreshAuth();
     const st = useStore.getState().auth.status;
+    if (st !== "anon") void fetchRoomState();
     setLoginMsg(st === "anon" ? "Token tidak valid" : "Berhasil masuk");
     if (st !== "anon") {
       setTokenOpen(false);


### PR DESCRIPTION
## What
Roster names/roles edited in the app reverted to defaults after reload, although they were correctly persisted in Redis (`room:roster:<user>`) and returned by `GET /room/roster` / `GET /room/state`.

## Why
The web only learned the roster from the `room.snapshot` SSE event on `/room/stream`. Through the Cloudflare quick tunnel the SSE body is never forwarded (200 headers arrive, 0 body bytes in 20 s, on both QUIC and HTTP/2 transports; direct nginx/Caddy are fine), so the snapshot never reached the client and the mock defaults stayed.

## How
- `net/roomStream.ts`: `fetchRoomState()` — GET `/room/state` (plain JSON) on start, and every 20 s while the tab is visible; result goes through the same `applyServerEvent` reconcile (idempotent). SSE stays as the live path when it works.
- `SettingsPanel`: fetch the snapshot immediately after a successful login.
- web v0.4.3 + changelog

## How to test
Rename an agent → reload the PWA over the tunnel → names persist; `/room/state` in Network shows the custom roster.