### PR TITLE
feat(room): websocket /room/ws — ruangan realtime lewat proxy yang menahan sse

### DIFF
--- a/app/interfaces/room.py
+++ b/app/interfaces/room.py
@@ -17,7 +17,8 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, Query, WebSocket, WebSocketDisconnect, status
+from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from app.composition import build_roster
@@ -272,3 +273,40 @@ async def room_stream(
     workers = await _worker_count_for(user_id, mode)
     agents = await _agents_snapshot_for(user_id, mode)
     return StreamingResponse(_room_stream(agents, workers), media_type="text/event-stream")
+
+
+# ── WebSocket mirror /room/ws ─────────────────────────────────────────────────
+# Beberapa proxy (Cloudflare quick tunnel) menahan body SSE sehingga
+# /room/stream tak pernah sampai ke klien, sedangkan WebSocket lolos. Payload
+# identik dengan SSE: snapshot dulu, lalu setiap event RoomBus sebagai JSON.
+
+_WS_HEARTBEAT_SEC = 20.0
+
+
+@router.websocket("/ws")
+async def room_ws(
+    websocket: WebSocket,
+    session: str = Query(..., description="Bearer session token / ADMIN_TOKEN"),
+) -> None:
+    try:
+        user_id, mode = _resolve_caller(f"Bearer {session}")
+    except HTTPException:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason="invalid session")
+        return
+
+    workers = await _worker_count_for(user_id, mode)
+    agents = await _agents_snapshot_for(user_id, mode)
+    await websocket.accept()
+    q = _bus.subscribe()
+    try:
+        await websocket.send_json(_snapshot(agents, workers))
+        while True:
+            try:
+                event = await asyncio.wait_for(q.get(), timeout=_WS_HEARTBEAT_SEC)
+                await websocket.send_json(event)
+            except TimeoutError:
+                await websocket.send_json({"type": "heartbeat"})
+    except WebSocketDisconnect:
+        pass
+    finally:
+        _bus.unsubscribe(q)

--- a/tests/interfaces/test_room.py
+++ b/tests/interfaces/test_room.py
@@ -173,3 +173,23 @@ def test_room_task_observer_push_exception_does_not_propagate() -> None:
         await asyncio.sleep(0)  # let the failing push task run & be swallowed
 
     asyncio.run(go())  # must not raise
+
+
+# ── /room/ws (WebSocket mirror) ───────────────────────────────────────────────
+
+def test_room_ws_rejects_invalid_token(client: TestClient) -> None:
+    from starlette.websockets import WebSocketDisconnect
+
+    with pytest.raises(WebSocketDisconnect) as exc, client.websocket_connect("/room/ws?session=wrong"):
+        pass
+    assert exc.value.code == 1008
+
+
+def test_room_ws_sends_snapshot_then_live_events(client: TestClient) -> None:
+    with client.websocket_connect("/room/ws?session=test-admin") as ws:
+        snap = ws.receive_json()
+        assert snap["type"] == "room.snapshot"
+        assert len(snap["agents"]) == 7
+        publish_room_event("agent.status", id="octo", status="working")
+        ev = ws.receive_json()
+        assert ev == {"type": "agent.status", "id": "octo", "status": "working"}

--- a/tests/interfaces/test_room.py
+++ b/tests/interfaces/test_room.py
@@ -177,9 +177,18 @@ def test_room_task_observer_push_exception_does_not_propagate() -> None:
 
 # ── /room/ws (WebSocket mirror) ───────────────────────────────────────────────
 
-def test_room_ws_rejects_invalid_token(client: TestClient) -> None:
+def test_room_ws_rejects_invalid_token(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastapi import HTTPException
     from starlette.websockets import WebSocketDisconnect
 
+    import app.interfaces.room as room_mod
+
+    # Token non-admin normalnya di-resolve ke DB sesi; di sini cukup dipastikan
+    # 401 dari resolver → WS ditutup 1008 (tanpa butuh tabel user_sessions).
+    def _deny(_auth: str | None) -> tuple[str, str]:
+        raise HTTPException(status_code=401, detail="invalid or expired session")
+
+    monkeypatch.setattr(room_mod, "_resolve_caller", _deny)
     with pytest.raises(WebSocketDisconnect) as exc, client.websocket_connect("/room/ws?session=wrong"):
         pass
     assert exc.value.code == 1008

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,3 +1,9 @@
+# "" bila bukan upgrade (SSE/keep-alive), "upgrade" untuk WebSocket
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ""      "";
+}
+
 server {
     listen 80;
     server_name _;
@@ -18,7 +24,9 @@ server {
         proxy_pass http://bot:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
-        proxy_set_header Connection "";
+        # /room/ws = WebSocket; request lain (SSE) tetap jalan dengan header ini
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
         proxy_buffering off;
         proxy_read_timeout 3600s;
     }

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "octopus-gather-room",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "description": "Ruang Octopus — gather-room frontend for the AI IT-Manager (mock data, Phase 3 P0-P1)",
   "scripts": {

--- a/web/src/changelog.ts
+++ b/web/src/changelog.ts
@@ -12,6 +12,13 @@ export interface ReleaseNote {
 
 export const CHANGELOG: ReleaseNote[] = [
   {
+    version: "0.4.4",
+    date: "2026-08-30",
+    notes: [
+      "Ruangan kembali realtime lewat URL tunnel: event live kini lewat WebSocket (SSE tertahan proxy), persetujuan & pergerakan agen muncul seketika.",
+    ],
+  },
+  {
     version: "0.4.3",
     date: "2026-08-30",
     notes: [

--- a/web/src/net/roomStream.ts
+++ b/web/src/net/roomStream.ts
@@ -49,8 +49,63 @@ export async function fetchRoomState(signal?: AbortSignal): Promise<boolean> {
   }
 }
 
+/** Terima satu payload event (WS/SSE) → store. */
+function applyRaw(raw: string): void {
+  try {
+    const ev = JSON.parse(raw) as Record<string, unknown>;
+    if (ev.type === "heartbeat") return;
+    useStore.getState().applyServerEvent(ev);
+  } catch {
+    /* abaikan payload non-JSON */
+  }
+}
+
+/** Jalur utama: WebSocket /room/ws (lolos proxy yang menahan SSE, mis.
+ *  Cloudflare quick tunnel). Resolve true bila pernah tersambung & menerima
+ *  data, false bila gagal handshake → pemanggil fallback ke SSE. */
+function connectWs(token: string, signal: AbortSignal): Promise<boolean> {
+  return new Promise((resolve) => {
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const url = `${proto}//${window.location.host}/room/ws?session=${encodeURIComponent(token)}`;
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      resolve(false);
+      return;
+    }
+    let gotData = false;
+    const onAbort = (): void => ws.close();
+    signal.addEventListener("abort", onAbort, { once: true });
+    ws.onmessage = (e) => {
+      gotData = true;
+      applyRaw(String(e.data));
+    };
+    ws.onerror = () => {
+      /* onclose menyusul */
+    };
+    ws.onclose = () => {
+      signal.removeEventListener("abort", onAbort);
+      resolve(gotData);
+    };
+  });
+}
+
 async function connectLive(signal: AbortSignal): Promise<void> {
+  let sseFallback = false;
   while (!signal.aborted) {
+    const wsToken = getToken();
+    if (wsToken && !sseFallback) {
+      const ok = await connectWs(wsToken, signal);
+      if (signal.aborted) return;
+      // Handshake gagal (mis. proxy tak dukung WS / 401) → coba SSE di bawah;
+      // pernah tersambung lalu putus → reconnect WS setelah jeda.
+      if (ok) {
+        await new Promise((r) => setTimeout(r, 2000));
+        continue;
+      }
+      sseFallback = true;
+    }
     // Token dibaca ulang tiap percobaan: setelah user login lewat Pengaturan
     // → Akun, stream langsung tersambung tanpa reload halaman.
     const token = getToken();
@@ -78,17 +133,14 @@ async function connectLive(signal: AbortSignal): Promise<void> {
             .split("\n")
             .find((l) => l.startsWith("data:"));
           if (!dataLine) continue; // heartbeat comment / event line saja
-          try {
-            const ev = JSON.parse(dataLine.slice(5).trim());
-            useStore.getState().applyServerEvent(ev);
-          } catch {
-            /* abaikan payload non-JSON */
-          }
+          applyRaw(dataLine.slice(5).trim());
         }
       }
     } catch {
       if (signal.aborted) return;
     }
+    // SSE putus → coba WS lagi dulu di iterasi berikutnya (mungkin sudah pulih).
+    sseFallback = false;
     await new Promise((r) => setTimeout(r, 3000)); // reconnect backoff
   }
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
     allowedHosts: true, // izinkan host tunnel (trycloudflare) di dev
     proxy: {
       "/chat": { target: "http://localhost:8080", changeOrigin: true },
-      "/room": { target: "http://localhost:8080", changeOrigin: true },
+      "/room": { target: "http://localhost:8080", changeOrigin: true, ws: true },
       "/auth": { target: "http://localhost:8080", changeOrigin: true },
       "/push": { target: "http://localhost:8080", changeOrigin: true },
     },


### PR DESCRIPTION
## What
Realtime room events over **WebSocket** (`/room/ws`) so the PWA is live again through the Cloudflare quick tunnel, which forwards SSE headers but never the SSE body.

## Why
Verified: `/room/stream` via the tunnel → 200 headers, 0 body bytes in 20 s (QUIC and HTTP/2); direct nginx/Caddy fine. A WebSocket probe through the same tunnel connected (101) in 0.9 s and received messages immediately. No DNS/domain change needed.

## How
- `app/interfaces/room.py`: `@router.websocket("/ws")` — auth `?session=<session token | ADMIN_TOKEN>` through the existing `_resolve_caller`; sends `room.snapshot` then every RoomBus event (same payload as SSE) + 20 s heartbeat; closes 1008 on invalid token. Tests: invalid token → 1008; snapshot then live event.
- `web/src/net/roomStream.ts`: WebSocket first; if the handshake fails fall back to SSE; the 20 s `/room/state` poll stays as a safety net.
- `web/nginx.conf`: `Upgrade`/`Connection` headers on `/room/` via a `map` (empty when not upgrading, so SSE keeps working); `vite.config.ts` dev proxy `ws: true`.
- web v0.4.4 + changelog.

## How to test
1. `make check` (10 room tests incl. 2 WS); `cd web && npm run build`.
2. Over the tunnel: open the PWA logged in → Network shows `/room/ws` 101; approve/reject cards and agent status update instantly.
3. `nginx -t` passes (`docker run --add-host bot:127.0.0.1 -v ./web/nginx.conf:/etc/nginx/conf.d/default.conf nginx:alpine nginx -t`).