### PR TITLE
feat(octopus-cli): mode worker headless (octopus worker) untuk pasukan asli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,4 @@ logs/
 # Artefak tooling lokal
 .playwright-cli/
 octopus-cli/octopus-worker-bin
+octopus-cli/octopus

--- a/octopus-cli/internal/tui/worker.go
+++ b/octopus-cli/internal/tui/worker.go
@@ -40,8 +40,10 @@ func RunWorkerLoop(cfg *config.Config, getSession func() *session.Session, isRun
 		if err == nil {
 			// Clean disconnect — reset backoff.
 			delay = workerReconnectInitial
-		} else {
+		} else if program != nil {
 			program.Send(outputMsg{simpleLine("dim", fmt.Sprintf("  worker disconnected (%s), reconnecting in %.0fs…", err.Error(), delay.Seconds()))})
+		} else {
+			fmt.Printf("worker disconnected (%s), reconnecting in %.0fs…\n", err.Error(), delay.Seconds())
 		}
 
 		if !isRunning() {
@@ -118,7 +120,11 @@ func handleWorkerMessage(conn *websocket.Conn, cfg *config.Config, msg map[strin
 	switch kind {
 	case "registered":
 		workerID, _ := msg["worker_id"].(string)
-		program.Send(workerStatusMsg{connected: true, workerID: workerID})
+		if program != nil {
+			program.Send(workerStatusMsg{connected: true, workerID: workerID})
+		} else {
+			fmt.Printf("worker registered: %s\n", workerID)
+		}
 
 	case "heartbeat_ack":
 		// no-op
@@ -156,10 +162,10 @@ func executeAgent(conn *websocket.Conn, cfg *config.Config, jobID, agent, prompt
 			"text":   fmt.Sprintf("[echo] received: %s\n", prompt),
 		})
 		sendWS(conn, map[string]any{
-			"type":     "job_done",
-			"job_id":   jobID,
+			"type":      "job_done",
+			"job_id":    jobID,
 			"exit_code": 0,
-			"summary":  fmt.Sprintf("echoed %d chars", len(prompt)),
+			"summary":   fmt.Sprintf("echoed %d chars", len(prompt)),
 		})
 		return
 	}

--- a/octopus-cli/main.go
+++ b/octopus-cli/main.go
@@ -37,6 +37,7 @@ func main() {
 	}
 
 	root.AddCommand(upgradeCmd())
+	root.AddCommand(workerCmd())
 	root.Version = Version
 
 	if err := root.Execute(); err != nil {
@@ -76,6 +77,54 @@ func runTUI() error {
 	if _, err := p.Run(); err != nil {
 		return fmt.Errorf("TUI error: %w", err)
 	}
+	return nil
+}
+
+// ── worker command (headless) ───────────────────────────────────────────────
+
+// workerCmd runs the agent worker loop without the TUI — untuk dijalankan
+// sebagai service (systemd/docker) di mesin mana pun agar jadi "pasukan".
+func workerCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "worker",
+		Short: "Jalankan sebagai pasukan headless (tanpa TUI): terima & eksekusi job",
+		Long: "Menghubungkan ke backend Octopus lewat WebSocket, mengiklankan agent " +
+			"yang terpasang, dan mengeksekusi job. Token dari ~/.config/octopus/session.json " +
+			"(hasil login TUI) atau env OCTOPUS_TOKEN. Backend dari OCTOPUS_URL.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runWorker()
+		},
+		SilenceUsage: true,
+	}
+}
+
+func runWorker() error {
+	cfg := config.Load(defaultAppURL, Version)
+
+	sess := session.Load(cfg.AppURL)
+	if t := os.Getenv("OCTOPUS_TOKEN"); t != "" {
+		if sess == nil {
+			sess = &session.Session{BackendURL: cfg.AppURL}
+		}
+		sess.Token = t
+	}
+	if sess == nil || sess.Token == "" {
+		return fmt.Errorf(
+			"belum ada sesi: login lewat TUI dulu, atau set env OCTOPUS_TOKEN",
+		)
+	}
+
+	fmt.Printf("octopus worker → %s\n", cfg.AppURL)
+	fmt.Printf("agents: codex=%v claude=%v glm=%v (echo selalu aktif)\n",
+		cfg.EnableCodex, cfg.EnableClaude, cfg.EnableGLM)
+	fmt.Println("menunggu job… (Ctrl+C untuk berhenti)")
+
+	// Headless: getSession konstan, isRunning selalu true, tanpa TUI program.
+	tui.RunWorkerLoop(cfg,
+		func() *session.Session { return sess },
+		func() bool { return true },
+		nil,
+	)
 	return nil
 }
 


### PR DESCRIPTION
Mengubah "pasukan" dari worker echo tiruan (Python) menjadi **worker asli octopus-cli** yang bisa dijalankan headless di mesin mana pun dan mengeksekusi CLI agent sungguhan.

## Masalah
Worker Go sudah lengkap (connect WS, capabilities, heartbeat, `executeAgent` jalankan CLI + stream), **tapi hanya jalan di dalam TUI** — butuh login Google interaktif + terminal. Tak bisa dijalankan sebagai service.

## Perubahan
- **main.go** — subcommand `octopus worker`: load config (env-driven) + session dari `~/.config/octopus/session.json` atau env `OCTOPUS_TOKEN`, lalu `RunWorkerLoop` tanpa TUI.
- **internal/tui/worker.go** — `program.Send` dibuat nil-safe (headless log ke stdout).
- **.gitignore** — binary build + sesi playwright.

## Cara pakai
```sh
export OCTOPUS_URL=https://octopus.flowbiz.id   # backend
export OCTOPUS_TOKEN=<session token>            # atau login via TUI dulu
# agent asli opt-in:
export ENABLE_CLAUDE=true    # + ENABLE_CODEX / ENABLE_GLM
octopus worker
```
Routing aman by-default: `DELEGATE_ROLE_INFRA=echo`; engineer→claude, research→codex, reviewer→glm (ubah via env).

## Verifikasi E2E
Worker Go headless (container, image bot) → connect `/ws/worker` via nginx → **registered** → `/tasks/run` (mock decompose) → dispatch → worker eksekusi (echo) → **ok=true, closed=true**. `go vet` ✅ · `gofmt` ✅ · `go build` ✅.

Part of #82

---
Rebase of #92 onto current `main` (only conflict: `.gitignore`). Supersedes #92; the original branch could not be force-pushed from this session.