### PR TITLE
feat: otak cli lokal tanpa api key (/use claude) + aturan per peran untuk pasukan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,12 +25,21 @@ HTTPS_PROXY=
 # ── AI Provider (cloud LLM, BYOK — otak orchestrator) ───────────────────────
 # Pilih provider default + masukkan API key milikmu. Tanpa key, perintah yang
 # butuh LLM akan ditolak dengan pesan jelas (perintah regex sepele tetap jalan).
-AI_PROVIDER_DEFAULT=anthropic          # anthropic | glm | mock (mock = dev/testing tanpa key)
+AI_PROVIDER_DEFAULT=anthropic          # anthropic | glm | mock | claude-cli | glm-cli
+                                        # mock = dev/testing tanpa key.
+                                        # claude-cli/glm-cli = "otak" lokal TANPA API key —
+                                        # brain + semua peran dijalankan di worker CLI (Claude
+                                        # Code / GLM CLI) yang sudah terpasang di device user.
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=claude-opus-4-8
 GLM_API_KEY=
 GLM_API_MODEL=glm-4-plus
 GLM_API_BASE_URL=https://open.bigmodel.cn/api/paas/v4
+
+# Aturan tambahan per-peran (opsional): taruh file data/roles/<role>.md
+# (engineer/reviewer/research/infra/planner/tester) — isinya ditempel ke
+# prompt step peran itu sebagai "Aturan tambahan proyek". Default profil
+# peran tetap di app/agents/roles.py.
 
 # Batasi akses Telegram ke user ID tertentu.
 # Kosongkan saat development kalau ingin semua chat yang masuk diizinkan.

--- a/app/adapters/ai_provider_db.py
+++ b/app/adapters/ai_provider_db.py
@@ -8,6 +8,8 @@ from typing import Protocol
 
 from app.adapters.ai_provider_factory import build_ai_provider
 from app.config import Settings
+from app.domain.exceptions import AIProviderError
+from app.domain.providers import is_cli_provider
 from app.ports.ai_provider import AIProvider
 
 personal_anthropic_key_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
@@ -20,9 +22,18 @@ class _PrefReader(Protocol):
 
 
 class DbAIProviderResolver:
-    def __init__(self, repo: _PrefReader, settings: Settings) -> None:
+    def __init__(
+        self, repo: _PrefReader, settings: Settings, *, degrade_cli_to_mock: bool = False
+    ) -> None:
         self._repo = repo
         self._settings = settings
+        # Chat brain saja: provider CLI lokal (claude-cli/glm-cli) tidak punya
+        # adapter cloud (build_ai_provider raise) — kerja berat sudah
+        # didelegasikan ke worker lewat dispatch override, jadi brain di sini
+        # cukup degrade ke MockAIProvider (bukan lempar error tiap chat).
+        # TaskRunner/ExecutionLoop TIDAK memakai flag ini — mereka butuh raise
+        # supaya jatuh ke jalur decompose-via-worker.
+        self._degrade_cli_to_mock = degrade_cli_to_mock
         # Hanya key server-side (personal_key None) yang layak di-cache untuk
         # lifetime process — personal key per-user tidak boleh menumpuk di
         # cache global (bocor plaintext secret + tumbuh tak terbatas).
@@ -33,12 +44,18 @@ class DbAIProviderResolver:
         provider, model = pref if pref else (self._settings.ai_provider_default, None)
         personal_key = personal_anthropic_key_var.get()
 
-        if personal_key is not None:
-            return build_ai_provider(provider, model, self._settings, personal_key=personal_key)
+        try:
+            if personal_key is not None:
+                return build_ai_provider(provider, model, self._settings, personal_key=personal_key)
 
-        key = (provider, model)
-        cached = self._cache.get(key)
-        if cached is None:
-            cached = build_ai_provider(provider, model, self._settings, personal_key=None)
-            self._cache[key] = cached
-        return cached
+            key = (provider, model)
+            cached = self._cache.get(key)
+            if cached is None:
+                cached = build_ai_provider(provider, model, self._settings, personal_key=None)
+                self._cache[key] = cached
+            return cached
+        except AIProviderError:
+            if self._degrade_cli_to_mock and is_cli_provider(provider):
+                from app.adapters.mock_llm import MockAIProvider
+                return MockAIProvider()
+            raise

--- a/app/adapters/ai_provider_factory.py
+++ b/app/adapters/ai_provider_factory.py
@@ -14,6 +14,7 @@ from app.adapters.circuit_breaker import CircuitBreaker
 from app.adapters.glm import GLMAdapter
 from app.config import Settings
 from app.domain.exceptions import AIProviderError
+from app.domain.providers import is_cli_provider
 from app.ports.ai_provider import AIProvider
 
 _ALIASES = {"claude": "anthropic", "zhipu": "glm"}
@@ -29,6 +30,12 @@ def build_ai_provider(
     provider: str, model: str | None, settings: Settings, personal_key: str | None = None
 ) -> AIProvider:
     name = _ALIASES.get(provider.strip().lower(), provider.strip().lower())
+    if is_cli_provider(name):
+        # CLI lokal (claude-cli/glm-cli): tidak ada adapter cloud untuk ini —
+        # brain + peran dijalankan di worker CLI user (lihat worker_dispatch).
+        raise AIProviderError(
+            "provider CLI lokal — dijalankan lewat worker, bukan cloud"
+        )
     if name == "anthropic":
         api_key = personal_key or settings.anthropic_api_key
         if not api_key:

--- a/app/adapters/worker_dispatch.py
+++ b/app/adapters/worker_dispatch.py
@@ -32,11 +32,15 @@ def _role_agent_map() -> dict[str, str]:
 
 
 # Provider (pilihan user) → agent CLI worker. Satu-LLM: semua role pakai ini.
+# claude-cli/glm-cli: provider "lokal" eksplisit (tanpa key cloud sama sekali) —
+# brain + semua peran dijalankan di worker CLI milik user.
 _PROVIDER_AGENT = {
     "claude": "claude",
     "anthropic": "claude",
+    "claude-cli": "claude",
     "glm": "glm",
     "zhipu": "glm",
+    "glm-cli": "glm",
     "codex": "codex",
 }
 

--- a/app/agents/roles.py
+++ b/app/agents/roles.py
@@ -1,0 +1,179 @@
+# app/agents/roles.py
+"""Profil peran ("skills & rules") untuk step yang didispatch ke worker CLI.
+
+Tanpa ini, worker (Claude/GLM/Codex CLI) menerima ``step.description`` mentah
+— tak ada batasan peran, tak ada format laporan, jadi hasilnya bias/generic.
+``build_step_prompt`` membungkus deskripsi step dengan aturan peran + kontrak
+output, plain text (worker CLI tak punya flag system-prompt terpisah).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.config import BASE_DIR
+
+_OUTPUT_CONTRACT = (
+    "Balas dengan bagian berikut (boleh isi '-' kalau tak relevan):\n"
+    "Hasil: <ringkas 1-3 kalimat>\n"
+    "File yang diubah: <daftar path, atau '-'>\n"
+    "Verifikasi: <test/command yang dijalankan + hasil, atau '-'>\n"
+    "Catatan-risiko: <hal yang perlu diwaspadai reviewer, atau '-'>"
+)
+
+
+@dataclass(frozen=True)
+class RoleProfile:
+    role: str
+    title: str
+    mission: str
+    rules: tuple[str, ...]
+    output_contract: str = _OUTPUT_CONTRACT
+    forbidden: tuple[str, ...] = field(default_factory=tuple)
+
+
+ROLE_PROFILES: dict[str, RoleProfile] = {
+    "engineer": RoleProfile(
+        role="engineer",
+        title="Engineer",
+        mission="Implementasikan step ini dengan diff sekecil mungkin — tidak lebih, tidak kurang.",
+        rules=(
+            "Kerjakan HANYA yang diminta step ini — jangan gold-plating atau refactor di luar scope.",
+            "Diff sekecil mungkin, ikuti konvensi kode yang sudah ada.",
+            "Kalau ada test di repo, jalankan setelah perubahan dan laporkan hasilnya.",
+            "Jangan pernah hardcode credential/secret.",
+        ),
+        forbidden=("menyentuh file di luar workdir proyek",),
+    ),
+    "reviewer": RoleProfile(
+        role="reviewer",
+        title="Reviewer",
+        mission="Periksa perubahan dengan kritis — temukan masalah nyata, jangan rubber-stamp.",
+        rules=(
+            "JANGAN mengubah kode — tugasmu cuma memberi temuan, bukan memperbaiki.",
+            "Verifikasi klaim dengan baca kode/diff langsung, jangan asumsi.",
+            "Urutkan temuan: blocker → major → minor, sertakan file:line.",
+            "Kalau tidak ada masalah, katakan itu secara eksplisit — jangan mengarang temuan.",
+        ),
+        forbidden=("mengedit/menulis file",),
+    ),
+    "research": RoleProfile(
+        role="research",
+        title="Peneliti",
+        mission="Gali & rangkum informasi yang dibutuhkan — read-only, faktual.",
+        rules=(
+            "Read-only — jangan ubah file atau state apa pun.",
+            "Sertakan path file/command konkret sebagai bukti, jangan klaim tanpa rujukan.",
+            "Pisahkan jelas mana FAKTA (terverifikasi) dan mana ASUMSI.",
+        ),
+        forbidden=("menulis/mengubah file", "menjalankan command yang mengubah state"),
+    ),
+    "infra": RoleProfile(
+        role="infra",
+        title="Infra",
+        mission="Operasi server/docker/git secara hati-hati — read-only dulu, mutasi lewat approval.",
+        rules=(
+            "Utamakan command read-only (status/logs/ps) untuk diagnosis dulu.",
+            "Command yang MENGUBAH state (restart/delete/deploy) harus disebutkan sebagai "
+            "proposal eksplisit — eksekusi sesungguhnya lewat chokepoint approval Octopus.",
+            "Jangan pernah restart/hapus service tanpa approval eksplisit.",
+        ),
+        forbidden=("restart/delete/deploy tanpa approval eksplisit",),
+    ),
+    "planner": RoleProfile(
+        role="planner",
+        title="Planner",
+        mission="Pecah request jadi 3-7 step yang jelas, tiap step untuk tepat satu peran.",
+        rules=(
+            "Hasilkan 3-7 step — jangan terlalu granular, jangan terlalu kasar.",
+            "Tiap step harus bisa diberikan ke TEPAT SATU peran (engineer/reviewer/research/infra/tester).",
+            "Step verifikasi/review WAJIB jadi step terakhir.",
+            "Balas JSON sesuai format yang diminta prompt di bawah — jangan tambah teks di luar JSON.",
+        ),
+        # Kosong sengaja: prompt planning (di bawah instruksi ini) sudah mendikte
+        # skema JSON secara eksplisit — kontrak "Hasil/File/.../Verifikasi" generik
+        # akan kontradiktif dengan "JSON only, no text outside" di atas.
+        output_contract="",
+    ),
+    "tester": RoleProfile(
+        role="tester",
+        title="Tester",
+        mission="Tulis/jalankan test untuk memverifikasi step sebelumnya benar-benar berhasil.",
+        rules=(
+            "Jalankan test suite yang relevan, laporkan pass/fail apa adanya — jangan poles hasil.",
+            "Kalau menambah test baru, pastikan test itu benar-benar gagal sebelum fix (regression-proof).",
+            "Jangan tandai selesai kalau ada test yang gagal — laporkan sebagai blocker.",
+        ),
+    ),
+}
+
+_GENERIC_PROFILE = RoleProfile(
+    role="worker",
+    title="Worker",
+    mission="Kerjakan step ini seakurat mungkin sesuai deskripsi, lalu laporkan hasilnya.",
+    rules=(
+        "Kerjakan HANYA yang diminta step ini.",
+        "Laporkan semua perubahan yang kamu buat secara eksplisit.",
+    ),
+)
+
+
+def get_role_profile(role: str) -> RoleProfile:
+    """Profil peran; peran tak dikenal jatuh ke profil generik ``worker``."""
+    return ROLE_PROFILES.get((role or "").strip().lower(), _GENERIC_PROFILE)
+
+
+def _project_override(role: str) -> str:
+    """Aturan tambahan opsional dari ``data/roles/<role>.md`` (per-proyek).
+
+    Best-effort — file tak ada/tak terbaca cukup diabaikan, bukan gagal step.
+    """
+    path = BASE_DIR / "data" / "roles" / f"{role}.md"
+    try:
+        if not path.is_file():
+            return ""
+        content = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+    return f"\n\nAturan tambahan proyek:\n{content}" if content else ""
+
+
+def build_step_prompt(
+    role: str,
+    description: str,
+    *,
+    task_title: str,
+    task_summary: str,
+    step_order: int,
+    step_total: int,
+    context: str = "",
+) -> str:
+    """Render prompt lengkap untuk satu step: profil peran + konteks task + kontrak output.
+
+    Worker CLI (Claude/GLM/Codex) tak punya flag system-prompt terpisah, jadi
+    semuanya digabung jadi satu prompt plain text.
+    """
+    profile = get_role_profile(role)
+    lines = [
+        f"Kamu berperan sebagai {profile.title} dalam tim eksekusi Octopus.",
+        f"Misi peranmu: {profile.mission}",
+        "Aturan wajib:",
+        *(f"- {rule}" for rule in profile.rules),
+    ]
+    if profile.forbidden:
+        lines.append("Dilarang: " + "; ".join(profile.forbidden) + ".")
+    lines += [
+        "",
+        f"Task: {task_title}",
+        f"Ringkasan task: {task_summary}",
+        f"Step {step_order}/{step_total}: {description}",
+    ]
+    if context:
+        lines.append(f"\nKonteks tambahan:\n{context}")
+    if profile.output_contract:
+        lines.append("")
+        lines.append(profile.output_contract)
+    override = _project_override(profile.role)
+    if override:
+        lines.append(override)
+    return "\n".join(lines)

--- a/app/composition.py
+++ b/app/composition.py
@@ -56,11 +56,30 @@ def _session_factory() -> sessionmaker[Any]:
 
 @lru_cache(maxsize=1)
 def _provider_resolver() -> Any:
-    """Resolver AI provider per-user (BYOK) — dipakai use case / loop / task runner."""
+    """Resolver AI provider per-user (BYOK) — dipakai loop / task runner.
+
+    Provider CLI lokal (claude-cli/glm-cli) tetap RAISE di sini (tak ada
+    adapter cloud) supaya task runner jatuh ke jalur decompose-via-worker.
+    """
     from app.adapters.ai_provider_db import DbAIProviderResolver
     from app.adapters.user_provider_config import UserProviderConfigRepository
     repo = UserProviderConfigRepository(_session_factory())
     return DbAIProviderResolver(repo, settings)
+
+
+@lru_cache(maxsize=1)
+def _chat_provider_resolver() -> Any:
+    """Resolver khusus 'otak' chat — provider CLI lokal degrade ke mock.
+
+    Kerja berat (agent_* delegation, task steps) sudah dijalankan lewat
+    worker dispatch override; brain chat langsung cukup respons mock supaya
+    ``/chat/send`` tidak menunjukkan error tiap kali user memilih provider
+    CLI lokal.
+    """
+    from app.adapters.ai_provider_db import DbAIProviderResolver
+    from app.adapters.user_provider_config import UserProviderConfigRepository
+    repo = UserProviderConfigRepository(_session_factory())
+    return DbAIProviderResolver(repo, settings, degrade_cli_to_mock=True)
 
 
 @lru_cache(maxsize=1)
@@ -252,5 +271,5 @@ def build_use_case() -> HandleMessageUseCase:
         rate_limiter=_rate_limiter(),
         audit=_audit_logger(),
         context_provider=_context_store(),
-        provider_resolver=_provider_resolver(),
+        provider_resolver=_chat_provider_resolver(),
     )

--- a/app/domain/providers.py
+++ b/app/domain/providers.py
@@ -1,0 +1,21 @@
+# app/domain/providers.py
+"""Satu sumber kebenaran untuk daftar provider 'otak' (LLM) yang diizinkan.
+
+CLOUD_PROVIDERS butuh API key (BYOK) dan dijalankan di server via
+``app.adapters.ai_provider_factory``. CLI_PROVIDERS ("claude-cli"/"glm-cli")
+tidak butuh key sama sekali — brain + semua peran dijalankan di worker CLI
+milik user sendiri (lihat ``app.adapters.worker_dispatch._PROVIDER_AGENT``).
+"""
+
+from __future__ import annotations
+
+CLOUD_PROVIDERS: frozenset[str] = frozenset({"anthropic", "glm"})
+CLI_PROVIDERS: frozenset[str] = frozenset({"claude-cli", "glm-cli"})
+MOCK_PROVIDER = "mock"
+
+ALL_PROVIDERS: frozenset[str] = CLOUD_PROVIDERS | CLI_PROVIDERS | frozenset({MOCK_PROVIDER})
+
+
+def is_cli_provider(name: str) -> bool:
+    """True kalau ``name`` adalah provider CLI lokal (tanpa key, via worker)."""
+    return (name or "").strip().lower() in CLI_PROVIDERS

--- a/app/interfaces/auth.py
+++ b/app/interfaces/auth.py
@@ -22,6 +22,22 @@ from app.adapters.database.session import (
 )
 from app.adapters.sessions import UserSessionRepository
 from app.config import settings
+from app.domain.providers import ALL_PROVIDERS
+from app.interfaces.auth_pages import (
+    error_page as _error_page,
+)
+from app.interfaces.auth_pages import (
+    login_page as _login_page,
+)
+from app.interfaces.auth_pages import (
+    success_page as _success_page,
+)
+from app.interfaces.auth_pages import (
+    tui_login_page as _tui_login_page,
+)
+from app.interfaces.auth_pages import (
+    tui_success_page as _tui_success_page,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -118,68 +134,6 @@ def _session_factory_lazy() -> Any:
         engine = create_database_engine(settings.database_url)
         _cached_factory = create_session_factory(engine)
     return _cached_factory
-
-
-# ── HTML pages ────────────────────────────────────────────────────────────────
-
-_PAGE_STYLE = """
-<style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: system-ui, sans-serif; background: #0f172a; color: #e2e8f0;
-         display: flex; align-items: center; justify-content: center; min-height: 100vh; }
-  .card { text-align: center; padding: 48px 40px; max-width: 440px; width: 100%; }
-  .icon { font-size: 3rem; margin-bottom: 16px; }
-  h1   { font-size: 1.6rem; margin-bottom: 10px; }
-  p    { color: #94a3b8; font-size: 0.95rem; line-height: 1.6; }
-  .meta { margin-top: 8px; font-size: 0.85rem; color: #64748b; }
-  .dim  { margin-top: 28px; font-size: 0.8rem; color: #475569; }
-  a    { color: #60a5fa; text-decoration: none; }
-  .btn { display: inline-block; margin-top: 24px; padding: 12px 28px;
-         background: #4285F4; color: #fff; border-radius: 6px;
-         font-size: 0.95rem; font-weight: 500; text-decoration: none; }
-  .btn:hover { background: #3367D6; }
-  .err { color: #f87171; }
-</style>
-"""
-
-
-def _page(body: str) -> str:
-    return f"<!DOCTYPE html><html><head><meta charset='utf-8'><title>AI Agent</title>{_PAGE_STYLE}</head><body>{body}</body></html>"
-
-
-def _success_page(name: str, email: str, is_new: bool) -> str:
-    greeting = "Akun berhasil dibuat" if is_new else "Selamat datang kembali"
-    return _page(f"""
-<div class="card">
-  <div class="icon">&#10003;</div>
-  <h1 style="color:#4ade80">Login Berhasil</h1>
-  <p>{greeting}, <strong>{name}</strong></p>
-  <p class="meta">{email}</p>
-  <p style="margin-top:20px">Buka Telegram dan kirim <strong>/start</strong> ke bot untuk mulai.</p>
-  <p class="dim">Halaman ini bisa ditutup.</p>
-</div>""")
-
-
-def _error_page(message: str) -> str:
-    return _page(f"""
-<div class="card">
-  <div class="icon">&#10007;</div>
-  <h1 class="err">Login Gagal</h1>
-  <p>{message}</p>
-  <a class="btn" href="/auth/google/login">Coba Lagi</a>
-  <p class="dim" style="margin-top:20px">Atau tutup halaman ini dan coba dari terminal.</p>
-</div>""")
-
-
-def _login_page() -> str:
-    return _page("""
-<div class="card">
-  <div class="icon">&#128100;</div>
-  <h1>AI Agent</h1>
-  <p>Login untuk mengakses dan mendaftarkan akun kamu.</p>
-  <a class="btn" href="/auth/google/login">Login dengan Google</a>
-  <p class="dim" style="margin-top:20px">Akun Google kamu digunakan hanya untuk verifikasi identitas.</p>
-</div>""")
 
 
 # ── Routes ────────────────────────────────────────────────────────────────────
@@ -371,32 +325,6 @@ async def google_callback(
 
 # ── TUI login flow ────────────────────────────────────────────────────────────
 
-def _tui_success_page(name: str, email: str) -> str:
-    return _page(f"""
-<div class="card">
-  <div class="icon">&#10003;</div>
-  <h1 style="color:#4ade80">TUI Terhubung</h1>
-  <p>Hai, <strong>{name}</strong></p>
-  <p class="meta">{email}</p>
-  <p style="margin-top:20px">Kembali ke terminal — TUI sudah login otomatis.</p>
-  <p class="dim" style="margin-top:20px">Halaman ini bisa ditutup.</p>
-</div>""")
-
-
-def _tui_login_page(code: str) -> str:
-    return _page(f"""
-<div class="card">
-  <div class="icon">&#128187;</div>
-  <h1>AI Agent TUI</h1>
-  <p>Kode pair: <strong>{code}</strong></p>
-  <p>Login dengan Google untuk hubungkan TUI di terminal kamu.</p>
-  <a class="btn" href="/auth/google/login?tui_code={urllib.parse.quote(code)}">
-    Login dengan Google
-  </a>
-  <p class="dim" style="margin-top:20px">Kode ini berlaku 10 menit.</p>
-</div>""")
-
-
 @router.post("/tui/start")
 async def tui_start() -> JSONResponse:
     """TUI minta kode pairing baru. Return code + login URL."""
@@ -489,6 +417,40 @@ async def auth_me(authorization: str | None = Header(default=None)) -> JSONRespo
                 "display_name": user.display_name,
             }
         )
+
+
+@router.put("/me/provider")
+async def set_my_provider(
+    payload: Annotated[dict[str, Any], Body(...)],
+    authorization: str | None = Header(default=None),
+) -> JSONResponse:
+    """Persist pilihan provider 'otak' user — TANPA efek samping lain (key
+    tak pernah dikirim/di-persist di sini, hanya nama provider).
+
+    Body: {"provider": "...", "as_email": "..."} — ``as_email`` cuma dipakai
+    kalau caller admin token (pola sama seperti ``/chat/send``).
+    """
+    from app.adapters.user_provider_config import UserProviderConfigRepository
+    from app.interfaces.chat import _resolve_admin_target, _resolve_caller
+
+    caller_user_id, mode = _resolve_caller(authorization)
+    if mode == "admin":
+        as_email = str(payload.get("as_email", "") or "")
+        if not as_email:
+            raise HTTPException(status_code=400, detail="admin token requires 'as_email' field")
+        user_id = _resolve_admin_target(as_email)
+    else:
+        user_id = caller_user_id
+
+    provider = str(payload.get("provider", "")).strip().lower()
+    if provider not in ALL_PROVIDERS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"provider harus salah satu: {sorted(ALL_PROVIDERS)}",
+        )
+
+    UserProviderConfigRepository(_session_factory_lazy()).set(user_id, provider)
+    return JSONResponse({"ok": True, "provider": provider})
 
 
 @router.post("/tui/logout")

--- a/app/interfaces/auth_pages.py
+++ b/app/interfaces/auth_pages.py
@@ -1,0 +1,93 @@
+# app/interfaces/auth_pages.py
+"""HTML page builders untuk flow login/pair (Google OAuth + TUI) — pure string
+templating, tanpa dependensi lain. Dipisah dari ``auth.py`` supaya file itu
+tidak membengkak (lihat CLAUDE.md: file < 500 baris)."""
+
+from __future__ import annotations
+
+import urllib.parse
+
+_PAGE_STYLE = """
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: system-ui, sans-serif; background: #0f172a; color: #e2e8f0;
+         display: flex; align-items: center; justify-content: center; min-height: 100vh; }
+  .card { text-align: center; padding: 48px 40px; max-width: 440px; width: 100%; }
+  .icon { font-size: 3rem; margin-bottom: 16px; }
+  h1   { font-size: 1.6rem; margin-bottom: 10px; }
+  p    { color: #94a3b8; font-size: 0.95rem; line-height: 1.6; }
+  .meta { margin-top: 8px; font-size: 0.85rem; color: #64748b; }
+  .dim  { margin-top: 28px; font-size: 0.8rem; color: #475569; }
+  a    { color: #60a5fa; text-decoration: none; }
+  .btn { display: inline-block; margin-top: 24px; padding: 12px 28px;
+         background: #4285F4; color: #fff; border-radius: 6px;
+         font-size: 0.95rem; font-weight: 500; text-decoration: none; }
+  .btn:hover { background: #3367D6; }
+  .err { color: #f87171; }
+</style>
+"""
+
+
+def page(body: str) -> str:
+    return f"<!DOCTYPE html><html><head><meta charset='utf-8'><title>AI Agent</title>{_PAGE_STYLE}</head><body>{body}</body></html>"
+
+
+def success_page(name: str, email: str, is_new: bool) -> str:
+    greeting = "Akun berhasil dibuat" if is_new else "Selamat datang kembali"
+    return page(f"""
+<div class="card">
+  <div class="icon">&#10003;</div>
+  <h1 style="color:#4ade80">Login Berhasil</h1>
+  <p>{greeting}, <strong>{name}</strong></p>
+  <p class="meta">{email}</p>
+  <p style="margin-top:20px">Buka Telegram dan kirim <strong>/start</strong> ke bot untuk mulai.</p>
+  <p class="dim">Halaman ini bisa ditutup.</p>
+</div>""")
+
+
+def error_page(message: str) -> str:
+    return page(f"""
+<div class="card">
+  <div class="icon">&#10007;</div>
+  <h1 class="err">Login Gagal</h1>
+  <p>{message}</p>
+  <a class="btn" href="/auth/google/login">Coba Lagi</a>
+  <p class="dim" style="margin-top:20px">Atau tutup halaman ini dan coba dari terminal.</p>
+</div>""")
+
+
+def login_page() -> str:
+    return page("""
+<div class="card">
+  <div class="icon">&#128100;</div>
+  <h1>AI Agent</h1>
+  <p>Login untuk mengakses dan mendaftarkan akun kamu.</p>
+  <a class="btn" href="/auth/google/login">Login dengan Google</a>
+  <p class="dim" style="margin-top:20px">Akun Google kamu digunakan hanya untuk verifikasi identitas.</p>
+</div>""")
+
+
+def tui_success_page(name: str, email: str) -> str:
+    return page(f"""
+<div class="card">
+  <div class="icon">&#10003;</div>
+  <h1 style="color:#4ade80">TUI Terhubung</h1>
+  <p>Hai, <strong>{name}</strong></p>
+  <p class="meta">{email}</p>
+  <p style="margin-top:20px">Kembali ke terminal — TUI sudah login otomatis.</p>
+  <p class="dim" style="margin-top:20px">Halaman ini bisa ditutup.</p>
+</div>""")
+
+
+def tui_login_page(code: str) -> str:
+    return page(f"""
+<div class="card">
+  <div class="icon">&#128187;</div>
+  <h1>AI Agent TUI</h1>
+  <p>Kode pair: <strong>{code}</strong></p>
+  <p>Login dengan Google untuk hubungkan TUI di terminal kamu.</p>
+  <a class="btn" href="/auth/google/login?tui_code={urllib.parse.quote(code)}">
+    Login dengan Google
+  </a>
+  <p class="dim" style="margin-top:20px">Kode ini berlaku 10 menit.</p>
+</div>""")

--- a/app/interfaces/chat.py
+++ b/app/interfaces/chat.py
@@ -33,6 +33,7 @@ from app.adapters.sessions import UserSessionRepository
 from app.composition import _session_factory, build_use_case
 from app.config import BASE_DIR, settings
 from app.domain.messaging import ChatEvent, MessageContext
+from app.domain.providers import ALL_PROVIDERS
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/chat", tags=["chat"])
@@ -71,7 +72,7 @@ def _resolve_caller(authorization: str | None) -> tuple[str, str]:
     return (info.user_id, "user")
 
 
-_ALLOWED_PROVIDERS = {"anthropic", "glm", "mock"}
+_ALLOWED_PROVIDERS = ALL_PROVIDERS
 
 
 class ChatSendRequest(BaseModel):

--- a/app/interfaces/tasks.py
+++ b/app/interfaces/tasks.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel
 
 from app.adapters.github import GitHubUnavailableError
 from app.composition import build_task_runner
+from app.domain.providers import ALL_PROVIDERS
 from app.interfaces.chat import _resolve_admin_target, _resolve_caller
 
 logger = logging.getLogger(__name__)
@@ -120,9 +121,15 @@ async def run_task(
     # BYOK: persist pilihan provider (kalau ada) + set key per-request ke
     # contextvar supaya PMAgent & dispatch pakai otak asli milik user.
     if req.provider:
+        provider = req.provider.strip().lower()
+        if provider not in ALL_PROVIDERS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"provider harus salah satu: {sorted(ALL_PROVIDERS)}",
+            )
         from app.adapters.user_provider_config import UserProviderConfigRepository
         from app.composition import _session_factory
-        UserProviderConfigRepository(_session_factory()).set(user_id, req.provider)
+        UserProviderConfigRepository(_session_factory()).set(user_id, provider)
 
     from app.adapters.ai_provider_db import personal_anthropic_key_var
     key_token = (

--- a/app/orchestrator/task_runner.py
+++ b/app/orchestrator/task_runner.py
@@ -27,6 +27,7 @@ import uuid
 from dataclasses import dataclass, field
 
 from app.agents.pm import TaskPlan
+from app.agents.roles import build_step_prompt
 from app.ports.ai_provider_resolver import AIProviderResolver
 from app.ports.github_issues import GitHubIssuesPort
 from app.ports.pm_agent import PMAgentPort
@@ -145,10 +146,20 @@ class TaskRunner:
         self.observer.issue_opened(task_id, issue.number, issue.url)
 
         outcomes: list[StepOutcome] = []
+        total_steps = len(plan.steps)
         for step in sorted(plan.steps, key=lambda s: s.order):
             role = role_for_action(step.action)
             self.observer.step_started(task_id, step.order, role, step.description)
-            result = await self.dispatch.dispatch_async(user_id, role, step.description)
+            prompt = build_step_prompt(
+                role,
+                step.description,
+                task_title=plan.title,
+                task_summary=plan.summary,
+                step_order=step.order,
+                step_total=total_steps,
+                context=context,
+            )
+            result = await self.dispatch.dispatch_async(user_id, role, prompt)
             detail = (result.summary or result.output or result.error)[:500]
             outcome = StepOutcome(
                 order=step.order,
@@ -215,8 +226,16 @@ class TaskRunner:
         agent = await asyncio.to_thread(_active_single_agent, user_id)
         if agent:
             try:
+                planning_prompt = build_step_prompt(
+                    "planner",
+                    self.pm.build_prompt(request, context),
+                    task_title="Decompose request menjadi rencana kerja",
+                    task_summary=request[:200],
+                    step_order=1,
+                    step_total=1,
+                )
                 result = await self.dispatch.dispatch_async(
-                    user_id, "research", self.pm.build_prompt(request, context)
+                    user_id, "research", planning_prompt
                 )
                 text = result.output or result.summary
                 if result.ok and text:

--- a/tests/adapters/test_ai_provider_db.py
+++ b/tests/adapters/test_ai_provider_db.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 
 import dataclasses
 
+import pytest
+
 from app.adapters.ai_provider_db import DbAIProviderResolver, personal_anthropic_key_var
 from app.adapters.anthropic import AnthropicAdapter
 from app.adapters.circuit_breaker import _CircuitBreakerProvider
+from app.adapters.mock_llm import MockAIProvider
 from app.config import load_settings
+from app.domain.exceptions import AIProviderError
 
 
 class _FakeRepo:
@@ -92,3 +96,36 @@ def test_server_key_provider_is_still_cached() -> None:
 
     assert p1 is p2
     assert resolver._cache == {("anthropic", "claude-opus-4-8"): p1}
+
+
+# ── CLI provider degrade behaviour (claude-cli/glm-cli have no cloud adapter) ──
+
+
+def test_cli_provider_raises_by_default() -> None:
+    resolver = DbAIProviderResolver(_FakeRepo({"u1": ("claude-cli", None)}), _settings_with_key())
+    with pytest.raises(AIProviderError):
+        resolver.for_user("u1")
+
+
+def test_cli_provider_degrades_to_mock_when_flagged() -> None:
+    resolver = DbAIProviderResolver(
+        _FakeRepo({"u1": ("claude-cli", None)}), _settings_with_key(), degrade_cli_to_mock=True
+    )
+    assert isinstance(resolver.for_user("u1"), MockAIProvider)
+
+
+def test_glm_cli_degrades_to_mock_when_flagged() -> None:
+    resolver = DbAIProviderResolver(
+        _FakeRepo({"u1": ("glm-cli", None)}), _settings_with_key(), degrade_cli_to_mock=True
+    )
+    assert isinstance(resolver.for_user("u1"), MockAIProvider)
+
+
+def test_non_cli_provider_error_still_raises_even_when_flagged() -> None:
+    """Flag only degrades CLI providers — a real missing-key error still surfaces."""
+    settings = dataclasses.replace(load_settings(), anthropic_api_key="")
+    resolver = DbAIProviderResolver(
+        _FakeRepo({"u1": ("anthropic", None)}), settings, degrade_cli_to_mock=True
+    )
+    with pytest.raises(AIProviderError):
+        resolver.for_user("u1")

--- a/tests/adapters/test_ai_provider_factory.py
+++ b/tests/adapters/test_ai_provider_factory.py
@@ -50,3 +50,13 @@ def test_personal_key_overrides_settings() -> None:
 def test_glm_alias_and_adapter() -> None:
     provider = build_ai_provider("zhipu", None, load_settings(), personal_key="pk-1")
     assert isinstance(_inner(provider), GLMAdapter)
+
+
+def test_claude_cli_raises_ai_provider_error_not_cloud_adapter() -> None:
+    with pytest.raises(AIProviderError):
+        build_ai_provider("claude-cli", None, load_settings(), personal_key="pk-1")
+
+
+def test_glm_cli_raises_ai_provider_error_even_without_key() -> None:
+    with pytest.raises(AIProviderError):
+        build_ai_provider("glm-cli", None, load_settings())

--- a/tests/adapters/test_worker_dispatch_provider.py
+++ b/tests/adapters/test_worker_dispatch_provider.py
@@ -1,0 +1,72 @@
+"""Tests for the provider→agent routing override in WorkerDispatchAdapter.
+
+Only the pure mapping is tested here (``_PROVIDER_AGENT``); the async
+dispatch/caps machinery is exercised elsewhere via composition-level tests.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.adapters.worker_dispatch import _PROVIDER_AGENT, _single_agent_override
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_claude_cli_maps_to_claude_agent() -> None:
+    assert _PROVIDER_AGENT["claude-cli"] == "claude"
+
+
+def test_glm_cli_maps_to_glm_agent() -> None:
+    assert _PROVIDER_AGENT["glm-cli"] == "glm"
+
+
+def test_existing_cloud_aliases_unchanged() -> None:
+    assert _PROVIDER_AGENT["claude"] == "claude"
+    assert _PROVIDER_AGENT["anthropic"] == "claude"
+    assert _PROVIDER_AGENT["glm"] == "glm"
+    assert _PROVIDER_AGENT["zhipu"] == "glm"
+
+
+class _FakeRepo:
+    def __init__(self, pref: tuple[str, str | None] | None) -> None:
+        self._pref = pref
+
+    def get(self, user_id: str) -> tuple[str, str | None] | None:
+        return self._pref
+
+
+def test_single_agent_override_claude_cli_routes_to_claude(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.adapters.user_provider_config as upc_mod
+
+    monkeypatch.setattr(
+        upc_mod,
+        "UserProviderConfigRepository",
+        lambda factory: _FakeRepo(("claude-cli", None)),
+    )
+    assert _single_agent_override("u1") == "claude"
+
+
+def test_single_agent_override_glm_cli_routes_to_glm(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.adapters.user_provider_config as upc_mod
+
+    monkeypatch.setattr(
+        upc_mod,
+        "UserProviderConfigRepository",
+        lambda factory: _FakeRepo(("glm-cli", None)),
+    )
+    assert _single_agent_override("u1") == "glm"
+
+
+def test_single_agent_override_mock_is_no_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.adapters.user_provider_config as upc_mod
+
+    monkeypatch.setattr(
+        upc_mod, "UserProviderConfigRepository", lambda factory: _FakeRepo(("mock", None))
+    )
+    assert _single_agent_override("u1") is None
+
+
+def test_single_agent_override_empty_user_id_is_none() -> None:
+    assert _single_agent_override("") is None

--- a/tests/agents/test_roles.py
+++ b/tests/agents/test_roles.py
@@ -1,0 +1,133 @@
+"""Tests for role profiles ("skills & rules") and step-prompt rendering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.agents.roles import (
+    ROLE_PROFILES,
+    build_step_prompt,
+    get_role_profile,
+)
+
+
+@pytest.mark.parametrize("role", sorted(ROLE_PROFILES))
+def test_every_profile_has_title_and_rules(role: str) -> None:
+    profile = ROLE_PROFILES[role]
+    assert profile.title
+    assert profile.mission
+    assert len(profile.rules) > 0
+    assert all(r.strip() for r in profile.rules)
+
+
+def test_known_roles_present() -> None:
+    for role in ("engineer", "reviewer", "research", "infra", "planner", "tester"):
+        assert role in ROLE_PROFILES
+
+
+def test_unknown_role_falls_back_to_generic() -> None:
+    profile = get_role_profile("does-not-exist")
+    assert profile.role == "worker"
+    assert profile.title
+    assert len(profile.rules) > 0
+
+
+def test_get_role_profile_is_case_insensitive() -> None:
+    assert get_role_profile("ENGINEER").role == "engineer"
+    assert get_role_profile(" reviewer ").role == "reviewer"
+
+
+def test_build_step_prompt_contains_role_title_and_step_text() -> None:
+    prompt = build_step_prompt(
+        "engineer",
+        "add a /health route",
+        task_title="Add health endpoint",
+        task_summary="expose liveness check",
+        step_order=1,
+        step_total=2,
+    )
+    assert "Engineer" in prompt
+    assert "add a /health route" in prompt
+    assert "Add health endpoint" in prompt
+    assert "1/2" in prompt
+    assert "Hasil:" in prompt  # generic output contract present
+
+
+def test_build_step_prompt_unknown_role_uses_generic_profile() -> None:
+    prompt = build_step_prompt(
+        "some_new_role",
+        "do the thing",
+        task_title="T",
+        task_summary="S",
+        step_order=1,
+        step_total=1,
+    )
+    assert "Worker" in prompt
+    assert "do the thing" in prompt
+
+
+def test_build_step_prompt_includes_context_when_given() -> None:
+    prompt = build_step_prompt(
+        "research",
+        "investigate the outage",
+        task_title="T",
+        task_summary="S",
+        step_order=1,
+        step_total=1,
+        context="previous step found high CPU",
+    )
+    assert "previous step found high CPU" in prompt
+
+
+def test_planner_profile_has_no_generic_output_contract() -> None:
+    """Planner already dictates its own JSON schema — no conflicting contract."""
+    prompt = build_step_prompt(
+        "planner",
+        "Respond with JSON only: {...}",
+        task_title="Decompose",
+        task_summary="req",
+        step_order=1,
+        step_total=1,
+    )
+    assert "Hasil:" not in prompt
+
+
+def test_project_override_appended_when_file_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app.agents.roles as roles_mod
+
+    monkeypatch.setattr(roles_mod, "BASE_DIR", tmp_path)
+    roles_dir = tmp_path / "data" / "roles"
+    roles_dir.mkdir(parents=True)
+    (roles_dir / "engineer.md").write_text("Selalu tulis docstring Indonesia.", encoding="utf-8")
+
+    prompt = build_step_prompt(
+        "engineer",
+        "do X",
+        task_title="T",
+        task_summary="S",
+        step_order=1,
+        step_total=1,
+    )
+    assert "Aturan tambahan proyek" in prompt
+    assert "Selalu tulis docstring Indonesia." in prompt
+
+
+def test_no_project_override_when_file_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app.agents.roles as roles_mod
+
+    monkeypatch.setattr(roles_mod, "BASE_DIR", tmp_path)
+    prompt = build_step_prompt(
+        "engineer",
+        "do X",
+        task_title="T",
+        task_summary="S",
+        step_order=1,
+        step_total=1,
+    )
+    assert "Aturan tambahan proyek" not in prompt

--- a/tests/domain/test_providers.py
+++ b/tests/domain/test_providers.py
@@ -1,0 +1,35 @@
+"""Tests for the shared provider constants/helpers (single source of truth)."""
+
+from __future__ import annotations
+
+from app.domain.providers import (
+    ALL_PROVIDERS,
+    CLI_PROVIDERS,
+    CLOUD_PROVIDERS,
+    is_cli_provider,
+)
+
+
+def test_all_providers_is_union_of_cloud_cli_mock() -> None:
+    assert CLOUD_PROVIDERS | CLI_PROVIDERS | {"mock"} == ALL_PROVIDERS
+
+
+def test_cloud_providers_are_anthropic_and_glm() -> None:
+    assert {"anthropic", "glm"} == CLOUD_PROVIDERS
+
+
+def test_cli_providers_are_claude_cli_and_glm_cli() -> None:
+    assert {"claude-cli", "glm-cli"} == CLI_PROVIDERS
+
+
+def test_is_cli_provider_true_for_cli_names() -> None:
+    assert is_cli_provider("claude-cli") is True
+    assert is_cli_provider("glm-cli") is True
+    assert is_cli_provider(" Claude-CLI ") is True
+
+
+def test_is_cli_provider_false_for_others() -> None:
+    assert is_cli_provider("anthropic") is False
+    assert is_cli_provider("glm") is False
+    assert is_cli_provider("mock") is False
+    assert is_cli_provider("") is False

--- a/tests/interfaces/test_auth_provider.py
+++ b/tests/interfaces/test_auth_provider.py
@@ -1,0 +1,89 @@
+"""Tests for PUT /auth/me/provider — persist 'otak' choice, no side effects."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import app.interfaces.auth as auth_iface
+import app.interfaces.chat as chat_iface
+
+USER = "user-1"
+ADMIN_EMAIL = "target@example.com"
+ADMIN_USER_ID = "user-admin-target"
+
+
+class _FakeProviderRepo:
+    def __init__(self, factory: object) -> None:
+        pass
+
+    def set(self, user_id: str, provider: str, model: str | None = None) -> None:
+        _CALLS.append((user_id, provider))
+
+
+_CALLS: list[tuple[str, str]] = []
+
+
+@pytest.fixture(autouse=True)
+def _reset_calls() -> Iterator[None]:
+    _CALLS.clear()
+    yield
+    _CALLS.clear()
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    import app.adapters.user_provider_config as upc_mod
+
+    monkeypatch.setattr(upc_mod, "UserProviderConfigRepository", _FakeProviderRepo)
+    monkeypatch.setattr(chat_iface, "_resolve_caller", lambda _a: (USER, "user"))
+    monkeypatch.setattr(
+        chat_iface, "_resolve_admin_target", lambda email: ADMIN_USER_ID if email == ADMIN_EMAIL else None
+    )
+    app = FastAPI()
+    app.include_router(auth_iface.router)
+    yield TestClient(app)
+
+
+def test_set_provider_persists_for_session_user(client: TestClient) -> None:
+    resp = client.put("/auth/me/provider", json={"provider": "claude-cli"})
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "provider": "claude-cli"}
+    assert _CALLS == [(USER, "claude-cli")]
+
+
+def test_invalid_provider_rejected(client: TestClient) -> None:
+    resp = client.put("/auth/me/provider", json={"provider": "gpt4"})
+    assert resp.status_code == 400
+    assert _CALLS == []
+
+
+@pytest.mark.parametrize("provider", ["mock", "anthropic", "glm", "claude-cli", "glm-cli"])
+def test_all_allowed_providers_accepted(client: TestClient, provider: str) -> None:
+    resp = client.put("/auth/me/provider", json={"provider": provider})
+    assert resp.status_code == 200
+
+
+def test_provider_case_and_whitespace_normalized(client: TestClient) -> None:
+    resp = client.put("/auth/me/provider", json={"provider": "  Claude-CLI  "})
+    assert resp.status_code == 200
+    assert _CALLS == [(USER, "claude-cli")]
+
+
+def test_admin_without_as_email_rejected(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    monkeypatch.setattr(chat_iface, "_resolve_caller", lambda _a: ("__ADMIN__", "admin"))
+    resp = client.put("/auth/me/provider", json={"provider": "mock"})
+    assert resp.status_code == 400
+    assert "as_email" in resp.json()["detail"]
+
+
+def test_admin_sets_provider_for_target_user(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    monkeypatch.setattr(chat_iface, "_resolve_caller", lambda _a: ("__ADMIN__", "admin"))
+    resp = client.put(
+        "/auth/me/provider", json={"provider": "glm-cli", "as_email": ADMIN_EMAIL}
+    )
+    assert resp.status_code == 200
+    assert _CALLS == [(ADMIN_USER_ID, "glm-cli")]

--- a/tests/interfaces/test_chat_provider.py
+++ b/tests/interfaces/test_chat_provider.py
@@ -1,0 +1,56 @@
+"""Provider validation on /chat/send (BYOK persist path) — includes CLI providers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.interfaces import chat as chat_iface
+
+USER = "user-1"
+
+
+class _FakeProviderRepo:
+    """Stands in for ``UserProviderConfigRepository`` — no real DB needed here,
+    this test only cares about validation, not persistence (that's covered by
+    tests/adapters/test_user_provider_config.py)."""
+
+    def __init__(self, factory: object) -> None:
+        self.sets: list[tuple[str, str]] = []
+
+    def set(self, user_id: str, provider: str, model: str | None = None) -> None:
+        self.sets.append((user_id, provider))
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    import app.adapters.user_provider_config as upc_mod
+
+    monkeypatch.setattr(chat_iface, "_resolve_caller", lambda _a: (USER, "user"))
+    monkeypatch.setattr(upc_mod, "UserProviderConfigRepository", _FakeProviderRepo)
+
+    def _fake_stream_events(text, ctx, personal_key=None):  # type: ignore[no-untyped-def]
+        async def gen():  # type: ignore[no-untyped-def]
+            yield "event: done\ndata: {}\n\n"
+
+        return gen()
+
+    monkeypatch.setattr(chat_iface, "_stream_events", _fake_stream_events)
+    app = FastAPI()
+    app.include_router(chat_iface.router)
+    yield TestClient(app)
+
+
+def test_invalid_provider_rejected(client: TestClient) -> None:
+    resp = client.post("/chat/send", json={"text": "hi", "provider": "gpt4"})
+    assert resp.status_code == 400
+    assert "provider" in resp.json()["detail"]
+
+
+@pytest.mark.parametrize("provider", ["mock", "anthropic", "glm", "claude-cli", "glm-cli"])
+def test_all_allowed_providers_accepted(client: TestClient, provider: str) -> None:
+    resp = client.post("/chat/send", json={"text": "hi", "provider": provider})
+    assert resp.status_code == 200

--- a/tests/interfaces/test_tasks_endpoints.py
+++ b/tests/interfaces/test_tasks_endpoints.py
@@ -46,10 +46,25 @@ def fake() -> FakeTaskRunner:
     return FakeTaskRunner()
 
 
+class _FakeProviderRepo:
+    """Stands in for ``UserProviderConfigRepository`` — these tests only care
+    about validation, not persistence (covered by
+    tests/adapters/test_user_provider_config.py)."""
+
+    def __init__(self, factory: object) -> None:
+        pass
+
+    def set(self, user_id: str, provider: str, model: str | None = None) -> None:
+        pass
+
+
 @pytest.fixture
 def client(fake: FakeTaskRunner, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    import app.adapters.user_provider_config as upc_mod
+
     monkeypatch.setattr(tasks_iface, "build_task_runner", lambda: fake)
     monkeypatch.setattr(tasks_iface, "_resolve_caller", lambda _a: (USER, "user"))
+    monkeypatch.setattr(upc_mod, "UserProviderConfigRepository", _FakeProviderRepo)
     app = FastAPI()
     app.include_router(tasks_iface.router)
     yield TestClient(app)
@@ -131,6 +146,24 @@ def test_run_503_when_github_unconfigured(
     resp = client.post("/tasks/run", json={"request": "x"})
     assert resp.status_code == 503
     assert "unavailable" in resp.json()["detail"]
+
+
+def test_invalid_provider_rejected(client: TestClient, fake: FakeTaskRunner) -> None:
+    resp = client.post("/tasks/run", json={"request": "x", "provider": "gpt4"})
+    assert resp.status_code == 400
+    assert "provider" in resp.json()["detail"]
+    assert fake.calls == []  # rejected before the runner ever ran
+
+
+def test_cli_provider_is_a_valid_choice(client: TestClient, fake: FakeTaskRunner) -> None:
+    """claude-cli/glm-cli (local, no key) must validate same as cloud providers."""
+    fake.result = TaskResult(plan=_plan(), issue_number=1, issue_url="u", outcomes=[
+        StepOutcome(order=1, description="x", role="engineer", ok=True),
+    ], closed=True)
+
+    resp = client.post("/tasks/run", json={"request": "x", "provider": "claude-cli"})
+
+    assert resp.status_code == 200
 
 
 def test_admin_requires_as_email(monkeypatch: pytest.MonkeyPatch, fake: FakeTaskRunner) -> None:

--- a/tests/orchestrator/test_task_runner.py
+++ b/tests/orchestrator/test_task_runner.py
@@ -114,8 +114,10 @@ async def test_steps_executed_in_order() -> None:
     runner = TaskRunner(pm=_FakePM(plan), github=gh, dispatch=dispatch)
     await runner.run("user-1", "ordered")
     # Despite plan order, runner sorts by .order → "first" dispatched first.
-    assert dispatch.calls[0][2] == "first"
-    assert dispatch.calls[1][2] == "second"
+    # Prompt now wraps the raw description with the role profile (see roles.py
+    # tests below), so we assert containment rather than equality.
+    assert "first" in dispatch.calls[0][2]
+    assert "second" in dispatch.calls[1][2]
 
 
 # ── failure path ─────────────────────────────────────────────────────────────────
@@ -364,4 +366,48 @@ def test_provider_agent_mapping() -> None:
     assert _PROVIDER_AGENT["claude"] == "claude"
     assert _PROVIDER_AGENT["anthropic"] == "claude"
     assert _PROVIDER_AGENT["glm"] == "glm"
+    assert _PROVIDER_AGENT["claude-cli"] == "claude"
+    assert _PROVIDER_AGENT["glm-cli"] == "glm"
     assert _PROVIDER_AGENT.get("mock") is None
+
+
+# ── role prompts (Part B): step dispatch uses build_step_prompt ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_step_dispatch_prompt_contains_role_title_and_description() -> None:
+    plan = _plan([
+        TaskStep(order=1, description="write the health route", action="file_write", params={}),
+    ])
+    dispatch = _FakeDispatch([DispatchResult(output="ok", ok=True)])
+    runner = TaskRunner(pm=_FakePM(plan), github=_FakeGitHub(), dispatch=dispatch)
+
+    await runner.run("user-1", "add health endpoint")
+
+    prompt = dispatch.calls[0][2]
+    assert "Engineer" in prompt              # role title (file_write → engineer)
+    assert "write the health route" in prompt  # raw step description preserved
+    assert plan.title in prompt
+    assert plan.summary in prompt
+
+
+@pytest.mark.asyncio
+async def test_decompose_via_worker_prompt_uses_planner_profile(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(
+        "app.orchestrator.task_runner._active_single_agent", lambda _uid: "claude"
+    )
+    plan_json = (
+        '{"title":"T","summary":"s","estimated_complexity":"simple",'
+        '"steps":[{"order":1,"description":"cek","action":"server_status","params":{}}]}'
+    )
+    dispatch = _FakeDispatch([
+        DispatchResult(output=plan_json, ok=True),
+        DispatchResult(output="done", ok=True),
+    ])
+    runner = TaskRunner(pm=PMAgent(), github=_FakeGitHub(), dispatch=dispatch)
+
+    await runner.run("user-1", "cek server")
+
+    decompose_prompt = dispatch.calls[0][2]
+    assert "Planner" in decompose_prompt
+    assert "cek server" in decompose_prompt or "Decompose" in decompose_prompt

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "octopus-gather-room",
   "private": true,
-  "version": "0.4.4",
+  "version": "0.5.0",
   "type": "module",
   "description": "Ruang Octopus — gather-room frontend for the AI IT-Manager (mock data, Phase 3 P0-P1)",
   "scripts": {

--- a/web/src/changelog.ts
+++ b/web/src/changelog.ts
@@ -12,6 +12,15 @@ export interface ReleaseNote {
 
 export const CHANGELOG: ReleaseNote[] = [
   {
+    version: "0.5.0",
+    date: "2026-08-30",
+    notes: [
+      "Otak (LLM provider) kini bisa \"claude-cli\"/\"glm-cli\" — Claude Code atau GLM CLI di device kamu sendiri, tanpa API key, dijalankan lewat worker.",
+      "Perintah cepat /use <provider> di kolom perintah untuk ganti otak tanpa buka Pengaturan (juga /otak untuk lihat yang aktif, /help untuk daftar perintah).",
+      "Otak aktif kini tampil sebagai chip di header — ketuk untuk buka Pengaturan.",
+    ],
+  },
+  {
     version: "0.4.4",
     date: "2026-08-30",
     notes: [

--- a/web/src/net/api.ts
+++ b/web/src/net/api.ts
@@ -132,9 +132,28 @@ export function setApiKey(k: string): void {
   if (k) store.setItem(APIKEY_KEY, k);
   else store.removeItem(APIKEY_KEY);
 }
-/** IT-Manager "asli" aktif = provider non-mock + ada key. */
+/** Provider lokal (jalan via worker CLI di device user) — tanpa API key. */
+export function isCliProvider(p: string): boolean {
+  return p === "claude-cli" || p === "glm-cli";
+}
+/** IT-Manager "asli" aktif = provider non-mock + (CLI lokal ATAU ada key). */
 export function isRealMode(): boolean {
-  return getProvider() !== "mock" && getApiKey().length > 0;
+  return getProvider() !== "mock" && (isCliProvider(getProvider()) || getApiKey().length > 0);
+}
+
+/** PUT /auth/me/provider — persist preferensi provider di server (tanpa efek
+ *  samping lain, tidak mengirim chat/tugas). Best-effort, tidak throw. */
+export async function saveProviderPreference(provider: string): Promise<boolean> {
+  try {
+    const resp = await fetch(`${API_BASE}/auth/me/provider`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body: JSON.stringify({ provider }),
+    });
+    return resp.ok;
+  } catch {
+    return false;
+  }
 }
 
 function authHeaders(): Record<string, string> {

--- a/web/src/state/store.ts
+++ b/web/src/state/store.ts
@@ -1,5 +1,16 @@
 import { create } from "zustand";
-import { approvePlan, fetchMe, getToken, rejectPlan, runTask } from "../net/api";
+import {
+  approvePlan,
+  fetchMe,
+  getProvider,
+  getToken,
+  isCliProvider,
+  rejectPlan,
+  runTask,
+  saveProviderPreference,
+  setApiKey,
+  setProvider,
+} from "../net/api";
 import { CURRENT_VERSION, fetchLatestVersion, type VersionInfo } from "../net/version";
 import type {
   Agent,
@@ -289,6 +300,8 @@ interface RoomState {
   queue: Task[];
   selectedId: string | null;
   theme: Theme;
+  /** Otak (LLM provider) aktif — reaktif, dipakai chip header + ProviderEditor. */
+  provider: string;
   managerName: string;
   /** pasukan (worker) online — dari /room/state + event worker.online/offline */
   workers: number;
@@ -306,6 +319,8 @@ interface RoomState {
   closeSettings: () => void;
   select: (id: string | null) => void;
   submitCommand: (text: string) => void;
+  /** Ganti otak aktif: persist ke localStorage + server, lalu update state reaktif. */
+  setActiveProvider: (p: string) => void;
   applyServerEvent: (ev: Record<string, unknown>) => void;
   /** Sinkronkan agents dengan roster server (CRUD /room/roster / event
    *  roster.updated / room.snapshot) — lihat reconcileAgents. */
@@ -475,6 +490,7 @@ export const useStore = create<RoomState>((set, get) => {
     queue: [],
     selectedId: null,
     theme: initialTheme(),
+    provider: getProvider(),
     managerName: MANAGER,
     workers: 0,
     live: false,
@@ -496,6 +512,12 @@ export const useStore = create<RoomState>((set, get) => {
     closeSettings: () => set({ settingsOpen: false }),
 
     select: (id) => set({ selectedId: id }),
+
+    setActiveProvider: (p) => {
+      setProvider(p);
+      void saveProviderPreference(p);
+      set({ provider: p });
+    },
 
     setTheme: (t) => {
       applyThemeAttr(t);
@@ -536,6 +558,73 @@ export const useStore = create<RoomState>((set, get) => {
     submitCommand: (text) => {
       const txt = text.trim();
       if (!txt) return;
+
+      // Perintah cepat lokal (ganti otak) — tidak diteruskan ke Manajer/backend.
+      if (txt.startsWith("/")) {
+        const [cmdRaw, ...restWords] = txt.slice(1).split(/\s+/);
+        const cmd = cmdRaw.toLowerCase();
+        const argRaw = restWords.join(" ").trim();
+        const OTAK_HINT = `Pilihan: mock, claude-cli, glm-cli, anthropic, glm. Pakai "/use <pilihan>" untuk ganti.`;
+
+        if (cmd === "use" && argRaw) {
+          const ALIASES: Record<string, string> = {
+            claude: "claude-cli",
+            "claude-cli": "claude-cli",
+            glm: "glm-cli",
+            "glm-cli": "glm-cli",
+            anthropic: "anthropic",
+            mock: "mock",
+          };
+          const resolved = ALIASES[argRaw.toLowerCase()];
+          if (!resolved) {
+            set((s) => ({
+              events: feedInto(
+                s.events,
+                `⚠️ Provider tidak dikenal: "${escapeHtml(argRaw)}". Pilihan: mock, claude, glm, anthropic.`,
+                "error",
+              ),
+            }));
+            return;
+          }
+          get().setActiveProvider(resolved);
+          if (resolved === "mock" || isCliProvider(resolved)) setApiKey("");
+          const LABELS: Record<string, string> = {
+            "claude-cli": `🧠 Otak: claude-cli — semua peran dijalankan Claude Code di device-mu`,
+            "glm-cli": `🧠 Otak: glm-cli — semua peran dijalankan GLM CLI di device-mu`,
+            anthropic: `🧠 Otak: anthropic — cloud, pastikan API key sudah diisi di Pengaturan`,
+            glm: `🧠 Otak: glm — cloud, pastikan API key sudah diisi di Pengaturan`,
+            mock: `🧠 Otak: mock — mode demo, tanpa key`,
+          };
+          set((s) => ({ events: feedInto(s.events, LABELS[resolved], "done") }));
+          return;
+        }
+
+        if (cmd === "use" || cmd === "otak") {
+          set((s) => ({
+            events: feedInto(s.events, `🧠 Otak saat ini: ${get().provider}. ${OTAK_HINT}`, "idle"),
+          }));
+          return;
+        }
+
+        if (cmd === "help") {
+          set((s) => ({
+            events: feedInto(
+              s.events,
+              `Perintah: /use <provider> — ganti otak · /otak — lihat otak aktif · /help — bantuan ini.`,
+              "idle",
+            ),
+          }));
+          return;
+        }
+
+        // Tidak ada konvensi "/foo" lain di codebase ini (CommandBar/MobileCommandBar
+        // hanya memanggil submitCommand ini) — perintah tak dikenal ditolak di sini.
+        set((s) => ({
+          events: feedInto(s.events, `⚠️ Perintah tidak dikenal: ${escapeHtml(txt)}`, "error"),
+        }));
+        return;
+      }
+
       const safe = escapeHtml(txt);
 
       // Ruangan kini dikendalikan backend nyata → matikan simulasi mock.

--- a/web/src/ui/ProviderSettings.tsx
+++ b/web/src/ui/ProviderSettings.tsx
@@ -3,10 +3,11 @@ import { useIsMobile } from "../hooks/useIsMobile";
 import {
   getApiKey,
   getProvider,
+  isCliProvider,
   isRealMode,
   setApiKey,
-  setProvider,
 } from "../net/api";
+import { useStore } from "../state/store";
 import { BottomSheet } from "./mobile/BottomSheet";
 
 export interface ProviderEditorProps {
@@ -20,10 +21,11 @@ export function ProviderEditor({ onClose }: ProviderEditorProps): JSX.Element {
   const isMobile = useIsMobile();
   const [provider, setProviderState] = useState(getProvider());
   const [key, setKeyState] = useState(getApiKey());
+  const setActiveProvider = useStore((s) => s.setActiveProvider);
 
   const save = (): void => {
-    setProvider(provider);
-    setApiKey(provider === "mock" ? "" : key.trim());
+    setActiveProvider(provider);
+    setApiKey(provider === "mock" || isCliProvider(provider) ? "" : key.trim());
     onClose();
   };
 
@@ -45,12 +47,18 @@ export function ProviderEditor({ onClose }: ProviderEditorProps): JSX.Element {
           className="mt-1 w-full rounded-lg border border-line bg-surface-2 px-3 py-2.5 text-[14px] text-ink"
         >
           <option value="mock">mock (demo, tanpa key)</option>
-          <option value="anthropic">anthropic (Claude)</option>
-          <option value="glm">glm (Zhipu)</option>
+          <option value="claude-cli">
+            claude-cli — Claude Code di device kamu (tanpa key, via worker)
+          </option>
+          <option value="glm-cli">
+            glm-cli — GLM CLI di device kamu (tanpa key, via worker)
+          </option>
+          <option value="anthropic">anthropic (cloud, API key)</option>
+          <option value="glm">glm (cloud, API key)</option>
         </select>
       </div>
 
-      {provider !== "mock" && (
+      {!isCliProvider(provider) && provider !== "mock" && (
         <div>
           <label className="block font-mono text-[11px] uppercase tracking-wide text-ink-faint">
             API Key
@@ -112,5 +120,9 @@ export function ProviderEditor({ onClose }: ProviderEditorProps): JSX.Element {
 
 /** Ringkasan provider aktif untuk baris "Otak" di SettingsPanel. */
 export function providerSummary(): string {
-  return isRealMode() ? `${getProvider()} · key tersimpan` : "mock (tanpa key)";
+  const p = getProvider();
+  if (p === "mock") return "mock (tanpa key)";
+  if (p === "claude-cli") return "claude-cli · Claude lokal via worker";
+  if (p === "glm-cli") return "glm-cli · GLM lokal via worker";
+  return isRealMode() ? `${p} · key tersimpan` : `${p} · key belum diisi`;
 }

--- a/web/src/ui/TopBar.tsx
+++ b/web/src/ui/TopBar.tsx
@@ -5,6 +5,8 @@ import { SettingsButton } from "./settings/SettingsButton";
 export function TopBar(): JSX.Element {
   const count = useStore((s) => s.agents.length);
   const workers = useStore((s) => s.workers);
+  const provider = useStore((s) => s.provider);
+  const openSettings = useStore((s) => s.openSettings);
 
   return (
     <header className="flex flex-wrap items-center gap-4 border-b border-line bg-surface px-4 py-2.5">
@@ -42,6 +44,15 @@ export function TopBar(): JSX.Element {
         />
         {workers} pasukan
       </div>
+
+      <button
+        type="button"
+        onClick={openSettings}
+        className="flex items-center gap-1.5 whitespace-nowrap rounded-full border border-line bg-surface-2 px-2.5 py-1.5 font-mono text-[12px] text-ink-soft"
+        title="Otak aktif — klik untuk ganti"
+      >
+        🧠 {provider}
+      </button>
 
       <SettingsButton />
     </header>

--- a/web/src/ui/mobile/MobileHeader.tsx
+++ b/web/src/ui/mobile/MobileHeader.tsx
@@ -13,6 +13,8 @@ export interface MobileHeaderProps {
 export function MobileHeader({ onCompose, onNavigateToPasukan }: MobileHeaderProps = {}): JSX.Element {
   const workers = useStore((s) => s.workers);
   const count = useStore((s) => s.agents.length);
+  const provider = useStore((s) => s.provider);
+  const openSettings = useStore((s) => s.openSettings);
 
   return (
     <header
@@ -38,6 +40,15 @@ export function MobileHeader({ onCompose, onNavigateToPasukan }: MobileHeaderPro
           {workers} pasukan online · {count} agen
         </div>
       </div>
+
+      <button
+        type="button"
+        onClick={openSettings}
+        className="flex flex-none items-center gap-1 whitespace-nowrap rounded-full border border-line bg-surface-2 px-2 py-1 font-mono text-[11.5px] text-ink-soft"
+        title="Otak aktif — klik untuk ganti"
+      >
+        🧠 {provider}
+      </button>
 
       {onCompose && (
         <button


### PR DESCRIPTION
## What
1. **Local-CLI "brain" without an API key** — new provider ids `claude-cli` / `glm-cli`: the manager and every role run on the CLI installed on the user's own device (via `octopus worker`). Selectable in Settings → Otak or by typing `/use claude` in the command bar.
2. **Per-role rules & output contract** so workers aren't biased: engineer / reviewer / research / infra / planner / tester profiles (mission, mandatory rules, forbidden actions, required response sections) wrapped around every dispatched step.

## Why
The UI only offered cloud providers that require a key, although the backend could already route to the worker CLI. Steps were dispatched as raw descriptions, so a reviewer could "fix" code, research could mutate, etc.

## How
| Area | Change |
|---|---|
| `app/domain/providers.py` | `CLOUD_PROVIDERS`, `CLI_PROVIDERS`, `ALL_PROVIDERS`, `is_cli_provider` — single validation source for `/chat/send` & `/tasks/run` |
| `ai_provider_factory`, `ai_provider_db`, `worker_dispatch` | CLI providers raise `AIProviderError` → existing decompose-via-worker fallback; `claude-cli→claude`, `glm-cli→glm` single-agent override |
| `app/interfaces/auth.py` (+ `auth_pages.py`) | `PUT /auth/me/provider` (validated, persisted, no side effects); HTML page builders extracted |
| `app/agents/roles.py` | `RoleProfile`, `ROLE_PROFILES`, `build_step_prompt(...)`; optional project override `data/roles/<role>.md` |
| `app/orchestrator/task_runner.py` | both dispatch sites + planner decompose use the role prompt |
| web | `ProviderEditor` CLI options, `saveProviderPreference`, slash commands `/use`, `/otak`, `/help`, provider chip in TopBar/MobileHeader, v0.5.0 + changelog |
| tests | +5 files (providers, roles, dispatch override, auth provider endpoint, chat provider validation); task_runner asserts role title + step text in the dispatched prompt |

## How to test
1. `make check` → 802 passed; `cd web && npm run build`.
2. PWA: type `/use claude` → feed confirms, chip shows `🧠 claude-cli`, Settings shows the same; `GET /auth/me`-scoped preference persisted.
3. Send a task → worker log shows the prompt starting with "Kamu berperan sebagai Engineer…" and the response follows the Hasil / File yang diubah / Verifikasi / Catatan-risiko contract.

## Notes
`app/interfaces/auth.py` is still 773 lines (was 812 before) — pre-existing; splitting telegram-pairing / agent-config routers is a follow-up.